### PR TITLE
Endpoint fix

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -20,11 +20,11 @@ func IsForwardedRequest(r *http.Request) bool {
 	return r.Header.Get("User-Agent") == clusterRequest.UserAgentNotifier
 }
 
-// Query is a helper for initiating a request on the /public endpoint. This function should be used for all client
+// Query is a helper for initiating a request on the /1.0 endpoint. This function should be used for all client
 // methods defined externally from MicroCluster.
 func (c *Client) Query(ctx context.Context, method string, path *api.URL, in any, out any) error {
 	queryCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, method, client.PublicEndpoint, path, in, &out)
+	return c.QueryStruct(queryCtx, method, client.ExtendedEndpoint, path, in, &out)
 }

--- a/example/api/endpoints.go
+++ b/example/api/endpoints.go
@@ -5,7 +5,7 @@ import (
 	"github.com/canonical/microcluster/rest"
 )
 
-// Endpoints is a global list of all API endpoints on the /public endpoint of
+// Endpoints is a global list of all API endpoints on the /1.0 endpoint of
 // microcluster, as supplied by this example project.
 var Endpoints = []rest.Endpoint{
 	extendedCmd,

--- a/example/api/extended.go
+++ b/example/api/extended.go
@@ -16,14 +16,14 @@ import (
 	"github.com/canonical/microcluster/state"
 )
 
-// This is an example extended endpoint on the /public endpoint, reachable at /public/extended.
+// This is an example extended endpoint on the /1.0 endpoint, reachable at /1.0/extended.
 var extendedCmd = rest.Endpoint{
 	Path: "extended",
 
 	Post: rest.EndpointAction{Handler: cmdPost, AllowUntrusted: true},
 }
 
-// This is the POST handler for the /public/extended endpoint.
+// This is the POST handler for the /1.0/extended endpoint.
 // This example shows how to forward a request to other cluster members.
 func cmdPost(state *state.State, r *http.Request) response.Response {
 	// Check the user agent header to check if we are the notifying cluster member.
@@ -47,7 +47,7 @@ func cmdPost(state *state.State, r *http.Request) response.Response {
 				Message: "Testing 1 2 3...",
 			}
 
-			// Asynchronously send a POST on /public/extended to each other cluster member.
+			// Asynchronously send a POST on /1.0/extended to each other cluster member.
 			outMessage, err := extendedClient.ExtendedPostCmd(ctx, c, data)
 			if err != nil {
 				clientURL := c.URL()

--- a/example/client/client.go
+++ b/example/client/client.go
@@ -12,7 +12,7 @@ import (
 	"github.com/canonical/microcluster/example/api/types"
 )
 
-// ExtendedPostCmd is a client function that sets a context timeout and sends a POST to /public/extended using the given
+// ExtendedPostCmd is a client function that sets a context timeout and sends a POST to /1.0/extended using the given
 // client. This function is expected to be called from an api endpoint handler, which gives us access to the
 // daemon state, from which we can create a client.
 func ExtendedPostCmd(ctx context.Context, c *client.Client, data *types.ExtendedType) (string, error) {


### PR DESCRIPTION
Noticed a bug with the `Query` helper, which was making requests for extended APIs on the internal public API of microcluster. 

Extended apis are now correctly all going through `/1.0`.
Public internal APIs are `/cluster/1.0`
Restricted internal APIs `/cluster/internal`
and Control socket APIs are `/cluster/control`