### PR TITLE
Pass `force` to the Pre/PostRemove hooks

### DIFF
--- a/config/hooks.go
+++ b/config/hooks.go
@@ -22,10 +22,10 @@ type Hooks struct {
 	PreJoin func(s *state.State, initConfig map[string]string) error
 
 	// PreRemove is run on a cluster member just before it is removed from the cluster.
-	PreRemove func(s *state.State) error
+	PreRemove func(s *state.State, force bool) error
 
 	// PostRemove is run on all other peers after one is removed from the cluster.
-	PostRemove func(s *state.State) error
+	PostRemove func(s *state.State, force bool) error
 
 	// OnHeartbeat is run after a successful heartbeat round.
 	OnHeartbeat func(s *state.State) error

--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -115,15 +115,15 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 		},
 
 		// PostRemove is run after the daemon is removed from a cluster.
-		PostRemove: func(s *state.State) error {
-			logger.Infof("This is a hook that is run on peer %q after a cluster member is removed", s.Name())
+		PostRemove: func(s *state.State, force bool) error {
+			logger.Infof("This is a hook that is run on peer %q after a cluster member is removed, with the force flag set to %v", s.Name(), force)
 
 			return nil
 		},
 
 		// PreRemove is run before the daemon is removed from the cluster.
-		PreRemove: func(s *state.State) error {
-			logger.Infof("This is a hook that is run on peer %q just before it is removed", s.Name())
+		PreRemove: func(s *state.State, force bool) error {
+			logger.Infof("This is a hook that is run on peer %q just before it is removed, with the force flag set to %v", s.Name(), force)
 
 			return nil
 		},

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -170,6 +170,7 @@ func (d *Daemon) init(listenPort string, extendedEndpoints []rest.Endpoint, sche
 func (d *Daemon) applyHooks(hooks *config.Hooks) {
 	// Apply a no-op hooks for any missing hooks.
 	noOpHook := func(s *state.State) error { return nil }
+	noOpRemoveHook := func(s *state.State, force bool) error { return nil }
 	noOpInitHook := func(s *state.State, initConfig map[string]string) error { return nil }
 
 	if hooks == nil {
@@ -203,11 +204,11 @@ func (d *Daemon) applyHooks(hooks *config.Hooks) {
 	}
 
 	if d.hooks.PreRemove == nil {
-		d.hooks.PreRemove = noOpHook
+		d.hooks.PreRemove = noOpRemoveHook
 	}
 
 	if d.hooks.PostRemove == nil {
-		d.hooks.PostRemove = noOpHook
+		d.hooks.PostRemove = noOpRemoveHook
 	}
 }
 

--- a/internal/rest/client/cluster.go
+++ b/internal/rest/client/cluster.go
@@ -47,9 +47,14 @@ func (c *Client) DeleteClusterMember(ctx context.Context, name string, force boo
 }
 
 // ResetClusterMember clears the state directory of the cluster member, and re-execs its daemon.
-func (c *Client) ResetClusterMember(ctx context.Context, name string) error {
+func (c *Client) ResetClusterMember(ctx context.Context, name string, force bool) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "PUT", PublicEndpoint, api.NewURL().Path("cluster", name), nil, nil)
+	endpoint := api.NewURL().Path("cluster", name)
+	if force {
+		endpoint = endpoint.WithQuery("force", "1")
+	}
+
+	return c.QueryStruct(queryCtx, "PUT", PublicEndpoint, endpoint, nil, nil)
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -63,10 +63,10 @@ type State struct {
 var StopListeners func() error
 
 // PostRemoveHook is a post-action hook that is run on all cluster members when a cluster member is removed.
-var PostRemoveHook func(state *State) error
+var PostRemoveHook func(state *State, force bool) error
 
 // PreRemoveHook is a post-action hook that is run on a cluster member just before it is is removed.
-var PreRemoveHook func(state *State) error
+var PreRemoveHook func(state *State, force bool) error
 
 // OnHeartbeatHook is a post-action hook that is run on the leader after a successful heartbeat round.
 var OnHeartbeatHook func(state *State) error


### PR DESCRIPTION
The deletion API does actually support a `force` flag already, but I noticed that the `PreRemove` hook was actually explicitly blocked when `force=1` was set as a query parameter. This should definitely not be the behaviour, so I went ahead and just propagated the `force` param to each of `PreRemove` (which runs on the to-be-removed node) and `PostRemove`  (which runs on every other node after the node is removed). The `PreRemove` hook will now always fire, even if `force=1`. 