### PR TITLE
microcluster/app: Add customizable timeout to bootstrap/join

### DIFF
--- a/example/cmd/microctl/main_init.go
+++ b/example/cmd/microctl/main_init.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/canonical/microcluster/microcluster"
 	"github.com/spf13/cobra"
@@ -48,11 +49,11 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("Name can only be specified with a join token")
 		}
 
-		return m.NewCluster()
+		return m.NewCluster(time.Second * 30)
 	}
 
 	if c.flagToken != "" {
-		return m.JoinCluster(c.flagToken)
+		return m.JoinCluster(c.flagToken, time.Second*30)
 	}
 
 	return fmt.Errorf("Option must be one of bootstrap or token")

--- a/internal/rest/client/control.go
+++ b/internal/rest/client/control.go
@@ -8,8 +8,12 @@ import (
 )
 
 // ControlDaemon posts control data to the daemon.
-func (c *Client) ControlDaemon(ctx context.Context, args types.Control) error {
-	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+func (c *Client) ControlDaemon(ctx context.Context, args types.Control, timeout time.Duration) error {
+	if timeout != 0 {
+		return c.QueryStruct(ctx, "POST", ControlEndpoint, nil, args, nil)
+	}
+
+	queryCtx, cancel := context.WithTimeout(ctx, timeout)
 	defer cancel()
 
 	return c.QueryStruct(queryCtx, "POST", ControlEndpoint, nil, args, nil)

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -159,23 +159,23 @@ func (m *MicroCluster) Ready(timeoutSeconds int) error {
 }
 
 // NewCluster bootstrapps a brand new cluster with this daemon as its only member.
-func (m *MicroCluster) NewCluster() error {
+func (m *MicroCluster) NewCluster(timeout time.Duration) error {
 	c, err := m.LocalClient()
 	if err != nil {
 		return err
 	}
 
-	return c.ControlDaemon(m.ctx, types.Control{Bootstrap: true})
+	return c.ControlDaemon(m.ctx, types.Control{Bootstrap: true}, timeout)
 }
 
 // JoinCluster joins an existing cluster with a join token supplied by an existing cluster member.
-func (m *MicroCluster) JoinCluster(token string) error {
+func (m *MicroCluster) JoinCluster(token string, timeout time.Duration) error {
 	c, err := m.LocalClient()
 	if err != nil {
 		return err
 	}
 
-	return c.ControlDaemon(m.ctx, types.Control{JoinToken: token})
+	return c.ControlDaemon(m.ctx, types.Control{JoinToken: token}, timeout)
 }
 
 // NewJoinToken creates and records a new join token containing all the necessary credentials for joining a cluster.


### PR DESCRIPTION
Allows passing a `time.Duration` to `microcluster.NewCluster` or `microcluster.JoinCluster` to deal with particularly long post-initialization hooks. If the time passed is 0, the default `microcluster.Microcluster` context will be used in the request.