### PR TITLE
Hooks interface

### DIFF
--- a/config/hooks.go
+++ b/config/hooks.go
@@ -1,0 +1,24 @@
+package config
+
+import (
+	"github.com/canonical/microcluster/internal/state"
+)
+
+// Hooks is an interface representing customizable functions that can be called at varying points by the daemon to
+// integrate with other tools.
+type Hooks interface {
+	// OnBootstrapHook is run after the daemon is initialized and bootstrapped.
+	OnBootstrapHook(s *state.State) error
+
+	// OnStartHook is run after the daemon is started.
+	OnStartHook(s *state.State) error
+
+	// OnJoinHook is run after the daemon is initialized and joins a cluster.
+	OnJoinHook(s *state.State) error
+
+	// OnRemoveHook is run after the daemon is removed from a cluster.
+	OnRemoveHook(s *state.State) error
+
+	// OnHeartbeatHook is run after a successful heartbeat round.
+	OnHeartbeatHook(s *state.State) error
+}

--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -64,15 +64,7 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return m.Start(api.Endpoints, database.SchemaExtensions, func(state *state.State, bootstrap bool) error {
-		if bootstrap {
-			logger.Info("This is a hook run on bootstrap")
-		} else {
-			logger.Info("This is a hook run on join")
-		}
-
-		return nil
-	})
+	return m.Start(api.Endpoints, database.SchemaExtensions, exampleHooks{})
 }
 
 func init() {
@@ -98,4 +90,42 @@ func main() {
 	if err != nil {
 		os.Exit(1)
 	}
+}
+
+// exampleHooks are some example post-action hooks that can be run by MicroCluster.
+type exampleHooks struct{}
+
+// OnBootstrapHook is run after the daemon is initialized and bootstrapped.
+func (e exampleHooks) OnBootstrapHook(s *state.State) error {
+	logger.Info("This is a hook that runs after the daemon is initialized and bootstrapped")
+
+	return nil
+}
+
+// OnStartHook is run after the daemon is started.
+func (e exampleHooks) OnStartHook(s *state.State) error {
+	logger.Info("This is a hook that runs after the daemon first starts")
+
+	return nil
+}
+
+// OnJoinHook is run after the daemon is initialized and joins a cluster.
+func (e exampleHooks) OnJoinHook(s *state.State) error {
+	logger.Info("This is a hook that runs after the daemon is initialized and joins an existing cluster")
+
+	return nil
+}
+
+// OnRemoveHook is run after the daemon is removed from a cluster.
+func (e exampleHooks) OnRemoveHook(s *state.State) error {
+	logger.Info("This is a hook that is run on the dqlite leader after a cluster member is removed")
+
+	return nil
+}
+
+// OnHeartbeatHook is run after a successful heartbeat round.
+func (e exampleHooks) OnHeartbeatHook(s *state.State) error {
+	logger.Info("This is a hook that is run on the dqlite leader after a successful heartbeat")
+
+	return nil
 }

--- a/internal/daemon/hooks.go
+++ b/internal/daemon/hooks.go
@@ -1,0 +1,23 @@
+package daemon
+
+import (
+	"github.com/canonical/microcluster/internal/state"
+)
+
+// defaultHooks is an empty set of hooks.
+type defaultHooks struct{}
+
+// OnBootstrapHook is run after the daemon is initialized and bootstrapped.
+func (d defaultHooks) OnBootstrapHook(s *state.State) error { return nil }
+
+// OnStartHook is run after the daemon is started.
+func (d defaultHooks) OnStartHook(s *state.State) error { return nil }
+
+// OnJoinHook is run after the daemon is initialized and joins a cluster.
+func (d defaultHooks) OnJoinHook(s *state.State) error { return nil }
+
+// OnRemoveHook is run after the daemon is removed from a cluster.
+func (d defaultHooks) OnRemoveHook(s *state.State) error { return nil }
+
+// OnHeartbeatHook is run after a successful heartbeat round.
+func (d defaultHooks) OnHeartbeatHook(s *state.State) error { return nil }

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -43,7 +43,7 @@ func controlPost(state *state.State, r *http.Request) response.Response {
 	}
 
 	daemonConfig := &trust.Location{Address: req.Address, Name: req.Name}
-	err = state.StartAPI(req.Bootstrap, true, daemonConfig)
+	err = state.StartAPI(req.Bootstrap, daemonConfig)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -136,7 +136,7 @@ func joinWithToken(state *state.State, req *internalTypes.Control) response.Resp
 	}
 
 	// Start the HTTPS listeners and join Dqlite.
