### PR TITLE
internal/rest/resources: Refresh cluster info when assigning a role to another node

### DIFF
--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -461,13 +461,14 @@ func clusterMemberDelete(s *state.State, r *http.Request) response.Response {
 				if err != nil {
 					return response.SmartError(err)
 				}
-				// Roles for second member has been updated, so re-query the cluster.
-				info, err = leader.Cluster(s.Context)
-				if err != nil {
-					return response.SmartError(err)
-				}
 			}
 		}
+	}
+
+	// Refresh members information since we may have changed roles.
+	info, err = leader.Cluster(s.Context)
+	if err != nil {
+		return response.SmartError(err)
 	}
 
 	// If we are the leader and removing ourselves, reassign the leader role and perform the removal from there.

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -461,6 +461,11 @@ func clusterMemberDelete(s *state.State, r *http.Request) response.Response {
 				if err != nil {
 					return response.SmartError(err)
 				}
+				// Roles for second member has been updated, so re-query the cluster.
+				info, err = leader.Cluster(s.Context)
+				if err != nil {
+					return response.SmartError(err)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
FIX #79 

In the case the cluster is composed of 2 members, and you try to remove the voter. The code successfully transfers leadership to the spare member, but since cluster info is not updated, subsequent checks fail with "Found no voters to transfer leadership to".