### PR TITLE
Allow passing additional configuration during bootstrap

### DIFF
--- a/config/hooks.go
+++ b/config/hooks.go
@@ -8,18 +8,18 @@ import (
 // integrate with other tools.
 type Hooks struct {
 	// OnBootstrap is run after the daemon is initialized and bootstrapped.
-	OnBootstrap func(s *state.State) error
+	OnBootstrap func(s *state.State, initConfig map[string]string) error
 
 	// OnStart is run after the daemon is started.
 	OnStart func(s *state.State) error
 
 	// PostJoin is run after the daemon is initialized, joined the cluster and existing members triggered
 	// their 'OnNewMember' hooks.
-	PostJoin func(s *state.State) error
+	PostJoin func(s *state.State, initConfig map[string]string) error
 
 	// PreJoin is run after the daemon is initialized and joined the cluster but before existing members triggered
 	// their 'OnNewMember' hooks.
-	PreJoin func(s *state.State) error
+	PreJoin func(s *state.State, initConfig map[string]string) error
 
 	// PreRemove is run on a cluster member just before it is removed from the cluster.
 	PreRemove func(s *state.State) error

--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -69,8 +69,14 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 	// exampleHooks are some example post-action hooks that can be run by MicroCluster.
 	exampleHooks := &config.Hooks{
 		// OnBootstrap is run after the daemon is initialized and bootstrapped.
-		OnBootstrap: func(s *state.State) error {
+		OnBootstrap: func(s *state.State, initConfig map[string]string) error {
+			logCtx := logger.Ctx{}
+			for k, v := range initConfig {
+				logCtx[k] = v
+			}
+
 			logger.Info("This is a hook that runs after the daemon is initialized and bootstrapped")
+			logger.Info("Here are the extra configuration keys that were passed into the init --bootstrap command", logCtx)
 
 			return nil
 		},
@@ -83,15 +89,27 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 		},
 
 		// PostJoin is run after the daemon is initialized and joins a cluster.
-		PostJoin: func(s *state.State) error {
+		PostJoin: func(s *state.State, initConfig map[string]string) error {
+			logCtx := logger.Ctx{}
+			for k, v := range initConfig {
+				logCtx[k] = v
+			}
+
 			logger.Info("This is a hook that runs after the daemon is initialized and joins an existing cluster, after OnNewMember runs on all peers")
+			logger.Info("Here are the extra configuration keys that were passed into the init --join command", logCtx)
 
 			return nil
 		},
 
 		// PreJoin is run after the daemon is initialized and joins a cluster.
-		PreJoin: func(s *state.State) error {
+		PreJoin: func(s *state.State, initConfig map[string]string) error {
+			logCtx := logger.Ctx{}
+			for k, v := range initConfig {
+				logCtx[k] = v
+			}
+
 			logger.Info("This is a hook that runs after the daemon is initialized and joins an existing cluster, before OnNewMember runs on all peers")
+			logger.Info("Here are the extra configuration keys that were passed into the init --join command", logCtx)
 
 			return nil
 		},

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -236,7 +236,7 @@ func (d *Daemon) reloadIfBootstrapped() error {
 		return fmt.Errorf("Failed to retrieve daemon configuration yaml: %w", err)
 	}
 
-	err = d.StartAPI(false, nil)
+	err = d.StartAPI(false, nil, nil)
 	if err != nil {
 		return err
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -168,8 +168,9 @@ func (d *Daemon) init(listenPort string, extendedEndpoints []rest.Endpoint, sche
 }
 
 func (d *Daemon) applyHooks(hooks *config.Hooks) {
-	// Apply a no-op hook for any missing hooks.
+	// Apply a no-op hooks for any missing hooks.
 	noOpHook := func(s *state.State) error { return nil }
+	noOpInitHook := func(s *state.State, initConfig map[string]string) error { return nil }
 
 	if hooks == nil {
 		d.hooks = config.Hooks{}
@@ -178,15 +179,15 @@ func (d *Daemon) applyHooks(hooks *config.Hooks) {
 	}
 
 	if d.hooks.OnBootstrap == nil {
-		d.hooks.OnBootstrap = noOpHook
+		d.hooks.OnBootstrap = noOpInitHook
 	}
 
 	if d.hooks.PostJoin == nil {
-		d.hooks.PostJoin = noOpHook
+		d.hooks.PostJoin = noOpInitHook
 	}
 
 	if d.hooks.PreJoin == nil {
-		d.hooks.PreJoin = noOpHook
+		d.hooks.PreJoin = noOpInitHook
 	}
 
 	if d.hooks.OnStart == nil {
@@ -378,7 +379,7 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 			return err
 		}
 
-		return d.hooks.OnBootstrap(d.State())
+		return d.hooks.OnBootstrap(d.State(), initConfig)
 	}
 
 	if len(joinAddresses) != 0 {
@@ -420,7 +421,7 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 	}
 
 	if len(joinAddresses) > 0 {
-		err = d.hooks.PreJoin(d.State())
+		err = d.hooks.PreJoin(d.State(), initConfig)
 		if err != nil {
 			return err
 		}
@@ -471,7 +472,7 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 	}
 
 	if len(joinAddresses) > 0 {
-		return d.hooks.PostJoin(d.State())
+		return d.hooks.PostJoin(d.State(), initConfig)
 	}
 
 	return nil

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -306,7 +306,7 @@ func (d *Daemon) initServer(resources ...*resources.Resources) *http.Server {
 
 // StartAPI starts up the admin and consumer APIs, and generates a cluster cert
 // if we are bootstrapping the first node.
-func (d *Daemon) StartAPI(bootstrap bool, newConfig *trust.Location, joinAddresses ...string) error {
+func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfig *trust.Location, joinAddresses ...string) error {
 	if newConfig != nil {
 		err := d.setDaemonConfig(newConfig)
 		if err != nil {

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -45,7 +45,7 @@ func controlPost(state *state.State, r *http.Request) response.Response {
 	}
 
 	daemonConfig := &trust.Location{Address: req.Address, Name: req.Name}
-	err = state.StartAPI(req.Bootstrap, daemonConfig)
+	err = state.StartAPI(req.Bootstrap, req.InitConfig, daemonConfig)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -138,7 +138,7 @@ func joinWithToken(state *state.State, req *internalTypes.Control) response.Resp
 	}
 
 	// Start the HTTPS listeners and join Dqlite.
-	err = state.StartAPI(false, daemonConfig, joinAddrs.Strings()...)
+	err = state.StartAPI(false, req.InitConfig, daemonConfig, joinAddrs.Strings()...)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/internal/rest/types/control.go
+++ b/internal/rest/types/control.go
@@ -6,8 +6,9 @@ import (
 
 // Control represents the arguments that can be used to initialize/shutdown the daemon.
 type Control struct {
-	Bootstrap bool           `json:"bootstrap" yaml:"bootstrap"`
-	JoinToken string         `json:"join_token" yaml:"join_token"`
-	Address   types.AddrPort `json:"address" yaml:"address"`
-	Name      string         `json:"name" yaml:"name"`
+	Bootstrap  bool              `json:"bootstrap" yaml:"bootstrap"`
+	InitConfig map[string]string `json:"config" yaml:"config"`
+	JoinToken  string            `json:"join_token" yaml:"join_token"`
+	Address    types.AddrPort    `json:"address" yaml:"address"`
+	Name       string            `json:"name" yaml:"name"`
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -53,7 +53,7 @@ type State struct {
 	Remotes func() *trust.Remotes
 
 	// Initialize APIs and bootstrap/join database.
-	StartAPI func(bootstrap bool, newConfig *trust.Location, joinAddresses ...string) error
+	StartAPI func(bootstrap bool, initConfig map[string]string, newConfig *trust.Location, joinAddresses ...string) error
 
 	// Stop fully stops the daemon, its database, and all listeners.
 	Stop func() error

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -198,7 +198,7 @@ func (m *MicroCluster) Ready(timeoutSeconds int) error {
 }
 
 // NewCluster bootstrapps a brand new cluster with this daemon as its only member.
-func (m *MicroCluster) NewCluster(name string, address string, timeout time.Duration) error {
+func (m *MicroCluster) NewCluster(name string, address string, config map[string]string, timeout time.Duration) error {
 	c, err := m.LocalClient()
 	if err != nil {
 		return err
@@ -209,11 +209,11 @@ func (m *MicroCluster) NewCluster(name string, address string, timeout time.Dura
 		return fmt.Errorf("Received invalid address %q: %w", address, err)
 	}
 
-	return c.ControlDaemon(m.ctx, internalTypes.Control{Bootstrap: true, Address: addr, Name: name}, timeout)
+	return c.ControlDaemon(m.ctx, internalTypes.Control{Bootstrap: true, Address: addr, Name: name, InitConfig: config}, timeout)
 }
 
 // JoinCluster joins an existing cluster with a join token supplied by an existing cluster member.
-func (m *MicroCluster) JoinCluster(name string, address string, token string, timeout time.Duration) error {
+func (m *MicroCluster) JoinCluster(name string, address string, token string, initConfig map[string]string, timeout time.Duration) error {
 	c, err := m.LocalClient()
 	if err != nil {
 		return err
@@ -224,7 +224,7 @@ func (m *MicroCluster) JoinCluster(name string, address string, token string, ti
 		return fmt.Errorf("Received invalid address %q: %w", address, err)
 	}
 
-	return c.ControlDaemon(m.ctx, internalTypes.Control{JoinToken: token, Address: addr, Name: name}, timeout)
+	return c.ControlDaemon(m.ctx, internalTypes.Control{JoinToken: token, Address: addr, Name: name, InitConfig: initConfig}, timeout)
 }
 
 // NewJoinToken creates and records a new join token containing all the necessary credentials for joining a cluster.


### PR DESCRIPTION
This PR adds an argument to `(*Microcluster).NewCluster` of the form `map[string]string` which is passed into the `OnBootstrap` hook. This allows clients to pass additional configuration that might be required at bootstrap.