### PR TITLE
internal/trust/truststore: Don't fail on Load if truststore is empty

### DIFF
--- a/internal/trust/remotes.go
+++ b/internal/trust/remotes.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/lxc/lxd/shared"
 	"github.com/lxc/lxd/shared/api"
+	"github.com/lxc/lxd/shared/logger"
 	"gopkg.in/yaml.v2"
 
 	internalTypes "github.com/canonical/microcluster/internal/rest/types"
@@ -72,7 +73,9 @@ func (r *Remotes) Load(dir string) error {
 	}
 
 	if len(remoteData) == 0 {
-		return fmt.Errorf("Failed to parse new remotes from truststore")
+		logger.Warn("Failed to parse new remotes from truststore")
+
+		return nil
 	}
 
 	r.data = remoteData

--- a/internal/trust/truststore.go
+++ b/internal/trust/truststore.go
@@ -24,6 +24,7 @@ func Init(watcher *sys.Watcher, onUpdate func(oldRemotes, newRemotes Remotes) er
 	ts.remotesMu.Lock()
 	defer ts.remotesMu.Unlock()
 
+	ts.remotes.data = map[string]Remote{}
 	err := ts.remotes.Load(dir)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
We use Load to set up the truststore the first time, so don't fail if it's empty on an uninitialized system.

Quickly going to merge this as `microcluster` is very broken atm :)