### PR TITLE
Supply daemon address/name on bootstrap/join

### DIFF
--- a/example/README.md
+++ b/example/README.md
@@ -12,11 +12,11 @@ The daemon can be started with `microd` and is controlled by `microctl`.
 `make`
 
 ## Running
-This starts up three daemons at the given addresses.
+This starts up three daemons.
 ```bash
-microd --state-dir /path/to/state/dir1 --address 127.0.0.1:9001 &
-microd --state-dir /path/to/state/dir2 --address 127.0.0.1:9002 &
-microd --state-dir /path/to/state/dir3 --address 127.0.0.1:9003 &
+microd --state-dir /path/to/state/dir1 &
+microd --state-dir /path/to/state/dir2 &
+microd --state-dir /path/to/state/dir3 &
 ```
 
 ## Starting dqlite
@@ -24,16 +24,16 @@ microd --state-dir /path/to/state/dir3 --address 127.0.0.1:9003 &
 # Wait for the daemon to finish setup.
 microctl --state-dir /path/to/state/dir1 waitready
 
-# Bootstrap the first node to start a new cluster.
-microctl --state-dir /path/to/state/dir1 init --bootstrap
+# Bootstrap the first node to start a new cluster. The new member will be given the name "member1" and will listen on `127.0.0.1:9001`
+microctl --state-dir /path/to/state/dir1 init "member1" 127.0.0.1:9001 --bootstrap
 
 # Get some join tokens from the new cluster. These are deleted after use.
-token_node2=$(microctl --state-dir /path/to/state/dir1 tokens add "dir2")
-token_node3=$(microctl --state-dir /path/to/state/dir1 tokens add "dir3")
+token_node2=$(microctl --state-dir /path/to/state/dir1 tokens add "member2")
+token_node3=$(microctl --state-dir /path/to/state/dir1 tokens add "member3")
 
 # Join the dqlite cluster.
