### PR TITLE
Init hook on bootstrap/join

### DIFF
--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -14,6 +14,7 @@ import (
 	"github.com/canonical/microcluster/example/database"
 	"github.com/canonical/microcluster/example/version"
 	"github.com/canonical/microcluster/microcluster"
+	"github.com/canonical/microcluster/state"
 )
 
 // Debug indicates whether to log debug messages or not.
@@ -64,7 +65,15 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return m.Start(c.flagAddr, api.Endpoints, database.SchemaExtensions)
+	return m.Start(c.flagAddr, api.Endpoints, database.SchemaExtensions, func(state *state.State, bootstrap bool) error {
+		if bootstrap {
+			logger.Info("This is a hook run on bootstrap")
+		} else {
+			logger.Info("This is a hook run on join")
+		}
+
+		return nil
+	})
 }
 
 func init() {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -49,6 +49,8 @@ type Daemon struct {
 	fsWatcher  *sys.Watcher
 	trustStore *trust.Store
 
+	initHook func(state *state.State, bootstrap bool) error // Hook to be called upon initializing the daemon for the first time.
+
 	ReadyChan      chan struct{}      // Closed when the daemon is fully ready.
 	ShutdownCtx    context.Context    // Cancelled when shutdown starts.
 	ShutdownDoneCh chan error         // Receives the result of the d.Stop() function and tells the daemon to end.
@@ -67,7 +69,7 @@ func NewDaemon(ctx context.Context) *Daemon {
 }
 
 // Init initializes the Daemon with the given configuration, and starts the database.
-func (d *Daemon) Init(addr string, stateDir string, extendedEndpoints []rest.Endpoint, schemaExtensions map[int]schema.Update) error {
+func (d *Daemon) Init(addr string, stateDir string, extendedEndpoints []rest.Endpoint, schemaExtensions map[int]schema.Update, initHook func(state *state.State, bootstrap bool) error) error {
 	if stateDir == "" {
 		stateDir = os.Getenv(sys.StateDir)
 	}
@@ -84,7 +86,7 @@ func (d *Daemon) Init(addr string, stateDir string, extendedEndpoints []rest.End
 		return fmt.Errorf("Failed to initialize directory structure: %w", err)
 	}
 
-	err = d.init(extendedEndpoints, schemaExtensions)
+	err = d.init(extendedEndpoints, schemaExtensions, initHook)
 	if err != nil {
 		return fmt.Errorf("Daemon failed to start: %w", err)
 	}
@@ -94,7 +96,7 @@ func (d *Daemon) Init(addr string, stateDir string, extendedEndpoints []rest.End
 	return nil
 }
 
-func (d *Daemon) init(extendedEndpoints []rest.Endpoint, schemaExtensions map[int]schema.Update) error {
+func (d *Daemon) init(extendedEndpoints []rest.Endpoint, schemaExtensions map[int]schema.Update, initHook func(state *state.State, bootstrap bool) error) error {
 	var err error
 	d.serverCert, err = util.LoadServerCert(d.os.StateDir)
 	if err != nil {
@@ -129,6 +131,8 @@ func (d *Daemon) init(extendedEndpoints []rest.Endpoint, schemaExtensions map[in
 	if err != nil {
 		return err
 	}
+
+	d.initHook = initHook
 
 	return nil
 }
@@ -374,8 +378,15 @@ func (d *Daemon) StartAPI(bootstrap bool, joinAddresses ...string) error {
 
 		return nil
 	})
+	if err != nil {
+		return err
+	}
 
-	return err
+	if d.initHook != nil {
+		return d.initHook(d.State(), bootstrap)
+	}
+
+	return nil
 }
 
 // ClusterCert ensures both the daemon and state have the same cluster cert.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -148,7 +148,7 @@ func (d *Daemon) reloadIfBootstrapped() error {
 		return err
 	}
 
-	err = d.StartAPI(false)
+	err = d.StartAPI(false, false)
 	if err != nil {
 		return err
 	}
@@ -241,7 +241,7 @@ func (d *Daemon) validateConfig(addr string, stateDir string) error {
 
 // StartAPI starts up the admin and consumer APIs, and generates a cluster cert
 // if we are bootstrapping the first node.
-func (d *Daemon) StartAPI(bootstrap bool, joinAddresses ...string) error {
+func (d *Daemon) StartAPI(bootstrap bool, runHook bool, joinAddresses ...string) error {
 	addr, err := types.ParseAddrPort(d.Address.URL.Host)
 	if err != nil {
 		return fmt.Errorf("Failed to parse listen address when bootstrapping API: %w", err)
@@ -382,7 +382,7 @@ func (d *Daemon) StartAPI(bootstrap bool, joinAddresses ...string) error {
 		return err
 	}
 
-	if d.initHook != nil {
+	if runHook && d.initHook != nil {
 		return d.initHook(d.State(), bootstrap)
 	}
 

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -43,7 +43,7 @@ func controlPost(state *state.State, r *http.Request) response.Response {
 		return joinWithToken(state, req)
 	}
 
-	err = state.StartAPI(req.Bootstrap)
+	err = state.StartAPI(req.Bootstrap, true)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -142,7 +142,7 @@ func joinWithToken(state *state.State, req *internalTypes.Control) response.Resp
 	}
 
 	// Start the HTTPS listeners and join Dqlite.
-	err = state.StartAPI(false, joinAddrs.Strings()...)
+	err = state.StartAPI(false, true, joinAddrs.Strings()...)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -50,7 +50,7 @@ type State struct {
 	Remotes func() *trust.Remotes
 
 	// Initialize APIs and bootstrap/join database.
-	StartAPI func(bootstrap bool, joinAddresses ...string) error
+	StartAPI func(bootstrap bool, runHook bool, joinAddresses ...string) error
 
 	// Stop fully stops the daemon, its database, and all listeners.
 	Stop func() error


### PR DESCRIPTION
Adds an init hook that can be passed to the daemon via `microcluster.Start`, which is run on a call to `microcluster.NewCluster()` (bootstrap) or `microcluster.JoinCluster()` (join)

The hook is of form `func(state *state.State, bootstrap bool) error`