### PR TITLE
Pre/Post remove hooks

### DIFF
--- a/config/hooks.go
+++ b/config/hooks.go
@@ -16,8 +16,11 @@ type Hooks struct {
 	// OnJoin is run after the daemon is initialized and joins a cluster.
 	OnJoin func(s *state.State) error
 
-	// OnRemove is run after the daemon is removed from a cluster.
-	OnRemove func(s *state.State) error
+	// PreRemove is run on a cluster member just before it is removed from the cluster.
+	PreRemove func(s *state.State) error
+
+	// PostRemove is run on all other peers after one is removed from the cluster.
+	PostRemove func(s *state.State) error
 
 	// OnHeartbeat is run after a successful heartbeat round.
 	OnHeartbeat func(s *state.State) error

--- a/example/cmd/microctl/cluster_members.go
+++ b/example/cmd/microctl/cluster_members.go
@@ -92,6 +92,8 @@ func (c *cmdClusterMembersList) Run(cmd *cobra.Command, args []string) error {
 
 type cmdClusterMemberRemove struct {
 	common *CmdControl
+
+	flagForce bool
 }
 
 func (c *cmdClusterMemberRemove) Command() *cobra.Command {
@@ -100,6 +102,8 @@ func (c *cmdClusterMemberRemove) Command() *cobra.Command {
 		Short: "Remove the cluster member with the given name.",
 		RunE:  c.Run,
 	}
+
+	cmd.Flags().BoolVarP(&c.flagForce, "force", "f", false, "Forcibly remove the cluster member")
 
 	return cmd
 }
@@ -119,7 +123,7 @@ func (c *cmdClusterMemberRemove) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = client.DeleteClusterMember(context.Background(), args[0])
+	err = client.DeleteClusterMember(context.Background(), args[0], c.flagForce)
 	if err != nil {
 		return err
 	}

--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -88,9 +88,16 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 			return nil
 		},
 
-		// OnRemove is run after the daemon is removed from a cluster.
-		OnRemove: func(s *state.State) error {
+		// PostRemove is run after the daemon is removed from a cluster.
+		PostRemove: func(s *state.State) error {
 			logger.Infof("This is a hook that is run on peer %q after a cluster member is removed", s.Name())
+
+			return nil
+		},
+
+		// PreRemove is run before the daemon is removed from the cluster.
+		PreRemove: func(s *state.State) error {
+			logger.Infof("This is a hook that is run on peer %q just before it is removed", s.Name())
 
 			return nil
 		},

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -179,6 +179,10 @@ func (d *Daemon) applyHooks(hooks *config.Hooks) {
 	if d.hooks.OnRemove == nil {
 		d.hooks.OnRemove = noOpHook
 	}
+
+	if d.hooks.OnNewMember == nil {
+		d.hooks.OnNewMember = noOpHook
+	}
 }
 
 func (d *Daemon) reloadIfBootstrapped() error {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -176,12 +176,16 @@ func (d *Daemon) applyHooks(hooks *config.Hooks) {
 		d.hooks.OnHeartbeat = noOpHook
 	}
 
-	if d.hooks.OnRemove == nil {
-		d.hooks.OnRemove = noOpHook
-	}
-
 	if d.hooks.OnNewMember == nil {
 		d.hooks.OnNewMember = noOpHook
+	}
+
+	if d.hooks.PreRemove == nil {
+		d.hooks.PreRemove = noOpHook
+	}
+
+	if d.hooks.PostRemove == nil {
+		d.hooks.PostRemove = noOpHook
 	}
 }
 
@@ -473,7 +477,8 @@ func (d *Daemon) Name() string {
 
 // State creates a State instance with the daemon's stateful components.
 func (d *Daemon) State() *state.State {
-	state.OnRemoveHook = d.hooks.OnRemove
+	state.PreRemoveHook = d.hooks.PreRemove
+	state.PostRemoveHook = d.hooks.PostRemove
 	state.OnHeartbeatHook = d.hooks.OnHeartbeat
 	state.OnNewMemberHook = d.hooks.OnNewMember
 	state.StopListeners = func() error {

--- a/internal/rest/client/client.go
+++ b/internal/rest/client/client.go
@@ -290,7 +290,14 @@ func (c *Client) QueryStruct(ctx context.Context, method string, endpointType En
 	localURL.URL.Host = c.url.URL.Host
 	localURL.URL.Scheme = c.url.URL.Scheme
 	localURL.URL.Path = "/" + string(endpointType) + localURL.URL.Path
-	localURL.URL.RawQuery = c.url.URL.RawQuery
+
+	localQuery := localURL.URL.Query()
+	clientQuery := c.url.URL.Query()
+	for k := range localQuery {
+		clientQuery.Set(k, localQuery.Get(k))
+	}
+
+	localURL.URL.RawQuery = clientQuery.Encode()
 
 	// Send the actual query through.
 	resp, err := c.rawQuery(ctx, method, localURL, data)

--- a/internal/rest/client/cluster.go
+++ b/internal/rest/client/cluster.go
@@ -34,11 +34,16 @@ func (c *Client) GetClusterMembers(ctx context.Context) ([]types.ClusterMember, 
 }
 
 // DeleteClusterMember deletes the cluster member with the given name.
-func (c *Client) DeleteClusterMember(ctx context.Context, name string) error {
+func (c *Client) DeleteClusterMember(ctx context.Context, name string, force bool) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "DELETE", PublicEndpoint, api.NewURL().Path("cluster", name), nil, nil)
+	endpoint := api.NewURL().Path("cluster", name)
+	if force {
+		endpoint = endpoint.WithQuery("force", "1")
+	}
+
+	return c.QueryStruct(queryCtx, "DELETE", PublicEndpoint, endpoint, nil, nil)
 }
 
 // ResetClusterMember clears the state directory of the cluster member, and re-execs its daemon.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -62,8 +62,11 @@ type State struct {
 // StopListeners stops the network listeners and the fsnotify listener.
 var StopListeners func() error
 
-// OnRemoveHook is a post-action hook that is run on all cluster members when a cluster member is removed.
-var OnRemoveHook func(state *State) error
+// PostRemoveHook is a post-action hook that is run on all cluster members when a cluster member is removed.
+var PostRemoveHook func(state *State) error
+
+// PreRemoveHook is a post-action hook that is run on a cluster member just before it is is removed.
+var PreRemoveHook func(state *State) error
 
 // OnHeartbeatHook is a post-action hook that is run on the leader after a successful heartbeat round.
 var OnHeartbeatHook func(state *State) error


### PR DESCRIPTION
Replaces `OnRemove` with a `PreRemove` and `PostRemove` hook. 

`PreRemove` is run on the peer-to-be-removed just before we remove it from `dqlite`, if `?force=1` is given in the removal request.

`PostRemove` is run on every other peer after we fully remove the cluster member.