### PR TITLE
cluster/stmt: Split registered statements by caller package

### DIFF
--- a/cluster/stmt.go
+++ b/cluster/stmt.go
@@ -3,10 +3,16 @@ package cluster
 import (
 	"database/sql"
 	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/lxc/lxd/shared/logger"
 )
 
-var stmts = map[int]string{}            // Statement code to statement SQL text
-var preparedStmts = map[int]*sql.Stmt{} // Statement code to SQL statement.
+var stmtsByProject = map[string]map[int]string{} // Statement code to statement SQL text
+var preparedStmts = map[int]*sql.Stmt{}          // Statement code to SQL statement.
 
 // RegisterStmt register a SQL statement.
 //
@@ -15,20 +21,47 @@ var preparedStmts = map[int]*sql.Stmt{} // Statement code to SQL statement.
 //
 // Return a unique registration code.
 func RegisterStmt(sql string) int {
-	code := len(stmts)
+	project := GetCallerProject()
+
+	stmts := stmtsByProject[project]
+	if stmts == nil {
+		stmts = map[int]string{}
+	}
+
+	// Have a unique code for each statement, regardless of project,
+	// so we can access them without knowing the project.
+	var code int
+	for _, stmts := range stmtsByProject {
+		code += len(stmts)
+	}
+
 	stmts[code] = sql
+
+	stmtsByProject[project] = stmts
+
 	return code
 }
 
 // PrepareStmts prepares all registered statements and stores them in preparedStmts.
