### PR TITLE
internal/db/update: Drop implicit global state

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -24,7 +24,6 @@ import (
 	"github.com/canonical/microcluster/cluster"
 	"github.com/canonical/microcluster/config"
 	"github.com/canonical/microcluster/internal/db"
-	"github.com/canonical/microcluster/internal/db/update"
 	"github.com/canonical/microcluster/internal/endpoints"
 	internalREST "github.com/canonical/microcluster/internal/rest"
 	internalClient "github.com/canonical/microcluster/internal/rest/client"
@@ -152,7 +151,7 @@ func (d *Daemon) init(listenPort string, extendedEndpoints []rest.Endpoint, sche
 		}
 	}
 
-	update.AppendSchema(schemaExtensions)
+	d.db.SetSchema(schemaExtensions)
 
 	err = d.reloadIfBootstrapped()
 	if err != nil {
@@ -365,7 +364,7 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 			Name:        localNode.Name,
 			Address:     localNode.Address.String(),
 			Certificate: localNode.Certificate.String(),
-			Schema:      update.Schema().Version(),
+			Schema:      d.db.Schema().Version(),
 			Heartbeat:   time.Time{},
 			Role:        cluster.Pending,
 		}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -15,7 +15,6 @@ import (
 	"github.com/canonical/lxd/shared/logger"
 
 	"github.com/canonical/microcluster/cluster"
-	"github.com/canonical/microcluster/internal/db/update"
 	"github.com/canonical/microcluster/internal/sys"
 )
 
@@ -36,7 +35,7 @@ func (db *DB) Open(bootstrap bool, project string) error {
 	}
 
 	otherNodesBehind := false
-	newSchema := update.Schema()
+	newSchema := db.Schema()
 	if !bootstrap {
 		checkVersions := func(ctx context.Context, current int, tx *sql.Tx) error {
 			schemaVersion := newSchema.Version()

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -27,6 +27,7 @@ import (
 	"github.com/canonical/lxd/shared/tcp"
 
 	"github.com/canonical/microcluster/cluster"
+	"github.com/canonical/microcluster/internal/db/update"
 	"github.com/canonical/microcluster/internal/rest/client"
 	internalClient "github.com/canonical/microcluster/internal/rest/client"
 	internalTypes "github.com/canonical/microcluster/internal/rest/types"
@@ -54,6 +55,8 @@ type DB struct {
 	cancel context.CancelFunc
 
 	heartbeatLock sync.Mutex
+
+	schema *update.SchemaUpdate
 }
 
 // Accept sends the outbound connection through the acceptCh channel to be received by dqlite.
@@ -75,6 +78,16 @@ func NewDB(ctx context.Context, serverCert *shared.CertInfo, os *sys.OS) *DB {
 		cancel:        shutdownCancel,
 		openCanceller: cancel.New(context.Background()),
 	}
+}
+
+func (db *DB) SetSchema(schemaExtensions map[int]schema.Update) {
+	s := update.NewSchema()
+	s.AppendSchema(schemaExtensions)
+	db.schema = s.Schema()
+}
+
+func (db *DB) Schema() *update.SchemaUpdate {
+	return db.schema
 }
 
 // Bootstrap dqlite.

--- a/internal/db/update/global.go
+++ b/internal/db/update/global.go
@@ -1,0 +1,19 @@
+package update
+
+import (
+	"github.com/canonical/lxd/lxd/db/schema"
+)
+
+var globalSchemaUpdateManager = NewSchema()
+
+func Schema() *SchemaUpdate {
+	return globalSchemaUpdateManager.Schema()
+}
+
+func AppendSchema(extensions map[int]schema.Update) {
+	globalSchemaUpdateManager.AppendSchema(extensions)
+}
+
+func SchemaDotGo() error {
+	return globalSchemaUpdateManager.SchemaDotGo()
+}

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -12,7 +12,6 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 
-	"github.com/canonical/microcluster/internal/db/update"
 	"github.com/canonical/microcluster/internal/rest/access"
 	"github.com/canonical/microcluster/internal/rest/client"
 	internalTypes "github.com/canonical/microcluster/internal/rest/types"
@@ -78,7 +77,7 @@ func joinWithToken(state *state.State, req *internalTypes.Control) response.Resp
 			Address:     localClusterMember.Address,
 			Certificate: localClusterMember.Certificate,
 		},
-		SchemaVersion: update.Schema().Version(),
+		SchemaVersion: state.Database.Schema().Version(),
 		Secret:        token.Secret,
 	}
 


### PR DESCRIPTION
### Summary

Refactor the `internal/db/update` package such that it does not carry any implicit global state for the database migrations.

### Description

When trying to instantiate more than one microcluster instance, the global `updates` state would perform duplicate migrations on instances other than the first and thus fail.

### Proposed change

- Create a `update.SchemaUpdateManager` type with the `Schema()`, `AppendSchema()`, `SchemaDotGo()` methods.
- Create a `globalSchemaUpdateManager` object
- Preserve the old `update.Schema()`, `update.AppendSchema()`, `update.SchemaDotGo()` functions, so that we don't break API. These use the global object, being backwards compatible.
- Update the microcluster instance creation to not use the global schema, but create its own schema instance and use that for initialization.

### Background

In https://github.com/canonical/k8s-snap/pull/69, we introduce tests that initialize separate microcluster instances and validate our database logic. These currently fail because creating a second microcluster instance attempts to apply the migrations multiple times.