### PR TITLE
internal/db/update/update: Convert extended schema to sorted list

### DIFF
--- a/internal/db/update/update.go
+++ b/internal/db/update/update.go
@@ -40,7 +40,8 @@ func Schema() *SchemaUpdate {
 
 func AppendSchema(extensions map[int]schema.Update) {
 	currentVersion := len(updates)
-	for _, extension := range extensions {
+	schema := NewFromMap(extensions)
+	for _, extension := range schema.updates {
 		updates[currentVersion+1] = extension
 		currentVersion = len(updates)
 	}


### PR DESCRIPTION
Fixes an issue where schema updates would apply out of order due to the non-deterministic iteration of maps in `go`.