-func PrepareStmts(db *sql.DB, skipErrors bool) error {
-	for code, stmt := range stmts {
-		preparedStmt, err := db.Prepare(stmt)
-		if err != nil && !skipErrors {
-			return fmt.Errorf("%q: %w", stmt, err)
-		}
+func PrepareStmts(db *sql.DB, project string, skipErrors bool) error {
+	logger.Infof("Preparing statements for Go project %q", project)
 
-		preparedStmts[code] = preparedStmt
+	// Also prepare statements from microcluster if we are in a different project.
+	projects := []string{"microcluster"}
+	if project != "microcluster" {
+		projects = append(projects, project)
+	}
+
+	for _, project := range projects {
+		stmts := stmtsByProject[project]
+		for code, stmt := range stmts {
+			preparedStmt, err := db.Prepare(stmt)
+			if err != nil && !skipErrors {
+				return fmt.Errorf("%q: %w", stmt, err)
+			}
+
+			preparedStmts[code] = preparedStmt
+		}
 	}
 
 	return nil
@@ -46,10 +79,44 @@ func Stmt(tx *sql.Tx, code int) (*sql.Stmt, error) {
 
 // StmtString returns the in-memory query string with the given code.
 func StmtString(code int) (string, error) {
-	stmt, ok := stmts[code]
-	if !ok {
-		return "", fmt.Errorf("No prepared statement registered with code %d", code)
+	for _, stmts := range stmtsByProject {
+		stmt, ok := stmts[code]
+		if ok {
+			return stmt, nil
+		}
 	}
 
-	return stmt, nil
+	return "", fmt.Errorf("No prepared statement registered with code %d", code)
+}
+
+// GetCallerProject will get the go project name of whichever function called `GetCallerProject`.
+func GetCallerProject() string {
+	sep := string(os.PathSeparator)
+
+	// Get the caller of whoever called this function.
+	_, file, _, _ := runtime.Caller(2)
+
+	// The project may be a snap build path of the form ...parts/<project>/build....
+	_, after, ok := strings.Cut(file, fmt.Sprintf("parts%s", sep))
+	if ok {
+		project, _, ok := strings.Cut(after, fmt.Sprintf("%sbuild", sep))
+		if ok {
+			return project
+		}
+	}
+
+	// If not a snap build path, the project may be in a go module path of the form .../project@version....
+	before, _, ok := strings.Cut(file, "@")
+	if ok && filepath.Base(before) != "" {
+		return filepath.Base(before)
+	}
+
+	// If not a go module path,	assume a GOPATH of the form example.com/author/project/packages....
+	_, after, _ = strings.Cut(file, fmt.Sprintf("%ssrc%s", sep, sep))
+	tree := strings.Split(after, sep)
+	if len(tree) >= 3 {
+		return tree[2]
+	}
+
+	return ""
 }

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -21,7 +21,7 @@ import (
 
 // Open opens the dqlite database and loads the schema.
 // Returns true if we need to wait for other nodes to catch up to our version.
-func (db *DB) Open(bootstrap bool) error {
+func (db *DB) Open(bootstrap bool, project string) error {
 	ctx, cancel := context.WithTimeout(db.ctx, 30*time.Second)
 	defer cancel()
 
@@ -101,7 +101,7 @@ func (db *DB) Open(bootstrap bool) error {
 		return err
 	}
 
-	err = cluster.PrepareStmts(db.db, false)
+	err = cluster.PrepareStmts(db.db, project, false)
 	if err != nil {
 		return err
 	}

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -78,7 +78,7 @@ func NewDB(ctx context.Context, serverCert *shared.CertInfo, os *sys.OS) *DB {
 }
 
 // Bootstrap dqlite.
-func (db *DB) Bootstrap(addr api.URL, clusterCert *shared.CertInfo, clusterRecord cluster.InternalClusterMember) error {
+func (db *DB) Bootstrap(project string, addr api.URL, clusterCert *shared.CertInfo, clusterRecord cluster.InternalClusterMember) error {
 	var err error
 	db.listenAddr = addr
 	db.clusterCert = clusterCert
@@ -90,7 +90,7 @@ func (db *DB) Bootstrap(addr api.URL, clusterCert *shared.CertInfo, clusterRecor
 		return fmt.Errorf("Failed to bootstrap dqlite: %w", err)
 	}
 
-	err = db.Open(true)
+	err = db.Open(true, project)
 	if err != nil {
 		return err
 	}
@@ -111,7 +111,7 @@ func (db *DB) Bootstrap(addr api.URL, clusterCert *shared.CertInfo, clusterRecor
 }
 
 // Join a dqlite cluster with the address of a member.
-func (db *DB) Join(addr api.URL, clusterCert *shared.CertInfo, joinAddresses ...string) error {
+func (db *DB) Join(project string, addr api.URL, clusterCert *shared.CertInfo, joinAddresses ...string) error {
 	for {
 		var err error
 		db.clusterCert = clusterCert
@@ -125,7 +125,7 @@ func (db *DB) Join(addr api.URL, clusterCert *shared.CertInfo, joinAddresses ...
 			return fmt.Errorf("Failed to join dqlite cluster %w", err)
 		}
 
-		err = db.Open(false)
+		err = db.Open(false, project)
 		if err == nil {
 			break
 		}
@@ -150,13 +150,13 @@ func (db *DB) Join(addr api.URL, clusterCert *shared.CertInfo, joinAddresses ...
 }
 
 // StartWithCluster starts up dqlite and joins the cluster.
-func (db *DB) StartWithCluster(addr api.URL, clusterMembers map[string]types.AddrPort, clusterCert *shared.CertInfo) error {
+func (db *DB) StartWithCluster(project string, addr api.URL, clusterMembers map[string]types.AddrPort, clusterCert *shared.CertInfo) error {
 	allClusterAddrs := []string{}
 	for _, clusterMemberAddrs := range clusterMembers {
 		allClusterAddrs = append(allClusterAddrs, clusterMemberAddrs.String())
 	}
 
-	return db.Join(addr, clusterCert, allClusterAddrs...)
+	return db.Join(project, addr, clusterCert, allClusterAddrs...)
 }
 
 // Leader returns a client connected to the leader of the dqlite cluster.

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -17,6 +17,7 @@ import (
 	"golang.org/x/sys/unix"
 
 	"github.com/canonical/microcluster/client"
+	"github.com/canonical/microcluster/cluster"
 	"github.com/canonical/microcluster/config"
 	"github.com/canonical/microcluster/internal/daemon"
 	internalClient "github.com/canonical/microcluster/internal/rest/client"
@@ -75,7 +76,7 @@ func (m *MicroCluster) Start(apiEndpoints []rest.Endpoint, schemaExtensions map[
 
 	// Start up a daemon with a basic control socket.
 	defer logger.Info("Daemon stopped")
-	d := daemon.NewDaemon(m.ctx)
+	d := daemon.NewDaemon(m.ctx, cluster.GetCallerProject())
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, unix.SIGPWR)


### PR DESCRIPTION
If a microcluster project indirectly imports microcluster from another project (i.e. microcloud using microceph, which both use microcluster), then the map of registered statements may end up polluted with entries from that project.

To avoid this, a call to microcluster.Start will record the name of the caller package (whether from snap build, GOPATH, or go module), and record it in the daemon.

As well, on start, when calls to `RegisterStmt` are executed, those packages will be recorded, and statements will be registered by their package.

Then, when preparing statements, only statements belonging to the daemon package, or to 'microcluster' (as that is ubiquitous) will be prepared.