### PR TITLE
Various fixes.

### DIFF
--- a/example/cmd/microctl/main.go
+++ b/example/cmd/microctl/main.go
@@ -46,11 +46,8 @@ func main() {
 	var cmdPeers = cmdClusterMembers{common: &commonCmd}
 	app.AddCommand(cmdPeers.Command())
 
-	//var cmdReload = cmdReload{common: &commonCmd}
-	//app.AddCommand(cmdReload.Command())
-
-	//var cmdShutdown = cmdShutdown{common: &commonCmd}
-	//app.AddCommand(cmdShutdown.Command())
+	var cmdShutdown = cmdShutdown{common: &commonCmd}
+	app.AddCommand(cmdShutdown.Command())
 
 	var cmdSQL = cmdSQL{common: &commonCmd}
 	app.AddCommand(cmdSQL.Command())

--- a/example/cmd/microctl/shutdown.go
+++ b/example/cmd/microctl/shutdown.go
@@ -1,0 +1,51 @@
+package main
+
+import (
+	"context"
+
+	"github.com/canonical/microcluster/microcluster"
+	"github.com/spf13/cobra"
+)
+
+type cmdShutdown struct {
+	common *CmdControl
+}
+
+func (c *cmdShutdown) Command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "shutdown",
+		Short: "Shutdown MicroCluster daemon",
+		RunE:  c.Run,
+	}
+
+	return cmd
+}
+
+func (c *cmdShutdown) Run(cmd *cobra.Command, args []string) error {
+	if len(args) != 0 {
+		return cmd.Help()
+	}
+
+	m, err := microcluster.App(context.Background(), c.common.FlagStateDir, c.common.FlagLogVerbose, c.common.FlagLogDebug)
+	if err != nil {
+		return err
+	}
+
+	client, err := m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	chResult := make(chan error, 1)
+	go func() {
+		defer close(chResult)
+
+		err := client.ShutdownDaemon(context.Background())
+		if err != nil {
+			chResult <- err
+			return
+		}
+	}()
+
+	return <-chResult
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -391,24 +391,31 @@ func (d *Daemon) ServerCert() *shared.CertInfo {
 // State creates a State instance with the daemon's stateful components.
 func (d *Daemon) State() *state.State {
 	state := &state.State{
-		Context:     d.ShutdownCtx,
-		ReadyCh:     d.ReadyChan,
-		OS:          d.os,
-		Address:     d.Address,
-		Endpoints:   d.endpoints,
-		ServerCert:  d.ServerCert,
-		ClusterCert: d.ClusterCert,
-		Database:    d.db,
-		Remotes:     d.trustStore.Remotes,
-		StartAPI:    d.StartAPI,
+		Context:        d.ShutdownCtx,
+		ReadyCh:        d.ReadyChan,
+		ShutdownDoneCh: d.ShutdownDoneCh,
+		OS:             d.os,
+		Address:        d.Address,
+		Endpoints:      d.endpoints,
+		ServerCert:     d.ServerCert,
+		ClusterCert:    d.ClusterCert,
+		Database:       d.db,
+		Remotes:        d.trustStore.Remotes,
+		StartAPI:       d.StartAPI,
+		Stop:           d.Stop,
 	}
 
 	return state
 }
 
 // Stop stops the Daemon via its shutdown channel.
-func (d *Daemon) Stop(ctx context.Context, sig os.Signal) error {
+func (d *Daemon) Stop() error {
 	d.ShutdownCancel()
+
+	err := d.db.Stop()
+	if err != nil {
+		return fmt.Errorf("Failed shutting down database: %w", err)
+	}
 
 	return d.endpoints.Down()
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -359,6 +360,12 @@ func (d *Daemon) StartAPI(bootstrap bool, joinAddresses ...string) error {
 		if err != nil {
 			logger.Error("Failed to send database upgrade request", logger.Ctx{"error": err})
 			return nil
+		}
+
+		defer resp.Body.Close()
+		_, err = io.Copy(io.Discard, resp.Body)
+		if err != nil {
+			logger.Error("Failed to read upgrade notification response body", logger.Ctx{"error": err})
 		}
 
 		if resp.StatusCode != http.StatusOK {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -357,7 +357,8 @@ func (d *Daemon) StartAPI(bootstrap bool, joinAddresses ...string) error {
 
 		resp, err := c.Client.Do(upgradeRequest)
 		if err != nil {
-			return fmt.Errorf("Failed to send database upgrade request: %w", err)
+			logger.Error("Failed to send database upgrade request", logger.Ctx{"error": err})
+			return nil
 		}
 
 		if resp.StatusCode != http.StatusOK {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -267,7 +267,7 @@ func (d *Daemon) StartAPI(bootstrap bool, joinAddresses ...string) error {
 	}
 
 	server := d.initServer(resources.InternalEndpoints, resources.PublicEndpoints, resources.ExtendedEndpoints)
-	network := endpoints.NewNetwork(endpoints.EndpointNetwork, server, d.Address, d.clusterCert)
+	network := endpoints.NewNetwork(d.ShutdownCtx, endpoints.EndpointNetwork, server, d.Address, d.clusterCert)
 
 	err = d.endpoints.Add(network)
 	if err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -106,7 +106,7 @@ func (d *Daemon) init(extendedEndpoints []rest.Endpoint, schemaExtensions map[in
 		return fmt.Errorf("Failed to initialize trust store: %w", err)
 	}
 
-	d.db = db.NewDB(d.serverCert, d.os, d.Address)
+	d.db = db.NewDB(d.ShutdownCtx, d.serverCert, d.os, d.Address)
 
 	ctlServer := d.initServer(resources.ControlEndpoints)
 	ctl := endpoints.NewSocket(d.ShutdownCtx, ctlServer, d.os.ControlSocket(), "") // TODO: add socket group.

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -7,6 +7,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -310,6 +311,10 @@ func dqliteNetworkDial(ctx context.Context, addr string, db *DB) (net.Conn, erro
 	}
 
 	defer response.Body.Close()
+	_, err = io.Copy(io.Discard, response.Body)
+	if err != nil {
+		logger.Error("Failed to read dqlite response body", logger.Ctx{"error": err})
+	}
 
 	// If the remote server has detected that we are out of date, let's
 	// trigger an upgrade.

--- a/internal/endpoints/socket.go
+++ b/internal/endpoints/socket.go
@@ -88,7 +88,12 @@ func (s *Socket) Serve() {
 		default:
 			err := s.server.Serve(s.listener)
 			if err != nil {
-				logger.Error("Failed to start server", logger.Ctx{"err": err})
+				select {
+				case <-s.ctx.Done():
+					logger.Infof("Received shutdown signal - aborting unix socket server startup")
+				default:
+					logger.Error("Failed to start server", logger.Ctx{"err": err})
+				}
 			}
 		}
 	}()

--- a/internal/rest/client/client.go
+++ b/internal/rest/client/client.go
@@ -299,7 +299,7 @@ func (c *Client) QueryStruct(ctx context.Context, method string, endpointType En
 	}
 
 	// Log the data.
-	logger.Debugf("Got response struct from microcluster daemon")
+	logger.Debug("Got response struct from microcluster daemon", logger.Ctx{"endpoint": localURL.String(), "method": method})
 	// TODO: Log.pretty.
 	return nil
 }

--- a/internal/rest/client/client.go
+++ b/internal/rest/client/client.go
@@ -255,9 +255,18 @@ func (c *Client) rawQuery(ctx context.Context, method string, url *api.URL, data
 		return nil, err
 	}
 
-	defer resp.Body.Close()
+	parsedResponse, err := parseResponse(resp)
+	if err != nil {
+		return nil, err
+	}
 
-	return parseResponse(resp)
+	defer resp.Body.Close()
+	_, err = io.Copy(io.Discard, resp.Body)
+	if err != nil {
+		logger.Error("Failed to read response body", logger.Ctx{"error": err})
+	}
+
+	return parsedResponse, nil
 }
 
 // QueryStruct sends a request of the specified method to the provided endpoint (optional) on the API matching the endpointType.

--- a/internal/rest/client/shutdown.go
+++ b/internal/rest/client/shutdown.go
@@ -1,0 +1,16 @@
+package client
+
+import (
+	"context"
+	"time"
+
+	"github.com/lxc/lxd/shared/api"
+)
+
+// ShutdownDaemon begins the daemon shutdown sequence.
+func (c *Client) ShutdownDaemon(ctx context.Context) error {
+	queryCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	defer cancel()
+
+	return c.QueryStruct(queryCtx, "POST", ControlEndpoint, api.NewURL().Path("shutdown"), nil, nil)
+}

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -37,12 +37,16 @@ func clusterPost(state *state.State, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	leaderClient, err := state.Database.Leader()
+	// Set a 5 second timeout in case dqlite locks up.
+	ctx, cancel := context.WithTimeout(state.Context, time.Second*5)
+	defer cancel()
+
+	leaderClient, err := state.Database.Leader(ctx)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	leaderInfo, err := leaderClient.Leader(state.Context)
+	leaderInfo, err := leaderClient.Leader(ctx)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -22,6 +22,7 @@ var ControlEndpoints = &Resources{
 		tokenCmd,
 		clusterCmd,
 		heartbeatCmd,
+    shutdownCmd,
 	},
 }
 

--- a/internal/rest/resources/shutdown.go
+++ b/internal/rest/resources/shutdown.go
@@ -1,0 +1,51 @@
+package resources
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/lxc/lxd/lxd/response"
+
+	"github.com/canonical/microcluster/internal/rest/access"
+	"github.com/canonical/microcluster/internal/state"
+	"github.com/canonical/microcluster/rest"
+)
+
+var shutdownCmd = rest.Endpoint{
+	Path: "shutdown",
+
+	Post: rest.EndpointAction{Handler: shutdownPost, AccessHandler: access.AllowAuthenticated},
+}
+
+func shutdownPost(state *state.State, r *http.Request) response.Response {
+	if state.Context.Err() != nil {
+		return response.SmartError(fmt.Errorf("Shutdown already in progress"))
+	}
+
+	return response.ManualResponse(func(w http.ResponseWriter) error {
+		<-state.ReadyCh // Wait for daemon to start.
+
+		// Run shutdown sequence synchronously.
+		stopErr := state.Stop()
+		err := response.SmartError(stopErr).Render(w)
+		if err != nil {
+			return err
+		}
+
+		// Send the response before the daemon process ends.
+		f, ok := w.(http.Flusher)
+		if ok {
+			f.Flush()
+		} else {
+			return fmt.Errorf("http.ResponseWriter is not type http.Flusher")
+		}
+
+		// Send result of d.Stop() to cmdDaemon so that process stops with correct exit code from Stop().
+		go func() {
+			<-r.Context().Done() // Wait until request is finished.
+			state.ShutdownDoneCh <- stopErr
+		}()
+
+		return nil
+	})
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -25,6 +25,9 @@ type State struct {
 	// Ready channel.
 	ReadyCh chan struct{}
 
+	// ShutdownDoneCh receives the result of the d.Stop() function and tells the daemon to end.
+	ShutdownDoneCh chan error
+
 	// File structure.
 	OS *sys.OS
 
@@ -49,8 +52,8 @@ type State struct {
 	// Initialize APIs and bootstrap/join database.
 	StartAPI func(bootstrap bool, joinAddresses ...string) error
 
-	// When set, the consumer API will only allow GET requests.
-	ReadOnly bool
+	// Stop fully stops the daemon, its database, and all listeners.
+	Stop func() error
 }
 
 // Cluster returns a client for every member of a cluster, except

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -3,6 +3,7 @@ package state
 import (
 	"context"
 	"net/http"
+	"time"
 
 	"github.com/lxc/lxd/lxd/cluster/request"
 	"github.com/lxc/lxd/shared"
@@ -94,12 +95,15 @@ func (s *State) Cluster(r *http.Request) (client.Cluster, error) {
 
 // Leader returns a client connected to the dqlite leader.
 func (s *State) Leader() (*client.Client, error) {
-	leaderClient, err := s.Database.Leader()
+	ctx, cancel := context.WithTimeout(s.Context, time.Second*5)
+	defer cancel()
+
+	leaderClient, err := s.Database.Leader(ctx)
 	if err != nil {
 		return nil, err
 	}
 
-	leaderInfo, err := leaderClient.Leader(s.Context)
+	leaderInfo, err := leaderClient.Leader(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/sys/environment.go
+++ b/internal/sys/environment.go
@@ -6,4 +6,7 @@ const (
 
 	// StateDir is the location of the daemon state directory.
 	StateDir = "STATE_DIR"
+
+	// SchemaUpdate is the path to the schema update to run.
+	SchemaUpdate = "SCHEMA_UPDATE"
 )

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -82,7 +82,7 @@ func (m *MicroCluster) Start(listenAddr string, apiEndpoints []rest.Endpoint, sc
 				logCtx.Warn("Ignoring signal, shutdown already in progress")
 			} else {
 				go func() {
-					d.ShutdownDoneCh <- d.Stop(context.Background(), sig)
+					d.ShutdownDoneCh <- d.Stop()
 				}()
 			}
 


### PR DESCRIPTION
Depends on #4 

This adds several bug fixes that I noticed upon more nuanced testing:

* Most importantly, this moves initiating the heartbeat out of the dqlite dialFunc. Calls to the dqlite client methods (to check the leader and cluster status during a heartbeat) will initiate further calls to the dialFunc, which calls more heartbeats, and on and on. I noticed my CPU spiking up to 600% from getting slammed with heartbeat requests. The corresponding commit here adds a helper that calls the heartbeat function every second, and is now set up to run in a goroutine upon opening the database.

* Auto-schema-update logic was missing from the heartbeat sequence. Now there is an environment variable: `SCHEMA_UPDATE` that will be checked for an auto-update executable.
* Adds a 5s context timeout for calls to the dqlite client since they can be blocking in some cases. I'm unable to replicate this frequently enough (It seems to happen randomly as far as I can tell) to be able to test how exactly this works, but I noticed that very occasionally, attempting to check if we are the dqlite leader froze the daemon. If this happens on the leader then no heartbeats will be sent until the leader is reloaded.
* Ensures all API responses are fully read and closed so we can reuse the connection. 
* Prevents erroring out during reload if other cluster members are still updating
* The heartbeat timeout logic was incorrect, and is now correctly sleeping a maximum of half the client context timeout for heartbeats (`HeartbeatTimeout`), and a minimum of 2 seconds, as the other cluster members will report their heartbeat times a bit ahead of the leader).
* Adds some debug logs for the heartbeat.