-microctl --state-dir /path/to/state/dir2 init "dir2" --token ${token_node2}
-microctl --state-dir /path/to/state/dir3 init "dir3"" --token ${token_node3}
+microctl --state-dir /path/to/state/dir2 init "member2" 127.0.0.1:9002 --token ${token_node2}
+microctl --state-dir /path/to/state/dir3 init "member3" 127.0.0.1:9003 --token ${token_node3}
 
 # The cluster is now up and running!
 ```
@@ -93,13 +93,15 @@ microctl --state-dir /path/to/state/dir1 cluster list
 ```
 * Remove a cluster member
 ```bash
-microctl --state-dir /path/to/state/dir1 cluster remove dir2
+# This will remove member2 from the cluster.
+microctl --state-dir /path/to/state/dir1 cluster remove member2
 ```
 
 * Perform an SQL query
 ```bash
 microctl --state-dir /path/to/state/dir1 sql "select name,address,schema,heartbeat from cluster_members"
 # Note that the schema version is 3, because this example has extended the schema with two additional updates.
+Customized schema updates and API endpoints can be added when first starting a cluster.
 +------+----------------+--------+--------------------------------+
 | name |    address     | schema |           heartbeat            |
 +------+----------------+--------+--------------------------------+

--- a/example/api/extended.go
+++ b/example/api/extended.go
@@ -36,9 +36,9 @@ func cmdPost(state *state.State, r *http.Request) response.Response {
 
 		messages := make([]string, 0, len(cluster))
 		err = cluster.Query(state.Context, true, func(ctx context.Context, c *client.Client) error {
-			addrPort, err := types.ParseAddrPort(state.Address.URL.Host)
+			addrPort, err := types.ParseAddrPort(state.Address().URL.Host)
 			if err != nil {
-				return fmt.Errorf("Failed to parse addr:port of listen address %q: %w", state.Address.String(), err)
+				return fmt.Errorf("Failed to parse addr:port of listen address %q: %w", state.Address().URL.Host, err)
 			}
 
 			// Our payload in this case is defined by us as ExtendedType.
@@ -79,7 +79,7 @@ func cmdPost(state *state.State, r *http.Request) response.Response {
 	}
 
 	// Return some identifying information.
-	message := fmt.Sprintf("cluster member at address %q received message %q from cluster member at address %q", state.Address.URL.Host, info.Message, info.Sender.String())
+	message := fmt.Sprintf("cluster member at address %q received message %q from cluster member at address %q", state.Address().URL.Host, info.Message, info.Sender.String())
 
 	return response.SyncResponse(true, message)
 }

--- a/example/cmd/microctl/main_init.go
+++ b/example/cmd/microctl/main_init.go
@@ -18,11 +18,11 @@ type cmdInit struct {
 
 func (c *cmdInit) Command() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "init",
+		Use:   "init <name> <address>",
 		Short: "Initialize the network endpoint and create or join a new cluster",
 		RunE:  c.Run,
-		Example: `  microctl init --bootstrap
-  microctl init --token <token>`,
+		Example: `  microctl init member1 127.0.0.1:8443 --bootstrap
+    microctl init member1 127.0.0.1:8443 --token <token>`,
 	}
 
 	cmd.Flags().BoolVar(&c.flagBootstrap, "bootstrap", false, "Configure a new cluster with this daemon")
@@ -31,7 +31,7 @@ func (c *cmdInit) Command() *cobra.Command {
 }
 
 func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
-	if len(args) != 0 {
+	if len(args) != 2 {
 		return cmd.Help()
 	}
 
@@ -45,15 +45,11 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if c.flagBootstrap {
-		if len(args) != 0 {
-			return fmt.Errorf("Name can only be specified with a join token")
-		}
-
-		return m.NewCluster(time.Second * 30)
+		return m.NewCluster(args[0], args[1], time.Second*30)
 	}
 
 	if c.flagToken != "" {
-		return m.JoinCluster(c.flagToken, time.Second*30)
+		return m.JoinCluster(args[0], args[1], c.flagToken, time.Second*30)
 	}
 
 	return fmt.Errorf("Option must be one of bootstrap or token")

--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -44,7 +44,6 @@ type cmdDaemon struct {
 	global *cmdGlobal
 
 	flagStateDir string
-	flagAddr     string
 }
 
 func (c *cmdDaemon) Command() *cobra.Command {
@@ -65,7 +64,7 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return m.Start(c.flagAddr, api.Endpoints, database.SchemaExtensions, func(state *state.State, bootstrap bool) error {
+	return m.Start(api.Endpoints, database.SchemaExtensions, func(state *state.State, bootstrap bool) error {
 		if bootstrap {
 			logger.Info("This is a hook run on bootstrap")
 		} else {
@@ -92,7 +91,6 @@ func main() {
 	app.PersistentFlags().BoolVarP(&daemonCmd.global.flagLogVerbose, "verbose", "v", false, "Show all information messages")
 
 	app.PersistentFlags().StringVar(&daemonCmd.flagStateDir, "state-dir", "", "Path to store state information"+"``")
-	app.PersistentFlags().StringVar(&daemonCmd.flagAddr, "address", "", "Address:Port to bind for the API"+"``")
 
 	app.SetVersionTemplate("{{.Version}}\n")
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -220,29 +220,6 @@ func (d *Daemon) initServer(resources ...*resources.Resources) *http.Server {
 	}
 }
 
-func (d *Daemon) validateConfig(addr string, stateDir string) error {
-	isListenAddress := validate.IsListenAddress(true, true, false)
-	if addr != "" {
-		err := isListenAddress(addr)
-		if err != nil {
-			return fmt.Errorf("Invalid admin address %q: %w", addr, err)
-		}
-
-		d.Address = *api.NewURL().Scheme("https").Host(addr)
-	}
-
-	if stateDir == "" {
-		return fmt.Errorf("State directory must be specified")
-	}
-
-	_, err := os.Stat(stateDir)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-
-	return nil
-}
-
 // StartAPI starts up the admin and consumer APIs, and generates a cluster cert
 // if we are bootstrapping the first node.
 func (d *Daemon) StartAPI(bootstrap bool, runHook bool, joinAddresses ...string) error {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -152,7 +152,22 @@ func (d *Daemon) reloadIfBootstrapped() error {
 		return err
 	}
 
-	err = d.StartAPI(false, false)
+	_, err = os.Stat(filepath.Join(d.os.StateDir, "daemon.yaml"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			logger.Warn("microcluster daemon config is missing")
+			return nil
+		}
+
+		return err
+	}
+
+	err = d.setDaemonConfig(nil)
+	if err != nil {
+		return fmt.Errorf("Failed to retrieve daemon configuration yaml: %w", err)
+	}
+
+	err = d.StartAPI(false, false, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -79,7 +79,7 @@ func clusterPost(state *state.State, r *http.Request) response.Response {
 	}
 
 	// Forward request to leader.
-	if leaderInfo.Address != state.Address.URL.Host {
+	if leaderInfo.Address != state.Address().URL.Host {
 		client, err := state.Leader()
 		if err != nil {
 			return response.SmartError(err)
@@ -290,8 +290,8 @@ func clusterMemberDelete(state *state.State, r *http.Request) response.Response 
 	}
 
 	// If we are not the leader, just update our trust store.
-	if leaderInfo.Address != state.Address.URL.Host {
-		if allRemotes[name].Address.String() == state.Address.URL.Host {
+	if leaderInfo.Address != state.Address().URL.Host {
+		if allRemotes[name].Address.String() == state.Address().URL.Host {
 			// If the member being removed is ourselves and we are not the leader, then lock the
 			// clusterPutDisableMu before we forward the request to the leader, so that when the leader
 			// goes on to request clusterPutDisable back to ourselves it won't be actioned until we
@@ -416,7 +416,7 @@ func clusterMemberDelete(state *state.State, r *http.Request) response.Response 
 	}
 
 	// Reset the state of the removed node.
-	if allRemotes[name].Address.String() == state.Address.URL.Host {
+	if allRemotes[name].Address.String() == state.Address().URL.Host {
 		return clusterMemberPut(state, r)
 	} else {
 

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -74,8 +74,7 @@ func clusterPost(state *state.State, r *http.Request) response.Response {
 	}
 
 	newRemote := trust.Remote{
-		Name:        req.Name,
-		Address:     req.Address,
+		Location:    trust.Location{Name: req.Name, Address: req.Address},
 		Certificate: req.Certificate,
 	}
 

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -126,9 +126,8 @@ func joinWithToken(state *state.State, req *internalTypes.Control) response.Resp
 	clusterMembers := make([]trust.Remote, 0, len(joinInfo.ClusterMembers))
 	for _, clusterMember := range joinInfo.ClusterMembers {
 		remote := trust.Remote{
-			Name:        clusterMember.Name,
+			Location:    trust.Location{Name: clusterMember.Name, Address: clusterMember.Address},
 			Certificate: clusterMember.Certificate,
-			Address:     clusterMember.Address,
 		}
 
 		joinAddrs = append(joinAddrs, clusterMember.Address)

--- a/internal/rest/resources/heartbeat.go
+++ b/internal/rest/resources/heartbeat.go
@@ -99,7 +99,7 @@ func beginHeartbeat(state *state.State, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	if state.Address.URL.Host != leaderInfo.Address {
+	if state.Address().URL.Host != leaderInfo.Address {
 		return response.SmartError(fmt.Errorf("Attempt to initiate heartbeat from non-leader"))
 	}
 
@@ -159,7 +159,7 @@ func beginHeartbeat(state *state.State, r *http.Request) response.Response {
 
 	// If we sent out a heartbeat within double the request timeout,
 	// then wait the up to half the request timeout before exiting to prevent sending more unsuccessful attempts.
-	leaderEntry := clusterMap[state.Address.URL.Host]
+	leaderEntry := clusterMap[state.Address().URL.Host]
 	heartbeatInterval := time.Duration(time.Second * internalClient.HeartbeatTimeout * 2)
 	timeSinceLast := time.Since(leaderEntry.LastHeartbeat)
 	if timeSinceLast < heartbeatInterval {
@@ -181,7 +181,7 @@ func beginHeartbeat(state *state.State, r *http.Request) response.Response {
 
 		return response.EmptySyncResponse
 	}
-	logger.Debug("Beginning new heartbeat round", logger.Ctx{"address": state.Address.URL.Host})
+	logger.Debug("Beginning new heartbeat round", logger.Ctx{"address": state.Address().URL.Host})
 
 	// Update local record of cluster members from the database, including any pending nodes for authentication.
 	err = state.Remotes().Replace(state.OS.TrustDir, clusterMembers...)
@@ -191,7 +191,7 @@ func beginHeartbeat(state *state.State, r *http.Request) response.Response {
 
 	// Set the time of the last heartbeat to now.
 	leaderEntry.LastHeartbeat = time.Now()
-	clusterMap[state.Address.URL.Host] = leaderEntry
+	clusterMap[state.Address().URL.Host] = leaderEntry
 
 	// Record the maximum schema version discovered.
 	hbInfo := types.HeartbeatInfo{ClusterMembers: clusterMap}

--- a/internal/rest/resources/heartbeat.go
+++ b/internal/rest/resources/heartbeat.go
@@ -56,7 +56,7 @@ func heartbeatPost(state *state.State, r *http.Request) response.Response {
 
 	var schemaVersion int
 	err = state.Database.Transaction(state.Context, func(ctx context.Context, tx *db.Tx) error {
-		localClusterMember, err := cluster.GetInternalClusterMember(ctx, tx, state.Address.URL.Host)
+		localClusterMember, err := cluster.GetInternalClusterMember(ctx, tx, state.Name())
 		if err != nil {
 			return err
 		}
@@ -260,7 +260,7 @@ func beginHeartbeat(state *state.State, r *http.Request) response.Response {
 
 			clusterMember.Heartbeat = heartbeatInfo.LastHeartbeat
 			clusterMember.Role = cluster.Role(heartbeatInfo.Role)
-			err = cluster.UpdateInternalClusterMember(ctx, tx, clusterMember.Address, clusterMember)
+			err = cluster.UpdateInternalClusterMember(ctx, tx, clusterMember.Name, clusterMember)
 			if err != nil {
 				return err
 			}

--- a/internal/rest/rest.go
+++ b/internal/rest/rest.go
@@ -172,7 +172,7 @@ func authenticate(state *internalState.State, r *http.Request) (bool, error) {
 
 	var trustedCerts map[string]x509.Certificate
 	switch r.Host {
-	case state.Address.URL.Host:
+	case state.Address().URL.Host:
 		trustedCerts = state.Remotes().CertificatesNative()
 	default:
 		return false, fmt.Errorf("Invalid request address %q", r.Host)

--- a/internal/rest/types/control.go
+++ b/internal/rest/types/control.go
@@ -1,7 +1,13 @@
 package types
 
+import (
+	"github.com/canonical/microcluster/rest/types"
+)
+
 // Control represents the arguments that can be used to initialize/shutdown the daemon.
 type Control struct {
-	Bootstrap bool   `json:"bootstrap" yaml:"bootstrap"`
-	JoinToken string `json:"join_token" yaml:"join_token"`
+	Bootstrap bool           `json:"bootstrap" yaml:"bootstrap"`
+	JoinToken string         `json:"join_token" yaml:"join_token"`
+	Address   types.AddrPort `json:"address" yaml:"address"`
+	Name      string         `json:"name" yaml:"name"`
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -53,7 +53,7 @@ type State struct {
 	Remotes func() *trust.Remotes
 
 	// Initialize APIs and bootstrap/join database.
-	StartAPI func(bootstrap bool, runHook bool, joinAddresses ...string) error
+	StartAPI func(bootstrap bool, runHook bool, newConfig *trust.Location, joinAddresses ...string) error
 
 	// Stop fully stops the daemon, its database, and all listeners.
 	Stop func() error

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -32,7 +32,10 @@ type State struct {
 	OS *sys.OS
 
 	// Listen Address.
-	Address api.URL
+	Address func() api.URL
+
+	// Name of the cluster member.
+	Name func() string
 
 	// Server.
 	Endpoints *endpoints.Endpoints
@@ -75,7 +78,7 @@ func (s *State) Cluster(r *http.Request) (client.Cluster, error) {
 
 	clients := make(client.Cluster, 0, len(clusterMembers)-1)
 	for _, clusterMember := range clusterMembers {
-		if s.Address.URL.Host == clusterMember.Address.String() {
+		if s.Address().URL.Host == clusterMember.Address.String() {
 			continue
 		}
 

--- a/internal/trust/remotes.go
+++ b/internal/trust/remotes.go
@@ -26,9 +26,14 @@ type Remotes struct {
 
 // Remote represents a yaml file with credentials to be read by the daemon.
 type Remote struct {
-	Name        string                `yaml:"name"`
-	Address     types.AddrPort        `yaml:"address"`
+	Location    `yaml:",inline"`
 	Certificate types.X509Certificate `yaml:"certificate"`
+}
+
+// Location represents configurable identifying information about a remote.
+type Location struct {
+	Name    string         `yaml:"name"`
+	Address types.AddrPort `yaml:"address"`
 }
 
 // Load reads any yaml files in the given directory and parses them into a set of Remotes.
@@ -114,7 +119,10 @@ func (r *Remotes) Replace(dir string, newRemotes ...internalTypes.ClusterMember)
 
 	r.data = map[string]Remote{}
 	for _, remote := range newRemotes {
-		newRemote := Remote{Name: remote.Name, Address: remote.Address, Certificate: remote.Certificate}
+		newRemote := Remote{
+			Location:    Location{Name: remote.Name, Address: remote.Address},
+			Certificate: remote.Certificate,
+		}
 		bytes, err := yaml.Marshal(newRemote)
 		if err != nil {
 			return fmt.Errorf("Failed to parse remote %q to yaml: %w", remote.Name, err)


### PR DESCRIPTION
Previously, the daemon would require a listen address to be supplied in order to start, and the value would not be stored anywhere. A restart would require specifying this address again.

Additionally, the cluster member name for each daemon was generated by its state directory name (for testing, mainly). This was problematic for scripting as each daemon would need a unique state directory name.

To solve both of these problems, this updates the MicroCluster daemon to accept a `name` and `address` argument upon bootstrapping or joining a cluster with a token. These values will then be saved in a `daemon.yaml` file in the state directory. 


* Updates go mod and lxd-generate code to the most recent updates.
* Supplies a context to helpers from LXD that now require it.
* As we want to update the `name` and `address` of the daemon, this adds a subtype to `Remote` called `Location` (similar to `LXD Cloud`) that holds location information about the node we are dealing with. This does not include `Certificate` so that we don't face issues unmarshalling an empty value.
* Adds a `setDaemonConfig` helper, on the daemon which will either insert a new `daemon.yaml` if a `Location` is supplied, or read the current config from the existing yaml.
