### PR TITLE
Split join hooks into Pre/Post

### DIFF
--- a/config/hooks.go
+++ b/config/hooks.go
@@ -16,6 +16,9 @@ type Hooks struct {
 	// PostJoin is run after the daemon is initialized and joins a cluster.
 	PostJoin func(s *state.State) error
 
+	// PreJoin is run after the daemon is initialized and joins a cluster.
+	PreJoin func(s *state.State) error
+
 	// PreRemove is run on a cluster member just before it is removed from the cluster.
 	PreRemove func(s *state.State) error
 

--- a/config/hooks.go
+++ b/config/hooks.go
@@ -13,8 +13,8 @@ type Hooks struct {
 	// OnStart is run after the daemon is started.
 	OnStart func(s *state.State) error
 
-	// OnJoin is run after the daemon is initialized and joins a cluster.
-	OnJoin func(s *state.State) error
+	// PostJoin is run after the daemon is initialized and joins a cluster.
+	PostJoin func(s *state.State) error
 
 	// PreRemove is run on a cluster member just before it is removed from the cluster.
 	PreRemove func(s *state.State) error

--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -89,6 +89,10 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 			return nil
 		},
 
+		// PreJoin is run after the daemon is initialized and joins a cluster.
+		PreJoin: func(s *state.State) error {
+			logger.Info("This is a hook that runs after the daemon is initialized and joins an existing cluster, before OnNewMember runs on all peers")
+
 			return nil
 		},
 

--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -82,9 +82,12 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 			return nil
 		},
 
-		// OnJoin is run after the daemon is initialized and joins a cluster.
-		OnJoin: func(s *state.State) error {
-			logger.Info("This is a hook that runs after the daemon is initialized and joins an existing cluster")
+		// PostJoin is run after the daemon is initialized and joins a cluster.
+		PostJoin: func(s *state.State) error {
+			logger.Info("This is a hook that runs after the daemon is initialized and joins an existing cluster, after OnNewMember runs on all peers")
+
+			return nil
+		},
 
 			return nil
 		},

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -179,8 +179,9 @@ func (d *Daemon) applyHooks(hooks *config.Hooks) {
 		d.hooks.OnBootstrap = noOpHook
 	}
 
-	if d.hooks.OnJoin == nil {
-		d.hooks.OnJoin = noOpHook
+	if d.hooks.PostJoin == nil {
+		d.hooks.PostJoin = noOpHook
+	}
 	}
 
 	if d.hooks.OnStart == nil {
@@ -467,7 +468,7 @@ func (d *Daemon) StartAPI(bootstrap bool, newConfig *trust.Location, joinAddress
 	}
 
 	if len(joinAddresses) > 0 {
-		return d.hooks.OnJoin(d.State())
+		return d.hooks.PostJoin(d.State())
 	}
 
 	return nil

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -182,6 +182,9 @@ func (d *Daemon) applyHooks(hooks *config.Hooks) {
 	if d.hooks.PostJoin == nil {
 		d.hooks.PostJoin = noOpHook
 	}
+
+	if d.hooks.PreJoin == nil {
+		d.hooks.PreJoin = noOpHook
 	}
 
 	if d.hooks.OnStart == nil {
@@ -421,6 +424,13 @@ func (d *Daemon) StartAPI(bootstrap bool, newConfig *trust.Location, joinAddress
 		}
 
 		cluster = append(cluster, client.Client{Client: *c})
+	}
+
+	if len(joinAddresses) > 0 {
+		err = d.hooks.PreJoin(d.State())
+		if err != nil {
+			return err
+		}
 	}
 
 	// Send notification that this node is upgraded to all other cluster members.


### PR DESCRIPTION
Replaces the `OnJoin` hook with two new hooks: `PreJoin` and `PostJoin`, which run before and after `OnNewMember` runs on every peer. 