-	err = state.StartAPI(false, true, daemonConfig, joinAddrs.Strings()...)
+	err = state.StartAPI(false, daemonConfig, joinAddrs.Strings()...)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -53,11 +53,17 @@ type State struct {
 	Remotes func() *trust.Remotes
 
 	// Initialize APIs and bootstrap/join database.
-	StartAPI func(bootstrap bool, runHook bool, newConfig *trust.Location, joinAddresses ...string) error
+	StartAPI func(bootstrap bool, newConfig *trust.Location, joinAddresses ...string) error
 
 	// Stop fully stops the daemon, its database, and all listeners.
 	Stop func() error
 }
+
+// OnRemoveHook is a post-action hook that is run on the leader when a cluster member is removed.
+var OnRemoveHook func(state *State) error
+
+// OnHeartbeatHook is a post-action hook that is run on the leader after a successful heartbeat round.
+var OnHeartbeatHook func(state *State) error
 
 // Cluster returns a client for every member of a cluster, except
 // this one, with the UserAgentNotifier header set if a request is given.

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -14,13 +14,13 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/canonical/microcluster/client"
+	"github.com/canonical/microcluster/config"
 	"github.com/canonical/microcluster/internal/daemon"
 	internalClient "github.com/canonical/microcluster/internal/rest/client"
 	internalTypes "github.com/canonical/microcluster/internal/rest/types"
 	"github.com/canonical/microcluster/internal/sys"
 	"github.com/canonical/microcluster/rest"
 	"github.com/canonical/microcluster/rest/types"
-	"github.com/canonical/microcluster/state"
 )
 
 // MicroCluster contains some basic filesystem information for interacting with the MicroCluster daemon.
@@ -49,7 +49,7 @@ func App(ctx context.Context, stateDir string, verbose bool, debug bool) (*Micro
 
 // Start starts up a brand new MicroCluster daemon. Only the local control socket will be available at this stage, no
 // database exists yet. Any api or schema extensions can be applied here.
-func (m *MicroCluster) Start(apiEndpoints []rest.Endpoint, schemaExtensions map[int]schema.Update, initHook func(state *state.State, bootstrap bool) error) error {
+func (m *MicroCluster) Start(apiEndpoints []rest.Endpoint, schemaExtensions map[int]schema.Update, hooks config.Hooks) error {
 	// Initialize the logger.
 	err := logger.InitLogger(m.FileSystem.LogFile, "", m.verbose, m.debug, nil)
 	if err != nil {
@@ -69,7 +69,7 @@ func (m *MicroCluster) Start(apiEndpoints []rest.Endpoint, schemaExtensions map[
 	chIgnore := make(chan os.Signal, 1)
 	signal.Notify(chIgnore, unix.SIGHUP)
 
-	err = d.Init(m.FileSystem.StateDir, apiEndpoints, schemaExtensions, initHook)
+	err = d.Init(m.FileSystem.StateDir, apiEndpoints, schemaExtensions, hooks)
 	if err != nil {
 		return fmt.Errorf("Unable to start daemon: %w", err)
 	}


### PR DESCRIPTION
Adds a `Hooks` interface under a `config` package. There are 5 hooks currently defined:
* `OnBootstrapHook` which runs after a bootstrap
* `OnStartHook` which runs after the daemon starts, and before `waitready` returns
* `OnJoinHook` which runs after joining an existing cluster
* `OnRemoveHook` which runs on the leader after a cluster member is removed
* `OnHeartbeatHook` which runs on the leader after a successful heartbeat

These can be implemented and the parent struct can be supplied to `microcluster.Start`.

The `State` has two additional functions for `OnRemoveHook` and `OnHeartbeatHook` as these are actions that take place over the API. Alternatively I can stick them in the endpoint handler and have them run after the specific endpoints are hit. This would avoid having to add the functions to the `State`, but I feel that would be hiding them a bit too much.