### PR TITLE
Token changes

### DIFF
--- a/cluster/token_records.go
+++ b/cluster/token_records.go
@@ -5,6 +5,7 @@ import (
 
 	internalTypes "github.com/canonical/microcluster/internal/rest/types"
 	"github.com/canonical/microcluster/rest/types"
+	"github.com/lxc/lxd/shared"
 )
 
 // Code generation directives.
@@ -43,7 +44,7 @@ type InternalTokenRecordFilter struct {
 func (t *InternalTokenRecord) ToAPI(clusterCert *x509.Certificate, joinAddresses []types.AddrPort) (*internalTypes.TokenRecord, error) {
 	token := internalTypes.Token{
 		Token:         t.Token,
-		ClusterCert:   types.X509Certificate{Certificate: clusterCert},
+		Fingerprint:   shared.CertFingerprint(clusterCert),
 		JoinAddresses: joinAddresses,
 	}
 

--- a/cluster/token_records.go
+++ b/cluster/token_records.go
@@ -14,7 +14,7 @@ import (
 //go:generate mapper reset
 //
 //go:generate mapper stmt -e internal_token_record objects table=internal_token_records version=2
-//go:generate mapper stmt -e internal_token_record objects-by-Token table=internal_token_records version=2
+//go:generate mapper stmt -e internal_token_record objects-by-Secret table=internal_token_records version=2
 //go:generate mapper stmt -e internal_token_record id table=internal_token_records version=2
 //go:generate mapper stmt -e internal_token_record create table=internal_token_records version=2
 //go:generate mapper stmt -e internal_token_record delete-by-Name table=internal_token_records version=2
@@ -28,22 +28,22 @@ import (
 
 // InternalTokenRecord is the database representation of a join token record.
 type InternalTokenRecord struct {
-	ID    int
-	Token string
-	Name  string `db:"primary=yes"`
+	ID     int
+	Secret string
+	Name   string `db:"primary=yes"`
 }
 
 // InternalTokenRecordFilter is the filter struct for filtering results from generated methods.
 type InternalTokenRecordFilter struct {
-	ID    *int
-	Token *string
-	Name  *string
+	ID     *int
+	Secret *string
+	Name   *string
 }
 
 // ToAPI converts the InternalTokenRecord to a full token and returns an API compatible struct.
 func (t *InternalTokenRecord) ToAPI(clusterCert *x509.Certificate, joinAddresses []types.AddrPort) (*internalTypes.TokenRecord, error) {
 	token := internalTypes.Token{
-		Token:         t.Token,
+		Secret:        t.Secret,
 		Fingerprint:   shared.CertFingerprint(clusterCert),
 		JoinAddresses: joinAddresses,
 	}

--- a/cluster/token_records.mapper.go
+++ b/cluster/token_records.mapper.go
@@ -93,7 +93,7 @@ func InternalTokenRecordExists(ctx context.Context, tx *sql.Tx, name string) (bo
 // generator: internal_token_record GetOne
 func GetInternalTokenRecord(ctx context.Context, tx *sql.Tx, token string) (*InternalTokenRecord, error) {
 	filter := InternalTokenRecordFilter{}
-	filter.Token = &token
+	filter.Secret = &token
 
 	objects, err := GetInternalTokenRecords(ctx, tx, filter)
 	if err != nil {
@@ -122,12 +122,12 @@ func GetInternalTokenRecords(ctx context.Context, tx *sql.Tx, filter InternalTok
 	var sqlStmt *sql.Stmt
 	var args []any
 
-	if filter.Name == nil && filter.ID == nil && filter.Token != nil {
+	if filter.Name == nil && filter.ID == nil && filter.Secret != nil {
 		sqlStmt = stmt(tx, internalTokenRecordObjectsByToken)
 		args = []any{
-			filter.Token,
+			filter.Secret,
 		}
-	} else if filter.ID == nil && filter.Token == nil && filter.Name == nil {
+	} else if filter.ID == nil && filter.Secret == nil && filter.Name == nil {
 		sqlStmt = stmt(tx, internalTokenRecordObjects)
 		args = []any{}
 	} else {
@@ -139,7 +139,7 @@ func GetInternalTokenRecords(ctx context.Context, tx *sql.Tx, filter InternalTok
 		objects = append(objects, InternalTokenRecord{})
 		return []any{
 			&objects[i].ID,
-			&objects[i].Token,
+			&objects[i].Secret,
 			&objects[i].Name,
 		}
 	}
@@ -169,7 +169,7 @@ func CreateInternalTokenRecord(ctx context.Context, tx *sql.Tx, object InternalT
 	args := make([]any, 2)
 
 	// Populate the statement arguments.
-	args[0] = object.Token
+	args[0] = object.Secret
 	args[1] = object.Name
 
 	// Prepared statement to use.

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -96,7 +96,7 @@ func clusterPost(state *state.State, r *http.Request) response.Response {
 			Role:        cluster.Pending,
 		}
 
-		record, err := cluster.GetInternalTokenRecord(ctx, tx, req.JoinToken)
+		record, err := cluster.GetInternalTokenRecord(ctx, tx, req.Secret)
 		if err != nil {
 			return err
 		}

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -82,7 +82,7 @@ func joinWithToken(state *state.State, req *internalTypes.Control) response.Resp
 			Certificate: localClusterMember.Certificate,
 		},
 		SchemaVersion: update.Schema().Version(),
-		JoinToken:     token.Token,
+		Secret:        token.Secret,
 	}
 
 	// Get a client to the target address.

--- a/internal/rest/resources/tokens.go
+++ b/internal/rest/resources/tokens.go
@@ -60,7 +60,7 @@ func tokensPost(state *state.State, r *http.Request) response.Response {
 
 	token := internalTypes.Token{
 		Name:          req.Name,
-		Token:         tokenKey,
+		Secret:        tokenKey,
 		Fingerprint:   shared.CertFingerprint(clusterCert),
 		JoinAddresses: joinAddresses,
 	}
@@ -71,7 +71,7 @@ func tokensPost(state *state.State, r *http.Request) response.Response {
 	}
 
 	err = state.Database.Transaction(state.Context, func(ctx context.Context, tx *db.Tx) error {
-		_, err = cluster.CreateInternalTokenRecord(ctx, tx, cluster.InternalTokenRecord{Name: req.Name, Token: tokenKey})
+		_, err = cluster.CreateInternalTokenRecord(ctx, tx, cluster.InternalTokenRecord{Name: req.Name, Secret: tokenKey})
 		return err
 	})
 	if err != nil {

--- a/internal/rest/resources/tokens.go
+++ b/internal/rest/resources/tokens.go
@@ -61,7 +61,7 @@ func tokensPost(state *state.State, r *http.Request) response.Response {
 	token := internalTypes.Token{
 		Name:          req.Name,
 		Token:         tokenKey,
-		ClusterCert:   types.X509Certificate{Certificate: clusterCert},
+		Fingerprint:   shared.CertFingerprint(clusterCert),
 		JoinAddresses: joinAddresses,
 	}
 

--- a/internal/rest/types/cluster.go
+++ b/internal/rest/types/cluster.go
@@ -13,7 +13,7 @@ type ClusterMember struct {
 	SchemaVersion int          `json:"schema_version" yaml:"schema_version"`
 	LastHeartbeat time.Time    `json:"last_heartbeat" yaml:"last_heartbeat"`
 	Status        MemberStatus `json:"status" yaml:"status"`
-	JoinToken     string       `json:"join_token" yaml:"join_token"`
+	Secret        string       `json:"secret" yaml:"secret"`
 }
 
 // ClusterMemberLocal represents local information about a new cluster member.

--- a/internal/rest/types/tokens.go
+++ b/internal/rest/types/tokens.go
@@ -23,7 +23,7 @@ type TokenResponse struct {
 // Token holds the information that is presented to the joining node when requesting a token.
 type Token struct {
 	Name          string           `json:"name" yaml:"name"`
-	Token         string           `json:"token" yaml:"token"`
+	Secret        string           `json:"secret" yaml:"secret"`
 	Fingerprint   string           `json:"fingerprint" yaml:"fingerprint"`
 	JoinAddresses []types.AddrPort `json:"join_addresses" yaml:"join_addresses"`
 }

--- a/internal/rest/types/tokens.go
+++ b/internal/rest/types/tokens.go
@@ -22,10 +22,10 @@ type TokenResponse struct {
 
 // Token holds the information that is presented to the joining node when requesting a token.
 type Token struct {
-	Name          string                `json:"name" yaml:"name"`
-	Token         string                `json:"token" yaml:"token"`
-	ClusterCert   types.X509Certificate `json:"cluster_cert" yaml:"cluster_cert"`
-	JoinAddresses []types.AddrPort      `json:"join_addresses" yaml:"join_addresses"`
+	Name          string           `json:"name" yaml:"name"`
+	Token         string           `json:"token" yaml:"token"`
+	Fingerprint   string           `json:"fingerprint" yaml:"fingerprint"`
+	JoinAddresses []types.AddrPort `json:"join_addresses" yaml:"join_addresses"`
 }
 
 func (t Token) String() (string, error) {


### PR DESCRIPTION
This changes tokens to store the cluster certificate fingerprint rather than the whole certificate.  The certificate is then checked against the actual cluster using `GetRemoteCertificate` and a cluster member address from the token.

Additionally, all references to the internal token key have been renamed to `secret`. 