### PR TITLE
Forward request to target if `?target=name` is specified

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -28,3 +28,10 @@ func (c *Client) Query(ctx context.Context, method string, path *api.URL, in any
 
 	return c.QueryStruct(queryCtx, method, client.ExtendedEndpoint, path, in, &out)
 }
+
+// UseTarget returns a new client with the query "?target=name" set.
+func (c *Client) UseTarget(name string) *Client {
+	newClient := c.Client.UseTarget(name)
+
+	return &Client{Client: *newClient}
+}

--- a/internal/rest/client/client.go
+++ b/internal/rest/client/client.go
@@ -249,8 +249,13 @@ func (c *Client) rawQuery(ctx context.Context, method string, url *api.URL, data
 		}
 	}
 
+	return c.MakeRequest(req)
+}
+
+// MakeRequest performs a request and parses the response into an api.Response.
+func (c *Client) MakeRequest(r *http.Request) (*api.Response, error) {
 	// Send the request
-	resp, err := c.Do(req)
+	resp, err := c.Do(r)
 	if err != nil {
 		return nil, err
 	}
@@ -285,6 +290,7 @@ func (c *Client) QueryStruct(ctx context.Context, method string, endpointType En
 	localURL.URL.Host = c.url.URL.Host
 	localURL.URL.Scheme = c.url.URL.Scheme
 	localURL.URL.Path = "/" + string(endpointType) + localURL.URL.Path
+	localURL.URL.RawQuery = c.url.URL.RawQuery
 
 	// Send the actual query through.
 	resp, err := c.rawQuery(ctx, method, localURL, data)
@@ -307,4 +313,19 @@ func (c *Client) QueryStruct(ctx context.Context, method string, endpointType En
 // URL returns the address used for the client.
 func (c *Client) URL() api.URL {
 	return c.url
+}
+
+// UseTarget returns a new client with the query "?target=name" set.
+func (c *Client) UseTarget(name string) *Client {
+	localURL := api.NewURL()
+	localURL.URL.Host = c.url.URL.Host
+	localURL.URL.Scheme = c.url.URL.Scheme
+	localURL.URL.Path = c.url.URL.Path
+	localURL.URL.RawQuery = c.url.URL.RawQuery
+	localURL = localURL.WithQuery("target", name)
+
+	return &Client{
+		Client: c.Client,
+		url:    *localURL,
+	}
 }

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -19,6 +19,7 @@ type EndpointAction struct {
 	Handler        func(state *state.State, r *http.Request) response.Response
 	AccessHandler  func(state *state.State, r *http.Request) response.Response
 	AllowUntrusted bool
+	ProxyTarget    bool // Allow forwarding of the request to a target if ?target=name is specified.
 }
 
 // Endpoint represents a URL in our API.


### PR DESCRIPTION
Closes #31 

Adds a `ProxyTarget` flag to each request method handler. If this is true, and the request URL has `?target=name` set, we will attempt to send the request over to the cluster member with the given `name`. 

A client method `UseTarget` has been added, which will return a new `client` with the `?target=name` query set. 