### PR TITLE
Fix internal_cluster_members primary key for lxd-generate and update invocations.

### DIFF
--- a/cluster/cluster_members.go
+++ b/cluster/cluster_members.go
@@ -38,8 +38,8 @@ const Pending Role = "PENDING"
 // InternalClusterMember represents the global database entry for a dqlite cluster member.
 type InternalClusterMember struct {
 	ID          int
-	Name        string
-	Address     string `db:"primary=yes"`
+	Name        string `db:"primary=yes"`
+	Address     string
 	Certificate string
 	Schema      int
 	Heartbeat   time.Time

--- a/cluster/cluster_members.go
+++ b/cluster/cluster_members.go
@@ -14,20 +14,20 @@ import (
 //go:generate -command mapper lxd-generate db mapper -t cluster_members.mapper.go
 //go:generate mapper reset
 //
-//go:generate mapper stmt -e internal_cluster_member objects table=internal_cluster_members version=2
-//go:generate mapper stmt -e internal_cluster_member objects-by-Address table=internal_cluster_members version=2
-//go:generate mapper stmt -e internal_cluster_member id table=internal_cluster_members version=2
-//go:generate mapper stmt -e internal_cluster_member create table=internal_cluster_members version=2
-//go:generate mapper stmt -e internal_cluster_member delete-by-Address table=internal_cluster_members version=2
-//go:generate mapper stmt -e internal_cluster_member update table=internal_cluster_members version=2
+//go:generate mapper stmt -e internal_cluster_member objects table=internal_cluster_members
+//go:generate mapper stmt -e internal_cluster_member objects-by-Address table=internal_cluster_members
+//go:generate mapper stmt -e internal_cluster_member id table=internal_cluster_members
+//go:generate mapper stmt -e internal_cluster_member create table=internal_cluster_members
+//go:generate mapper stmt -e internal_cluster_member delete-by-Address table=internal_cluster_members
+//go:generate mapper stmt -e internal_cluster_member update table=internal_cluster_members
 //
-//go:generate mapper method -i -e internal_cluster_member GetMany version=2
-//go:generate mapper method -i -e internal_cluster_member GetOne version=2
-//go:generate mapper method -i -e internal_cluster_member ID version=2
-//go:generate mapper method -i -e internal_cluster_member Exists version=2
-//go:generate mapper method -i -e internal_cluster_member Create version=2
-//go:generate mapper method -i -e internal_cluster_member DeleteOne-by-Address version=2
-//go:generate mapper method -i -e internal_cluster_member Update version=2
+//go:generate mapper method -i -e internal_cluster_member GetMany
+//go:generate mapper method -i -e internal_cluster_member GetOne
+//go:generate mapper method -i -e internal_cluster_member ID
+//go:generate mapper method -i -e internal_cluster_member Exists
+//go:generate mapper method -i -e internal_cluster_member Create
+//go:generate mapper method -i -e internal_cluster_member DeleteOne-by-Address
+//go:generate mapper method -i -e internal_cluster_member Update
 
 // Role is the role of the dqlite cluster member, with the addition of "pending" for nodes about to be added or
 // removed.

--- a/cluster/token_records.go
+++ b/cluster/token_records.go
@@ -13,18 +13,18 @@ import (
 //go:generate -command mapper lxd-generate db mapper -t token_records.mapper.go
 //go:generate mapper reset
 //
-//go:generate mapper stmt -e internal_token_record objects table=internal_token_records version=2
-//go:generate mapper stmt -e internal_token_record objects-by-Secret table=internal_token_records version=2
-//go:generate mapper stmt -e internal_token_record id table=internal_token_records version=2
-//go:generate mapper stmt -e internal_token_record create table=internal_token_records version=2
-//go:generate mapper stmt -e internal_token_record delete-by-Name table=internal_token_records version=2
+//go:generate mapper stmt -e internal_token_record objects table=internal_token_records
+//go:generate mapper stmt -e internal_token_record objects-by-Secret table=internal_token_records
+//go:generate mapper stmt -e internal_token_record id table=internal_token_records
+//go:generate mapper stmt -e internal_token_record create table=internal_token_records
+//go:generate mapper stmt -e internal_token_record delete-by-Name table=internal_token_records
 //
-//go:generate mapper method -e internal_token_record ID version=2
-//go:generate mapper method -e internal_token_record Exists version=2
-//go:generate mapper method -e internal_token_record GetOne version=2
-//go:generate mapper method -e internal_token_record GetMany version=2
-//go:generate mapper method -e internal_token_record Create version=2
-//go:generate mapper method -e internal_token_record DeleteOne-by-Name version=2
+//go:generate mapper method -e internal_token_record ID
+//go:generate mapper method -e internal_token_record Exists
+//go:generate mapper method -e internal_token_record GetOne
+//go:generate mapper method -e internal_token_record GetMany
+//go:generate mapper method -e internal_token_record Create
+//go:generate mapper method -e internal_token_record DeleteOne-by-Name
 
 // InternalTokenRecord is the database representation of a join token record.
 type InternalTokenRecord struct {

--- a/cluster/token_records.mapper.go
+++ b/cluster/token_records.mapper.go
@@ -24,7 +24,8 @@ SELECT internal_token_records.id, internal_token_records.secret, internal_token_
 var internalTokenRecordObjectsBySecret = RegisterStmt(`
 SELECT internal_token_records.id, internal_token_records.secret, internal_token_records.name
   FROM internal_token_records
-  WHERE ( internal_token_records.secret = ? ) ORDER BY internal_token_records.secret
+  WHERE ( internal_token_records.secret = ? )
+  ORDER BY internal_token_records.secret
 `)
 
 var internalTokenRecordID = RegisterStmt(`

--- a/example/database/extended.mapper.go
+++ b/example/database/extended.mapper.go
@@ -25,7 +25,8 @@ SELECT extended_table.id, extended_table.key, extended_table.value
 var extendedTableObjectsByKey = cluster.RegisterStmt(`
 SELECT extended_table.id, extended_table.key, extended_table.value
   FROM extended_table
-  WHERE ( extended_table.key = ? ) ORDER BY extended_table.key
+  WHERE ( extended_table.key = ? )
+  ORDER BY extended_table.key
 `)
 
 var extendedTableID = cluster.RegisterStmt(`

--- a/example/database/extended_table.go
+++ b/example/database/extended_table.go
@@ -3,20 +3,20 @@ package database
 //go:generate -command mapper lxd-generate db mapper -t extended.mapper.go
 //go:generate mapper reset
 //
-//go:generate mapper stmt -d cluster -e extended_table objects table=extended_table version=2
-//go:generate mapper stmt -d cluster -e extended_table objects-by-Key table=extended_table version=2
-//go:generate mapper stmt -d cluster -e extended_table id table=extended_table version=2
-//go:generate mapper stmt -d cluster -e extended_table create table=extended_table version=2
-//go:generate mapper stmt -d cluster -e extended_table delete-by-Key table=extended_table version=2
-//go:generate mapper stmt -d cluster -e extended_table update table=extended_table version=2
+//go:generate mapper stmt -d cluster -e extended_table objects table=extended_table
+//go:generate mapper stmt -d cluster -e extended_table objects-by-Key table=extended_table
+//go:generate mapper stmt -d cluster -e extended_table id table=extended_table
+//go:generate mapper stmt -d cluster -e extended_table create table=extended_table
+//go:generate mapper stmt -d cluster -e extended_table delete-by-Key table=extended_table
+//go:generate mapper stmt -d cluster -e extended_table update table=extended_table
 //
-//go:generate mapper method -i -d cluster -e extended_table GetMany version=2
-//go:generate mapper method -i -d cluster -e extended_table GetOne version=2
-//go:generate mapper method -i -d cluster -e extended_table ID version=2
-//go:generate mapper method -i -d cluster -e extended_table Exists version=2
-//go:generate mapper method -i -d cluster -e extended_table Create version=2
-//go:generate mapper method -i -d cluster -e extended_table DeleteOne-by-Key version=2
-//go:generate mapper method -i -d cluster -e extended_table Update version=2
+//go:generate mapper method -i -d cluster -e extended_table GetMany
+//go:generate mapper method -i -d cluster -e extended_table GetOne
+//go:generate mapper method -i -d cluster -e extended_table ID
+//go:generate mapper method -i -d cluster -e extended_table Exists
+//go:generate mapper method -i -d cluster -e extended_table Create
+//go:generate mapper method -i -d cluster -e extended_table DeleteOne-by-Key
+//go:generate mapper method -i -d cluster -e extended_table Update
 
 // ExtendedTable is an example of a database table. In this case named `extended_table`. The above comments will
 // generate database queries and helpers using lxd-generate.

--- a/example/database/extended_table.go
+++ b/example/database/extended_table.go
@@ -3,20 +3,20 @@ package database
 //go:generate -command mapper lxd-generate db mapper -t extended.mapper.go
 //go:generate mapper reset
 //
-//go:generate mapper stmt -d cluster -e extended_table objects table=extended_table
-//go:generate mapper stmt -d cluster -e extended_table objects-by-Key table=extended_table
-//go:generate mapper stmt -d cluster -e extended_table id table=extended_table
-//go:generate mapper stmt -d cluster -e extended_table create table=extended_table
-//go:generate mapper stmt -d cluster -e extended_table delete-by-Key table=extended_table
-//go:generate mapper stmt -d cluster -e extended_table update table=extended_table
+//go:generate mapper stmt -d github.com/canonical/microcluster/cluster -e extended_table objects table=extended_table
+//go:generate mapper stmt -d github.com/canonical/microcluster/cluster -e extended_table objects-by-Key table=extended_table
+//go:generate mapper stmt -d github.com/canonical/microcluster/cluster -e extended_table id table=extended_table
+//go:generate mapper stmt -d github.com/canonical/microcluster/cluster -e extended_table create table=extended_table
+//go:generate mapper stmt -d github.com/canonical/microcluster/cluster -e extended_table delete-by-Key table=extended_table
+//go:generate mapper stmt -d github.com/canonical/microcluster/cluster -e extended_table update table=extended_table
 //
-//go:generate mapper method -i -d cluster -e extended_table GetMany
-//go:generate mapper method -i -d cluster -e extended_table GetOne
-//go:generate mapper method -i -d cluster -e extended_table ID
-//go:generate mapper method -i -d cluster -e extended_table Exists
-//go:generate mapper method -i -d cluster -e extended_table Create
-//go:generate mapper method -i -d cluster -e extended_table DeleteOne-by-Key
-//go:generate mapper method -i -d cluster -e extended_table Update
+//go:generate mapper method -i -d github.com/canonical/microcluster/cluster -e extended_table GetMany
+//go:generate mapper method -i -d github.com/canonical/microcluster/cluster -e extended_table GetOne
+//go:generate mapper method -i -d github.com/canonical/microcluster/cluster -e extended_table ID
+//go:generate mapper method -i -d github.com/canonical/microcluster/cluster -e extended_table Exists
+//go:generate mapper method -i -d github.com/canonical/microcluster/cluster -e extended_table Create
+//go:generate mapper method -i -d github.com/canonical/microcluster/cluster -e extended_table DeleteOne-by-Key
+//go:generate mapper method -i -d github.com/canonical/microcluster/cluster -e extended_table Update
 
 // ExtendedTable is an example of a database table. In this case named `extended_table`. The above comments will
 // generate database queries and helpers using lxd-generate.


### PR DESCRIPTION
This correctly applies the `primary=yes` lxd-generate tag to the `InternalClusterMembers` struct on the `Name` field, which corresponds to the unique `name` column on the `internal_cluster_members` table.

Additionally, this updates the `--database` (or `-d` shorthand) flag to expect the full import path for the cluster package, rather than just the package name and hoping `goimports` finds the right one.

