### PR TITLE
Ensure database is open before heartbeat response

### DIFF
--- a/internal/rest/resources/heartbeat.go
+++ b/internal/rest/resources/heartbeat.go
@@ -39,6 +39,11 @@ func heartbeatPost(state *state.State, r *http.Request) response.Response {
 
 	// If we are not beginning a heartbeat, we are receiving one sent by the leader,
 	// so we should update our local store of cluster members with the data from the heartbeat.
+
+	if !state.Database.IsOpen() {
+		return response.SmartError(fmt.Errorf("Failed to respond to heartbeat, database is not yet open"))
+	}
+
 	clusterMemberList := []types.ClusterMember{}
 	for _, clusterMember := range hbInfo.ClusterMembers {
 		clusterMemberList = append(clusterMemberList, clusterMember)


### PR DESCRIPTION
I wasn't able to replicate the panic, but it seems to be coming from the `sql.DB` type, so this adds a check to ensure the database is actually open before attempting to respond to a heartbeat.

I'm starting a cluster like this, and did not run into this issue.

https://paste.ubuntu.com/p/fs5nDGs2rs/