### PR TITLE
Start a listen port before initialization

### DIFF
--- a/internal/endpoints/endpoints.go
+++ b/internal/endpoints/endpoints.go
@@ -88,15 +88,24 @@ func (e *Endpoints) up(listeners map[EndpointType]Endpoint) error {
 	return nil
 }
 
-// Down closes all of the configured listeners.
-func (e *Endpoints) Down() error {
+// Down closes all of the configured listeners, or any for the type specifically supplied.
+func (e *Endpoints) Down(types ...EndpointType) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
 	for _, listener := range e.listeners {
-		err := listener.Close()
-		if err != nil {
-			return err
+		remove := false
+		for _, endpoint := range types {
+			if listener.Type() == endpoint {
+				remove = true
+			}
+		}
+
+		if types == nil || remove {
+			err := listener.Close()
+			if err != nil {
+				return err
+			}
 		}
 	}
 

--- a/internal/rest/rest.go
+++ b/internal/rest/rest.go
@@ -65,10 +65,6 @@ func handleAPIRequest(action rest.EndpointAction, state *internalState.State, w 
 }
 
 func proxyTarget(action rest.EndpointAction, s *internalState.State, r *http.Request) response.Response {
-	if !s.Database.IsOpen() {
-		return response.Unavailable(fmt.Errorf("Cannot send request to target. Daemon not yet initialized"))
-	}
-
 	if r.URL == nil {
 		return action.Handler(s, r)
 	}
@@ -251,6 +247,11 @@ func HandleEndpoint(state *internalState.State, mux *mux.Router, version string,
 // - HTTP requests require our cluster cert, or remote certs.
 func authenticate(state *internalState.State, r *http.Request) (bool, error) {
 	if r.RemoteAddr == "@" {
+		return true, nil
+	}
+
+	if state.Address().URL.Host == "" {
+		logger.Info("Allowing unauthenticated request to un-initialized system")
 		return true, nil
 	}
 

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -39,8 +39,9 @@ type Args struct {
 	Debug    bool
 	StateDir string
 
-	Client *client.Client
-	Proxy  func(*http.Request) (*url.URL, error)
+	ListenPort string
+	Client     *client.Client
+	Proxy      func(*http.Request) (*url.URL, error)
 }
 
 // App returns an instance of MicroCluster with a newly initialized filesystem if one does not exist.
@@ -83,7 +84,7 @@ func (m *MicroCluster) Start(apiEndpoints []rest.Endpoint, schemaExtensions map[
 	chIgnore := make(chan os.Signal, 1)
 	signal.Notify(chIgnore, unix.SIGHUP)
 
-	err = d.Init(m.FileSystem.StateDir, apiEndpoints, schemaExtensions, hooks)
+	err = d.Init(m.args.ListenPort, m.FileSystem.StateDir, apiEndpoints, schemaExtensions, hooks)
 	if err != nil {
 		return fmt.Errorf("Unable to start daemon: %w", err)
 	}


### PR DESCRIPTION
Adds the option `ListenPort` to `microcluster.Args`, which when set, will cause microcluster to listen on the specified port. Authentication will be ignored, and only the public and extended endpoints will be available. 

This is necessary to allow MicroCloud to check the available disks on each peer prior to forming a cluster.