### PR TITLE
Use the unix socket for all endpoints

### DIFF
--- a/example/cmd/microctl/cluster_members.go
+++ b/example/cmd/microctl/cluster_members.go
@@ -63,7 +63,7 @@ func (c *cmdClusterMembersList) Run(cmd *cobra.Command, args []string) error {
 
 	// Get a local client connected to the unix socket if no address is specified.
 	if len(args) == 1 {
-		client, err = m.Client(args[0])
+		client, err = m.RemoteClient(args[0])
 		if err != nil {
 			return err
 		}

--- a/example/cmd/microctl/extended_cmd.go
+++ b/example/cmd/microctl/extended_cmd.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 
+	microClient "github.com/canonical/microcluster/client"
 	"github.com/canonical/microcluster/example/client"
 	"github.com/canonical/microcluster/microcluster"
 	"github.com/spf13/cobra"
@@ -24,7 +25,7 @@ func (c *cmdExtended) Command() *cobra.Command {
 }
 
 func (c *cmdExtended) Run(cmd *cobra.Command, args []string) error {
-	if len(args) != 1 {
+	if len(args) > 1 {
 		return cmd.Help()
 	}
 
@@ -33,7 +34,13 @@ func (c *cmdExtended) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	cli, err := m.Client(args[0])
+	var cli *microClient.Client
+	if len(args) == 1 {
+		cli, err = m.RemoteClient(args[0])
+	} else {
+		cli, err = m.LocalClient()
+	}
+
 	if err != nil {
 		return err
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -128,7 +128,10 @@ func (d *Daemon) init(extendedEndpoints []rest.Endpoint, schemaExtensions map[in
 
 	d.db = db.NewDB(d.ShutdownCtx, d.serverCert, d.os)
 
-	ctlServer := d.initServer(resources.ControlEndpoints)
+	// Apply extensions to API/Schema.
+	resources.ExtendedEndpoints.Endpoints = append(resources.ExtendedEndpoints.Endpoints, extendedEndpoints...)
+
+	ctlServer := d.initServer(resources.UnixEndpoints, resources.InternalEndpoints, resources.PublicEndpoints, resources.ExtendedEndpoints)
 	ctl := endpoints.NewSocket(d.ShutdownCtx, ctlServer, d.os.ControlSocket(), "") // TODO: add socket group.
 	d.endpoints = endpoints.NewEndpoints(d.ShutdownCtx, ctl)
 	err = d.endpoints.Up()
@@ -136,8 +139,6 @@ func (d *Daemon) init(extendedEndpoints []rest.Endpoint, schemaExtensions map[in
 		return err
 	}
 
-	// Apply extensions to API/Schema.
-	resources.ExtendedEndpoints.Endpoints = append(resources.ExtendedEndpoints.Endpoints, extendedEndpoints...)
 	update.AppendSchema(schemaExtensions)
 
 	err = d.reloadIfBootstrapped()

--- a/internal/rest/client/cluster.go
+++ b/internal/rest/client/cluster.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/canonical/microcluster/internal/rest/types"
@@ -25,42 +24,27 @@ func (c *Client) AddClusterMember(ctx context.Context, args types.ClusterMember)
 
 // GetClusterMembers returns the database record of cluster members.
 func (c *Client) GetClusterMembers(ctx context.Context) ([]types.ClusterMember, error) {
-	endpoint := PublicEndpoint
-	if strings.HasSuffix(c.url.String(), "control.socket") {
-		endpoint = ControlEndpoint
-	}
-
 	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	clusterMembers := []types.ClusterMember{}
-	err := c.QueryStruct(queryCtx, "GET", endpoint, api.NewURL().Path("cluster"), nil, &clusterMembers)
+	err := c.QueryStruct(queryCtx, "GET", PublicEndpoint, api.NewURL().Path("cluster"), nil, &clusterMembers)
 
 	return clusterMembers, err
 }
 
 // DeleteClusterMember deletes the cluster member with the given name.
 func (c *Client) DeleteClusterMember(ctx context.Context, name string) error {
-	endpoint := PublicEndpoint
-	if strings.HasSuffix(c.url.String(), "control.socket") {
-		endpoint = ControlEndpoint
-	}
-
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "DELETE", endpoint, api.NewURL().Path("cluster", name), nil, nil)
+	return c.QueryStruct(queryCtx, "DELETE", PublicEndpoint, api.NewURL().Path("cluster", name), nil, nil)
 }
 
 // ResetClusterMember clears the state directory of the cluster member, and re-execs its daemon.
 func (c *Client) ResetClusterMember(ctx context.Context, name string) error {
-	endpoint := PublicEndpoint
-	if strings.HasSuffix(c.url.String(), "control.socket") {
-		endpoint = ControlEndpoint
-	}
-
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "PUT", endpoint, api.NewURL().Path("cluster", name), nil, nil)
+	return c.QueryStruct(queryCtx, "PUT", PublicEndpoint, api.NewURL().Path("cluster", name), nil, nil)
 }

--- a/internal/rest/client/heartbeat.go
+++ b/internal/rest/client/heartbeat.go
@@ -16,13 +16,5 @@ func (c *Client) Heartbeat(ctx context.Context, hbInfo types.HeartbeatInfo) erro
 	queryCtx, cancel := context.WithTimeout(ctx, HeartbeatTimeout*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "POST", ControlEndpoint, api.NewURL().Path("heartbeat"), hbInfo, nil)
-}
-
-// SendHeartbeat sends out a heartbeat from the leader node.
-func (c *Client) SendHeartbeat(ctx context.Context, hbInfo types.HeartbeatInfo) error {
-	queryCtx, cancel := context.WithTimeout(ctx, HeartbeatTimeout*time.Second)
-	defer cancel()
-
 	return c.QueryStruct(queryCtx, "POST", InternalEndpoint, api.NewURL().Path("heartbeat"), hbInfo, nil)
 }

--- a/internal/rest/client/ready.go
+++ b/internal/rest/client/ready.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/lxc/lxd/shared/api"
@@ -10,15 +9,10 @@ import (
 
 // CheckReady returns once the daemon has signalled to the ready channel that it is done setting up.
 func (c *Client) CheckReady(ctx context.Context) error {
-	endpoint := PublicEndpoint
-	if strings.HasSuffix(c.url.String(), "control.socket") {
-		endpoint = ControlEndpoint
-	}
-
 	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	err := c.QueryStruct(queryCtx, "GET", endpoint, api.NewURL().Path("ready"), nil, nil)
+	err := c.QueryStruct(queryCtx, "GET", PublicEndpoint, api.NewURL().Path("ready"), nil, nil)
 
 	return err
 }

--- a/internal/rest/client/sql.go
+++ b/internal/rest/client/sql.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/lxc/lxd/shared/api"
@@ -22,7 +21,7 @@ func (c *Client) GetSQL(ctx context.Context, schema bool) (*types.SQLDump, error
 		endpoint.WithQuery("schema", "1")
 	}
 
-	err := c.QueryStruct(reqCtx, "GET", ControlEndpoint, endpoint, nil, dump)
+	err := c.QueryStruct(reqCtx, "GET", InternalEndpoint, endpoint, nil, dump)
 	if err != nil {
 		return nil, err
 	}
@@ -32,16 +31,11 @@ func (c *Client) GetSQL(ctx context.Context, schema bool) (*types.SQLDump, error
 
 // PostSQL executes a SQL query against the database.
 func (c *Client) PostSQL(ctx context.Context, query types.SQLQuery) (*types.SQLBatch, error) {
-	endpoint := InternalEndpoint
-	if strings.HasSuffix(c.url.String(), "control.socket") {
-		endpoint = ControlEndpoint
-	}
-
 	reqCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	batch := &types.SQLBatch{}
-	err := c.QueryStruct(reqCtx, "POST", endpoint, api.NewURL().Path("sql"), query, batch)
+	err := c.QueryStruct(reqCtx, "POST", InternalEndpoint, api.NewURL().Path("sql"), query, batch)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/rest/client/tokens.go
+++ b/internal/rest/client/tokens.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"context"
-	"strings"
 	"time"
 
 	"github.com/canonical/microcluster/internal/rest/types"
@@ -11,48 +10,33 @@ import (
 
 // RequestToken requests a join token with the given name.
 func (c *Client) RequestToken(ctx context.Context, name string) (string, error) {
-	endpoint := PublicEndpoint
-	if strings.HasSuffix(c.url.String(), "control.socket") {
-		endpoint = ControlEndpoint
-	}
-
 	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	var token string
 	tokenRecord := types.TokenRecord{Name: name}
-	err := c.QueryStruct(queryCtx, "POST", endpoint, api.NewURL().Path("tokens"), tokenRecord, &token)
+	err := c.QueryStruct(queryCtx, "POST", PublicEndpoint, api.NewURL().Path("tokens"), tokenRecord, &token)
 
 	return token, err
 }
 
 // DeleteTokenRecord deletes the toekn record.
 func (c *Client) DeleteTokenRecord(ctx context.Context, name string) error {
-	endpoint := InternalEndpoint
-	if strings.HasSuffix(c.url.String(), "control.socket") {
-		endpoint = ControlEndpoint
-	}
-
 	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
-	err := c.QueryStruct(queryCtx, "DELETE", endpoint, api.NewURL().Path("tokens", name), nil, nil)
+	err := c.QueryStruct(queryCtx, "DELETE", InternalEndpoint, api.NewURL().Path("tokens", name), nil, nil)
 
 	return err
 }
 
 // GetTokenRecords returns the token records.
 func (c *Client) GetTokenRecords(ctx context.Context) ([]types.TokenRecord, error) {
-	endpoint := PublicEndpoint
-	if strings.HasSuffix(c.url.String(), "control.socket") {
-		endpoint = ControlEndpoint
-	}
-
 	queryCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	tokenRecords := []types.TokenRecord{}
-	err := c.QueryStruct(queryCtx, "GET", endpoint, api.NewURL().Path("tokens"), nil, &tokenRecords)
+	err := c.QueryStruct(queryCtx, "GET", PublicEndpoint, api.NewURL().Path("tokens"), nil, &tokenRecords)
 
 	return tokenRecords, err
 }

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -23,6 +23,8 @@ import (
 )
 
 var controlCmd = rest.Endpoint{
+	AllowedBeforeInit: true,
+
 	Post: rest.EndpointAction{Handler: controlPost, AccessHandler: access.AllowAuthenticated},
 }
 

--- a/internal/rest/resources/database.go
+++ b/internal/rest/resources/database.go
@@ -12,7 +12,8 @@ import (
 )
 
 var databaseCmd = rest.Endpoint{
-	Path: "database",
+	AllowedBeforeInit: true,
+	Path:              "database",
 
 	Post:  rest.EndpointAction{Handler: databasePost},
 	Patch: rest.EndpointAction{Handler: databasePatch},

--- a/internal/rest/resources/heartbeat.go
+++ b/internal/rest/resources/heartbeat.go
@@ -227,7 +227,7 @@ func beginHeartbeat(s *state.State, r *http.Request) response.Response {
 			return nil
 		}
 
-		err := c.SendHeartbeat(ctx, hbInfo)
+		err := c.Heartbeat(ctx, hbInfo)
 		if err != nil {
 			logger.Error("Received error sending heartbeat to cluster member", logger.Ctx{"target": addr, "error": err})
 			return nil

--- a/internal/rest/resources/ready.go
+++ b/internal/rest/resources/ready.go
@@ -12,7 +12,8 @@ import (
 )
 
 var readyCmd = rest.Endpoint{
-	Path: "ready",
+	AllowedBeforeInit: true,
+	Path:              "ready",
 
 	Get: rest.EndpointAction{Handler: getWaitReady, AccessHandler: access.AllowAuthenticated},
 }

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -11,18 +11,11 @@ type Resources struct {
 	Endpoints []rest.Endpoint
 }
 
-// ControlEndpoints are the endpoints available over the unix socket.
-var ControlEndpoints = &Resources{
+// UnixEndpoints are the endpoints available over the unix socket.
+var UnixEndpoints = &Resources{
 	Path: client.ControlEndpoint,
 	Endpoints: []rest.Endpoint{
 		controlCmd,
-		sqlCmd,
-		readyCmd,
-		tokensCmd,
-		tokenCmd,
-		clusterCmd,
-		clusterMemberCmd,
-		heartbeatCmd,
 		shutdownCmd,
 	},
 }

--- a/internal/rest/resources/shutdown.go
+++ b/internal/rest/resources/shutdown.go
@@ -12,7 +12,8 @@ import (
 )
 
 var shutdownCmd = rest.Endpoint{
-	Path: "shutdown",
+	AllowedBeforeInit: true,
+	Path:              "shutdown",
 
 	Post: rest.EndpointAction{Handler: shutdownPost, AccessHandler: access.AllowAuthenticated},
 }

--- a/internal/rest/rest.go
+++ b/internal/rest/rest.go
@@ -115,6 +115,17 @@ func HandleEndpoint(state *internalState.State, mux *mux.Router, version string,
 			return
 		}
 
+		if !e.AllowedBeforeInit {
+			if !state.Database.IsOpen() {
+				err := response.Unavailable(fmt.Errorf("Daemon not yet initialized")).Render(w)
+				if err != nil {
+					logger.Error("Failed to write HTTP response", logger.Ctx{"url": r.URL, "err": err})
+				}
+
+				return
+			}
+		}
+
 		// If the request is a database request, the connection should be hijacked.
 		handleRequest := handleAPIRequest
 		if e.Path == "database" {

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -246,9 +246,9 @@ func (m *MicroCluster) LocalClient() (*client.Client, error) {
 	return &client.Client{Client: *c}, nil
 }
 
-// Client gets a client for the specified cluster member URL. The filesystem will be parsed for the cluster and server
-// certificates.
-func (m *MicroCluster) Client(address string) (*client.Client, error) {
+// RemoteClient gets a client for the specified cluster member URL.
+// The filesystem will be parsed for the cluster and server certificates.
+func (m *MicroCluster) RemoteClient(address string) (*client.Client, error) {
 	serverCert, err := m.FileSystem.ServerCert()
 	if err != nil {
 		return nil, err

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -33,4 +33,5 @@ type Endpoint struct {
 	Patch   EndpointAction
 
 	AllowedDuringShutdown bool // Whether we should return Unavailable Error (503) if daemon is shutting down.
+	AllowedBeforeInit     bool // Whether we should return Unavailabel Error (503) if the daemon has not been initialized (is not yet part of a cluster).
 }


### PR DESCRIPTION
* Internally:
  * Exposes every API endpoint on the unix socket. There are 2 endpoint paths exclusive to the unix socket for bootstrapping and shutting down the daemon. 

* Publicly:
  * Each `rest.Endpoint` has a `AllowedBeforeInit` flag, that if set to `true`, will allow the endpoint to go through before the database is initialized. 
  * `microcluster.Client` has been replaced with `microcluster.RemoteClient` in case we want to talk to some other microcluster daemon. 


