### PR TITLE
Add a new 'runtime extension' system to MicroCluster

### DIFF
--- a/cluster/cluster_members.go
+++ b/cluster/cluster_members.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/canonical/lxd/lxd/db/query"
 
+	"github.com/canonical/microcluster/internal/extensions"
 	internalTypes "github.com/canonical/microcluster/internal/rest/types"
 	"github.com/canonical/microcluster/rest/types"
 )
@@ -45,6 +46,7 @@ type InternalClusterMember struct {
 	Certificate    string
 	SchemaInternal uint64
 	SchemaExternal uint64
+	APIExtensions  extensions.Extensions
 	Heartbeat      time.Time
 	Role           Role
 }
@@ -79,6 +81,7 @@ func (c InternalClusterMember) ToAPI() (*internalTypes.ClusterMember, error) {
 		SchemaExternalVersion: c.SchemaExternal,
 		LastHeartbeat:         c.Heartbeat,
 		Status:                internalTypes.MemberUnreachable,
+		Extensions:            c.APIExtensions,
 	}, nil
 }
 

--- a/cluster/cluster_members.go
+++ b/cluster/cluster_members.go
@@ -132,3 +132,53 @@ func GetClusterMemberSchemaVersions(ctx context.Context, tx *sql.Tx) (internalSc
 
 	return internalSchema, externalSchema, nil
 }
+
+// UpdateClusterMemberAPIExtensions sets the API extensions for the cluster member with the given address.
+// This helper is non-generated to work before generated statements are loaded, as we update the API extensions.
+func UpdateClusterMemberAPIExtensions(tx *sql.Tx, apiExtensions extensions.Extensions, address string) error {
+	stmt := "UPDATE internal_cluster_members SET api_extensions=? WHERE address=?"
+	result, err := tx.Exec(stmt, apiExtensions, address)
+	if err != nil {
+		return err
+	}
+
+	n, err := result.RowsAffected()
+	if err != nil {
+		return err
+	}
+	if n != 1 {
+		return fmt.Errorf("Updated %d rows instead of 1", n)
+	}
+
+	return nil
+}
+
+// GetClusterMemberAPIExtensions returns the API extensions from all cluster members that are not pending.
+// This helper is non-generated to work before generated statements are loaded, as we update the API extensions.
+func GetClusterMemberAPIExtensions(ctx context.Context, tx *sql.Tx) ([]extensions.Extensions, error) {
+	query := "SELECT api_extensions FROM internal_cluster_members WHERE NOT role='pending'"
+	rows, err := tx.QueryContext(ctx, query)
+	if err != nil {
+		return nil, err
+	}
+
+	defer rows.Close()
+
+	var results []extensions.Extensions
+	for rows.Next() {
+		var ext extensions.Extensions
+		err := rows.Scan(&ext)
+		if err != nil {
+			return nil, err
+		}
+
+		results = append(results, ext)
+	}
+
+	err = rows.Err()
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}

--- a/cluster/cluster_members.mapper.go
+++ b/cluster/cluster_members.mapper.go
@@ -17,20 +17,20 @@ import (
 var _ = api.ServerEnvironment{}
 
 var internalClusterMemberObjects = RegisterStmt(`
-SELECT internal_cluster_members.id, internal_cluster_members.name, internal_cluster_members.address, internal_cluster_members.certificate, internal_cluster_members.schema_internal, internal_cluster_members.schema_external, internal_cluster_members.heartbeat, internal_cluster_members.role
+SELECT internal_cluster_members.id, internal_cluster_members.name, internal_cluster_members.address, internal_cluster_members.certificate, internal_cluster_members.schema_internal, internal_cluster_members.schema_external, internal_cluster_members.api_extensions, internal_cluster_members.heartbeat, internal_cluster_members.role
   FROM internal_cluster_members
   ORDER BY internal_cluster_members.name
 `)
 
 var internalClusterMemberObjectsByAddress = RegisterStmt(`
-SELECT internal_cluster_members.id, internal_cluster_members.name, internal_cluster_members.address, internal_cluster_members.certificate, internal_cluster_members.schema_internal, internal_cluster_members.schema_external, internal_cluster_members.heartbeat, internal_cluster_members.role
+SELECT internal_cluster_members.id, internal_cluster_members.name, internal_cluster_members.address, internal_cluster_members.certificate, internal_cluster_members.schema_internal, internal_cluster_members.schema_external, internal_cluster_members.api_extensions, internal_cluster_members.heartbeat, internal_cluster_members.role
   FROM internal_cluster_members
   WHERE ( internal_cluster_members.address = ? )
   ORDER BY internal_cluster_members.name
 `)
 
 var internalClusterMemberObjectsByName = RegisterStmt(`
-SELECT internal_cluster_members.id, internal_cluster_members.name, internal_cluster_members.address, internal_cluster_members.certificate, internal_cluster_members.schema_internal, internal_cluster_members.schema_external, internal_cluster_members.heartbeat, internal_cluster_members.role
+SELECT internal_cluster_members.id, internal_cluster_members.name, internal_cluster_members.address, internal_cluster_members.certificate, internal_cluster_members.schema_internal, internal_cluster_members.schema_external, internal_cluster_members.api_extensions, internal_cluster_members.heartbeat, internal_cluster_members.role
   FROM internal_cluster_members
   WHERE ( internal_cluster_members.name = ? )
   ORDER BY internal_cluster_members.name
@@ -42,8 +42,8 @@ SELECT internal_cluster_members.id FROM internal_cluster_members
 `)
 
 var internalClusterMemberCreate = RegisterStmt(`
-INSERT INTO internal_cluster_members (name, address, certificate, schema_internal, schema_external, heartbeat, role)
-  VALUES (?, ?, ?, ?, ?, ?, ?)
+INSERT INTO internal_cluster_members (name, address, certificate, schema_internal, schema_external, api_extensions, heartbeat, role)
+  VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 `)
 
 var internalClusterMemberDeleteByAddress = RegisterStmt(`
@@ -52,14 +52,14 @@ DELETE FROM internal_cluster_members WHERE address = ?
 
 var internalClusterMemberUpdate = RegisterStmt(`
 UPDATE internal_cluster_members
-  SET name = ?, address = ?, certificate = ?, schema_internal = ?, schema_external = ?, heartbeat = ?, role = ?
+  SET name = ?, address = ?, certificate = ?, schema_internal = ?, schema_external = ?, api_extensions = ?, heartbeat = ?, role = ?
  WHERE id = ?
 `)
 
 // internalClusterMemberColumns returns a string of column names to be used with a SELECT statement for the entity.
 // Use this function when building statements to retrieve database entries matching the InternalClusterMember entity.
 func internalClusterMemberColumns() string {
-	return "internal_cluster_members.id, internal_cluster_members.name, internal_cluster_members.address, internal_cluster_members.certificate, internal_cluster_members.schema_internal, internal_cluster_members.schema_external, internal_cluster_members.heartbeat, internal_cluster_members.role"
+	return "internal_cluster_members.id, internal_cluster_members.name, internal_cluster_members.address, internal_cluster_members.certificate, internal_cluster_members.schema_internal, internal_cluster_members.schema_external, internal_cluster_members.api_extensions, internal_cluster_members.heartbeat, internal_cluster_members.role"
 }
 
 // getInternalClusterMembers can be used to run handwritten sql.Stmts to return a slice of objects.
@@ -68,7 +68,7 @@ func getInternalClusterMembers(ctx context.Context, stmt *sql.Stmt, args ...any)
 
 	dest := func(scan func(dest ...any) error) error {
 		i := InternalClusterMember{}
-		err := scan(&i.ID, &i.Name, &i.Address, &i.Certificate, &i.SchemaInternal, &i.SchemaExternal, &i.Heartbeat, &i.Role)
+		err := scan(&i.ID, &i.Name, &i.Address, &i.Certificate, &i.SchemaInternal, &i.SchemaExternal, &i.APIExtensions, &i.Heartbeat, &i.Role)
 		if err != nil {
 			return err
 		}
@@ -92,7 +92,7 @@ func getInternalClusterMembersRaw(ctx context.Context, tx *sql.Tx, sql string, a
 
 	dest := func(scan func(dest ...any) error) error {
 		i := InternalClusterMember{}
-		err := scan(&i.ID, &i.Name, &i.Address, &i.Certificate, &i.SchemaInternal, &i.SchemaExternal, &i.Heartbeat, &i.Role)
+		err := scan(&i.ID, &i.Name, &i.Address, &i.Certificate, &i.SchemaInternal, &i.SchemaExternal, &i.APIExtensions, &i.Heartbeat, &i.Role)
 		if err != nil {
 			return err
 		}
@@ -272,7 +272,7 @@ func CreateInternalClusterMember(ctx context.Context, tx *sql.Tx, object Interna
 		return -1, api.StatusErrorf(http.StatusConflict, "This \"internal_cluster_members\" entry already exists")
 	}
 
-	args := make([]any, 7)
+	args := make([]any, 8)
 
 	// Populate the statement arguments.
 	args[0] = object.Name
@@ -280,8 +280,9 @@ func CreateInternalClusterMember(ctx context.Context, tx *sql.Tx, object Interna
 	args[2] = object.Certificate
 	args[3] = object.SchemaInternal
 	args[4] = object.SchemaExternal
-	args[5] = object.Heartbeat
-	args[6] = object.Role
+	args[5] = object.APIExtensions
+	args[6] = object.Heartbeat
+	args[7] = object.Role
 
 	// Prepared statement to use.
 	stmt, err := Stmt(tx, internalClusterMemberCreate)
@@ -343,7 +344,7 @@ func UpdateInternalClusterMember(ctx context.Context, tx *sql.Tx, name string, o
 		return fmt.Errorf("Failed to get \"internalClusterMemberUpdate\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(object.Name, object.Address, object.Certificate, object.SchemaInternal, object.SchemaExternal, object.Heartbeat, object.Role, id)
+	result, err := stmt.Exec(object.Name, object.Address, object.Certificate, object.SchemaInternal, object.SchemaExternal, object.APIExtensions, object.Heartbeat, object.Role, id)
 	if err != nil {
 		return fmt.Errorf("Update \"internal_cluster_members\" entry failed: %w", err)
 	}

--- a/example/api/extensions.go
+++ b/example/api/extensions.go
@@ -1,0 +1,12 @@
+package api
+
+// These are the extensions that are present when the daemon starts.
+var extensions = []string{
+	"custom_extension_a_0",
+	"custom_extension_a_1",
+}
+
+// Extensions returns the list of MicroOVN extensions.
+func Extensions() []string {
+	return extensions
+}

--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -152,7 +152,7 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 		},
 	}
 
-	return m.Start(cmd.Context(), api.Endpoints, database.SchemaExtensions, exampleHooks)
+	return m.Start(cmd.Context(), api.Endpoints, database.SchemaExtensions, []string{}, exampleHooks)
 }
 
 func main() {

--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -11,6 +11,7 @@ import (
 	"github.com/canonical/microcluster/example/api"
 	"github.com/canonical/microcluster/example/database"
 	"github.com/canonical/microcluster/example/version"
+	"github.com/canonical/microcluster/internal/extensions"
 	"github.com/canonical/microcluster/microcluster"
 	"github.com/canonical/microcluster/state"
 )
@@ -70,6 +71,42 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 			logCtx := logger.Ctx{}
 			for k, v := range initConfig {
 				logCtx[k] = v
+			}
+
+			// You can check your app extensions using the *state.State object.
+			hasMissingExt := s.Extensions.HasExtension("missing_extension")
+			if !hasMissingExt {
+				logger.Warn("The 'missing_extension' is not registered")
+			}
+
+			// You can also check the internal extensions. (starting with "internal:" prefix)
+			// These are read-only and defined at the MicroCluster level and cannot be added at runtime
+			hasInternalExt := s.Extensions.HasExtension("internal:runtime_extension_v1")
+			if !hasInternalExt {
+				logger.Warn("Every system should have the 'internal:runtime_extension_v1' extension")
+			}
+
+			// You can also register new extensions at runtime.
+			err := s.Extensions.Register([]string{"new_extension_at_runtime_1", "new_extension_at_runtime_2"})
+			if err != nil {
+				return err
+			}
+
+			// This shows the number of extensions that are registered (internal and external).
+			numberOfExtensions := s.Extensions.Version()
+			logger.Infof("The number of extensions is %d", numberOfExtensions)
+
+			// You can also create a new registry of extensions from a list of extensions.
+			// This is useful to communicate a system's extensions to other systems, for comparison purposes for example.
+			newExt, err := extensions.NewExtensionRegistryFromList([]string{"internal:runtime_extension_v1", "new_extension_at_runtime_1", "new_extension_at_runtime_2", "custom_extension_a_0", "custom_extension_a_1"})
+			if err != nil {
+				return err
+			}
+
+			// You can compare the extensions of two systems.
+			err = s.Extensions.IsSameVersion(newExt)
+			if err != nil {
+				return err
 			}
 
 			logger.Info("This is a hook that runs after the daemon is initialized and bootstrapped")
@@ -152,7 +189,7 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 		},
 	}
 
-	return m.Start(cmd.Context(), api.Endpoints, database.SchemaExtensions, []string{}, exampleHooks)
+	return m.Start(cmd.Context(), api.Endpoints, database.SchemaExtensions, api.Extensions(), exampleHooks)
 }
 
 func main() {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -423,7 +423,7 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 
 		clusterMember.SchemaInternal, clusterMember.SchemaExternal = d.db.Schema().Version()
 
-		err = d.db.Bootstrap(d.project, d.address, clusterMember)
+		err = d.db.Bootstrap(d.Extensions, d.project, d.address, clusterMember)
 		if err != nil {
 			return err
 		}
@@ -443,12 +443,12 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 	}
 
 	if len(joinAddresses) != 0 {
-		err = d.db.Join(d.project, d.address, joinAddresses...)
+		err = d.db.Join(d.Extensions, d.project, d.address, joinAddresses...)
 		if err != nil {
 			return fmt.Errorf("Failed to join cluster: %w", err)
 		}
 	} else {
-		err = d.db.StartWithCluster(d.project, d.address, d.trustStore.Remotes().Addresses())
+		err = d.db.StartWithCluster(d.Extensions, d.project, d.address, d.trustStore.Remotes().Addresses())
 		if err != nil {
 			return fmt.Errorf("Failed to re-establish cluster connection: %w", err)
 		}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -15,12 +15,13 @@ import (
 	"github.com/canonical/lxd/shared/logger"
 
 	"github.com/canonical/microcluster/cluster"
+	"github.com/canonical/microcluster/internal/extensions"
 	"github.com/canonical/microcluster/internal/sys"
 )
 
 // Open opens the dqlite database and loads the schema.
 // Returns true if we need to wait for other nodes to catch up to our version.
-func (db *DB) Open(bootstrap bool, project string) error {
+func (db *DB) Open(ext extensions.Extensions, bootstrap bool, project string) error {
 	ctx, cancel := context.WithTimeout(db.ctx, 30*time.Second)
 	defer cancel()
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -35,7 +35,7 @@ func (db *DB) Open(ext extensions.Extensions, bootstrap bool, project string) er
 		return err
 	}
 
-	err = db.waitUpgrade(bootstrap)
+	err = db.waitUpgrade(bootstrap, ext)
 	if err != nil {
 		return err
 	}
@@ -53,7 +53,7 @@ func (db *DB) Open(ext extensions.Extensions, bootstrap bool, project string) er
 // waitUpgrade compares the version information of all cluster members in the database to the local version.
 // If this node's version is ahead of others, then it will block on the `db.upgradeCh` or up to a minute.
 // If this node's version is behind others, then it returns an error.
-func (db *DB) waitUpgrade(bootstrap bool) error {
+func (db *DB) waitUpgrade(bootstrap bool, ext extensions.Extensions) error {
 	checkSchemaVersion := func(schemaVersion uint64, clusterMemberVersions []uint64) (otherNodesBehind bool, err error) {
 		nodeIsBehind := false
 		for _, version := range clusterMemberVersions {
@@ -76,6 +76,33 @@ func (db *DB) waitUpgrade(bootstrap bool) error {
 			// to upgrade. Let's error out and shutdown
 			// since we need a greater version.
 			return false, fmt.Errorf("This node's version is behind, please upgrade")
+		}
+
+		return nodeIsBehind, nil
+	}
+
+	checkAPIExtensions := func(currentAPIExtensions extensions.Extensions, clusterMemberAPIExtensions []extensions.Extensions) (otherNodesBehind bool, err error) {
+		logger.Warnf("Local API extensions: %v, cluster members API extensions: %v", currentAPIExtensions, clusterMemberAPIExtensions)
+
+		nodeIsBehind := false
+		for _, extensions := range clusterMemberAPIExtensions {
+			if currentAPIExtensions.IsSameVersion(extensions) == nil {
+				// API extensions are equal, there's hope for the
+				// update. Let's check the next node.
+				continue
+			} else if extensions == nil || currentAPIExtensions.Version() > extensions.Version() {
+				// Our version is bigger, we should stop here
+				// and wait for other nodes to be upgraded and
+				// restarted.
+				nodeIsBehind = true
+				continue
+			} else {
+				// Another node has a version greater than ours
+				// and presumeably is waiting for other nodes
+				// to upgrade. Let's error out and shutdown
+				// since we need a greater version.
+				return false, fmt.Errorf("This node's API extensions are behind, please upgrade")
+			}
 		}
 
 		return nodeIsBehind, nil
@@ -122,7 +149,42 @@ func (db *DB) waitUpgrade(bootstrap bool) error {
 
 	err := db.retry(context.TODO(), func(_ context.Context) error {
 		_, err := newSchema.Ensure(db.db)
-		return err
+		if err != nil {
+			return err
+		}
+
+		if !bootstrap {
+			otherNodesBehindAPI := false
+			// Perform the API extensions check.
+			err = query.Transaction(context.TODO(), db.db, func(ctx context.Context, tx *sql.Tx) error {
+				err := cluster.UpdateClusterMemberAPIExtensions(tx, ext, db.listenAddr.URL.Host)
+				if err != nil {
+					return fmt.Errorf("Failed to update API extensions when joining cluster: %w", err)
+				}
+
+				clusterMembersAPIExtensions, err := cluster.GetClusterMemberAPIExtensions(ctx, tx)
+				if err != nil {
+					return fmt.Errorf("Failed to get other members' API extensions: %w", err)
+				}
+
+				otherNodesBehindAPI, err = checkAPIExtensions(ext, clusterMembersAPIExtensions)
+				if err != nil {
+					return err
+				}
+
+				return nil
+			})
+			if err != nil {
+				return err
+			}
+
+			if otherNodesBehindAPI {
+				otherNodesBehind = true
+				return schema.ErrGracefulAbort
+			}
+		}
+
+		return nil
 	})
 
 	// If we are not bootstrapping, wait for an upgrade notification, or wait a minute before checking again.
@@ -130,7 +192,7 @@ func (db *DB) waitUpgrade(bootstrap bool) error {
 		logger.Warn("Waiting for other cluster members to upgrade their versions", logger.Ctx{"address": db.listenAddr.String()})
 		select {
 		case <-db.upgradeCh:
-		case <-time.After(time.Minute):
+		case <-time.After(30 * time.Second):
 		}
 	}
 

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -3,6 +3,7 @@ package db
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
 	"testing"
 	"time"
@@ -14,6 +15,7 @@ import (
 
 	"github.com/canonical/microcluster/cluster"
 	"github.com/canonical/microcluster/internal/db/update"
+	"github.com/canonical/microcluster/internal/extensions"
 )
 
 type dbSuite struct {
@@ -25,7 +27,7 @@ func TestDBSuite(t *testing.T) {
 }
 
 // Ensures waitUpgrade properly waits or returns an error with mismatched cluster versions.
-func (s *dbSuite) Test_waitUpgrade() {
+func (s *dbSuite) Test_waitUpgradeSchema() {
 	type versions struct {
 		schemaInt uint64
 		schemaExt uint64
@@ -162,6 +164,9 @@ func (s *dbSuite) Test_waitUpgrade() {
 		tx, err := db.db.BeginTx(ctx, nil)
 		s.NoError(err)
 
+		apiExtensions, err := extensions.NewExtensionRegistry(true)
+		s.NoError(err)
+
 		// Generate a cluster member for the local node.
 		_, err = cluster.CreateInternalClusterMember(ctx, tx, cluster.InternalClusterMember{
 			Name:           fmt.Sprintf("cluster-member-%d", 0),
@@ -169,6 +174,7 @@ func (s *dbSuite) Test_waitUpgrade() {
 			Certificate:    fmt.Sprintf("test-cert-%d", 0),
 			SchemaInternal: 0,
 			SchemaExternal: 0,
+			APIExtensions:  apiExtensions,
 			Heartbeat:      time.Time{},
 			Role:           "voter",
 		})
@@ -183,6 +189,7 @@ func (s *dbSuite) Test_waitUpgrade() {
 				Certificate:    fmt.Sprintf("test-cert-%d", j+1),
 				SchemaInternal: clusterMember.schemaInt + 1,
 				SchemaExternal: clusterMember.schemaExt + 1,
+				APIExtensions:  apiExtensions,
 				Heartbeat:      time.Time{},
 				Role:           "voter",
 			})
@@ -228,7 +235,7 @@ func (s *dbSuite) Test_waitUpgrade() {
 		db.schema = manager.Schema()
 
 		// Run the upgrade function to wait, error, or succeed.
-		err = db.waitUpgrade(false)
+		err = db.waitUpgrade(false, apiExtensions)
 		if t.expectErr != nil {
 			s.Equal(t.expectErr, err)
 		} else if t.expectWait {
@@ -275,6 +282,368 @@ func (s *dbSuite) Test_waitUpgrade() {
 
 		s.Equal(internalVersions, schemaInternal)
 		s.Equal(externalVersions, schemaExternal)
+	}
+}
+
+func (s *dbSuite) Test_waitUpgradeAPI() {
+	tests := []struct {
+		name                       string
+		upgradedLocalAPIExtensions extensions.Extensions
+		clusterMembersExtensions   []extensions.Extensions
+		expectErr                  error
+		expectWait                 bool
+	}{
+		{
+			name:                       "No upgrade, no other nodes",
+			upgradedLocalAPIExtensions: extensions.Extensions{},
+		},
+		{
+			name:                       "API upgrade, no other nodes",
+			upgradedLocalAPIExtensions: extensions.Extensions{"internal:a", "ext"},
+		},
+		{
+			name:                       "All other nodes ahead",
+			upgradedLocalAPIExtensions: extensions.Extensions{"internal:a", "ext"},
+			clusterMembersExtensions:   []extensions.Extensions{{"internal:a", "ext", "ext2"}, {"internal:a", "ext", "ext2"}},
+			expectErr:                  fmt.Errorf("This node's API extensions are behind, please upgrade"),
+		},
+		{
+			name:                       "Some other nodes ahead",
+			upgradedLocalAPIExtensions: extensions.Extensions{"internal:a", "ext"},
+			clusterMembersExtensions:   []extensions.Extensions{{"internal:a", "ext"}, {"internal:a", "ext", "ext2"}},
+			expectErr:                  fmt.Errorf("This node's API extensions are behind, please upgrade"),
+		},
+		{
+			name:                       "All other nodes behind",
+			upgradedLocalAPIExtensions: extensions.Extensions{"internal:a", "ext", "ext2"},
+			clusterMembersExtensions:   []extensions.Extensions{{"internal:a", "ext"}, {"internal:a", "ext"}},
+			expectWait:                 true,
+		},
+		{
+			name:                       "Some other nodes behind",
+			upgradedLocalAPIExtensions: extensions.Extensions{"internal:a", "ext", "ext2"},
+			clusterMembersExtensions:   []extensions.Extensions{{"internal:a", "ext", "ext2"}, {"internal:a", "ext"}},
+			expectWait:                 true,
+		},
+		{
+			name:                       "Some nodes behind, others ahead",
+			upgradedLocalAPIExtensions: extensions.Extensions{"internal:a", "ext", "ext2"},
+			clusterMembersExtensions:   []extensions.Extensions{{"internal:a", "ext"}, {"internal:a", "ext", "ext2", "ext3"}},
+			expectErr:                  fmt.Errorf("This node's API extensions are behind, please upgrade"),
+		},
+	}
+
+	for i, t := range tests {
+		s.T().Logf("%s (case %d)", t.name, i)
+
+		db, err := NewTestDB([]schema.Update{})
+		s.NoError(err)
+
+		ctx := context.Background()
+		tx, err := db.db.BeginTx(ctx, nil)
+		s.NoError(err)
+
+		// Generate a cluster member for the local node.
+		_, err = cluster.CreateInternalClusterMember(ctx, tx, cluster.InternalClusterMember{
+			Name:           fmt.Sprintf("cluster-member-%d", 0),
+			Address:        fmt.Sprintf("10.0.0.%d:8443", 0),
+			Certificate:    fmt.Sprintf("test-cert-%d", 0),
+			SchemaInternal: 0,
+			SchemaExternal: 0,
+			APIExtensions:  t.upgradedLocalAPIExtensions,
+			Heartbeat:      time.Time{},
+			Role:           "voter",
+		})
+
+		s.NoError(err)
+
+		// Generate a cluster member entry for all other expected nodes.
+		for j, clusterMemberExtensions := range t.clusterMembersExtensions {
+			_, err = cluster.CreateInternalClusterMember(ctx, tx, cluster.InternalClusterMember{
+				Name:           fmt.Sprintf("cluster-member-%d", j+1),
+				Address:        fmt.Sprintf("10.0.0.%d:8443", j+1),
+				Certificate:    fmt.Sprintf("test-cert-%d", j+1),
+				SchemaInternal: 1,
+				SchemaExternal: 1,
+				APIExtensions:  clusterMemberExtensions,
+				Heartbeat:      time.Time{},
+				Role:           "voter",
+			})
+
+			s.NoError(err)
+		}
+
+		s.NoError(tx.Commit())
+
+		// Reset the local schema so we can override the updates.
+		_, err = db.db.Exec("delete from schemas")
+		s.NoError(err)
+
+		stmt := `INSERT INTO schemas (version, type, updated_at) VALUES (?, ?, strftime("%s"))`
+
+		// Apply the local updates to the schema table.
+		manager := &update.SchemaUpdateManager{}
+
+		_, err = db.db.Exec(stmt, 0, 0)
+		s.NoError(err)
+		updates := []schema.Update{func(ctx context.Context, tx *sql.Tx) error { return nil }}
+		manager.SetInternalUpdates(updates)
+
+		_, err = db.db.Exec(stmt, 0, 1)
+		s.NoError(err)
+		updates = []schema.Update{func(ctx context.Context, tx *sql.Tx) error { return nil }}
+		manager.SetExternalUpdates(updates)
+
+		if t.expectWait {
+			db.upgradeCh <- struct{}{}
+		}
+
+		// Set a no-op schema manager so that we can go through the schema upgrade logic without running any real updates.
+		db.schema = manager.Schema()
+
+		// Run the upgrade function to wait, error, or succeed.
+		err = db.waitUpgrade(false, t.upgradedLocalAPIExtensions)
+		if t.expectErr != nil {
+			s.Equal(t.expectErr, err)
+		} else if t.expectWait {
+			s.Equal(schema.ErrGracefulAbort, err)
+		} else {
+			s.NoError(err)
+		}
+
+		tx, err = db.db.BeginTx(ctx, nil)
+		s.NoError(err)
+
+		res, err := query.SelectStrings(ctx, tx, "SELECT api_extensions FROM internal_cluster_members ORDER BY id")
+		s.NoError(err)
+		allExtensions := make([]extensions.Extensions, 0)
+		for _, r := range res {
+			e := extensions.Extensions{}
+			err = json.Unmarshal([]byte(r), &e)
+			s.NoError(err)
+			allExtensions = append(allExtensions, e)
+		}
+
+		s.NoError(tx.Commit())
+
+		s.Equal(len(t.clusterMembersExtensions)+1, len(allExtensions))
+
+		if t.expectErr == nil && t.expectWait == false {
+			for _, c := range t.clusterMembersExtensions {
+				err = t.upgradedLocalAPIExtensions.IsSameVersion(c)
+				s.NoError(err)
+			}
+		}
+	}
+}
+
+func (s *dbSuite) Test_waitUpgradeSchemaAndAPI() {
+	type versionsWithExtensions struct {
+		schemaInt uint64
+		schemaExt uint64
+		ext       extensions.Extensions
+	}
+
+	tests := []struct {
+		name              string
+		upgradedLocalInfo versionsWithExtensions
+		clusterMembers    []versionsWithExtensions
+		expectErr         error
+		expectWait        bool
+	}{
+		{
+			name: "Local node in sync, no other nodes",
+			upgradedLocalInfo: versionsWithExtensions{
+				schemaInt: 0,
+				schemaExt: 0,
+				ext:       extensions.Extensions{"internal:a"},
+			},
+		},
+		{
+			name: "Local node behind in schema and API",
+			upgradedLocalInfo: versionsWithExtensions{
+				schemaInt: 0,
+				schemaExt: 0,
+				ext:       extensions.Extensions{"internal:a"},
+			},
+			clusterMembers: []versionsWithExtensions{
+				{schemaInt: 1, schemaExt: 1, ext: extensions.Extensions{"internal:a"}},
+				{schemaInt: 1, schemaExt: 1, ext: extensions.Extensions{"internal:a"}},
+			},
+			expectErr: fmt.Errorf("This node's version is behind, please upgrade"),
+		},
+		{
+			name: "Local node ahead, all other nodes behind",
+			upgradedLocalInfo: versionsWithExtensions{
+				schemaInt: 2,
+				schemaExt: 2,
+				ext:       extensions.Extensions{"internal:a", "b", "c"},
+			},
+			clusterMembers: []versionsWithExtensions{
+				{schemaInt: 1, schemaExt: 1, ext: extensions.Extensions{"internal:a", "b", "c"}},
+				{schemaInt: 1, schemaExt: 1, ext: extensions.Extensions{"internal:a", "b", "c"}},
+			},
+			expectWait: true,
+		},
+		{
+			name: "Mixed node versions, some ahead and some behind",
+			upgradedLocalInfo: versionsWithExtensions{
+				schemaInt: 1,
+				schemaExt: 1,
+				ext:       extensions.Extensions{"internal:a", "b"},
+			},
+			clusterMembers: []versionsWithExtensions{
+				{schemaInt: 2, schemaExt: 2, ext: extensions.Extensions{"internal:a", "b"}},
+				{schemaInt: 0, schemaExt: 0, ext: extensions.Extensions{"internal:a", "b"}},
+			},
+			expectErr: fmt.Errorf("This node's version is behind, please upgrade"),
+		},
+	}
+
+	for i, t := range tests {
+		s.T().Logf("%s (case %d)", t.name, i)
+
+		db, err := NewTestDB([]schema.Update{})
+		s.NoError(err)
+
+		ctx := context.Background()
+		tx, err := db.db.BeginTx(ctx, nil)
+		s.NoError(err)
+
+		// Generate a cluster member for the local node.
+		_, err = cluster.CreateInternalClusterMember(ctx, tx, cluster.InternalClusterMember{
+			Name:           fmt.Sprintf("cluster-member-%d", 0),
+			Address:        fmt.Sprintf("10.0.0.%d:8443", 0),
+			Certificate:    fmt.Sprintf("test-cert-%d", 0),
+			SchemaInternal: 0,
+			SchemaExternal: 0,
+			APIExtensions:  extensions.Extensions{},
+			Heartbeat:      time.Time{},
+			Role:           "voter",
+		})
+
+		s.NoError(err)
+
+		// Generate a cluster member entry for all other expected nodes.
+		for j, clusterMember := range t.clusterMembers {
+			_, err = cluster.CreateInternalClusterMember(ctx, tx, cluster.InternalClusterMember{
+				Name:           fmt.Sprintf("cluster-member-%d", j+1),
+				Address:        fmt.Sprintf("10.0.0.%d:8443", j+1),
+				Certificate:    fmt.Sprintf("test-cert-%d", j+1),
+				SchemaInternal: clusterMember.schemaInt + 1,
+				SchemaExternal: clusterMember.schemaExt + 1,
+				APIExtensions:  clusterMember.ext,
+				Heartbeat:      time.Time{},
+				Role:           "voter",
+			})
+
+			s.NoError(err)
+		}
+
+		s.NoError(tx.Commit())
+
+		// Reset the local schema so we can override the updates.
+		_, err = db.db.Exec("delete from schemas")
+		s.NoError(err)
+
+		stmt := `INSERT INTO schemas (version, type, updated_at) VALUES (?, ?, strftime("%s"))`
+
+		// Apply the local updates to the schema table.
+		manager := &update.SchemaUpdateManager{}
+		updates := []schema.Update{}
+		for j := 0; j < int(t.upgradedLocalInfo.schemaInt)+1; j++ {
+			_, err = db.db.Exec(stmt, j, 0)
+			s.NoError(err)
+
+			updates = append(updates, func(ctx context.Context, tx *sql.Tx) error { return nil })
+		}
+
+		manager.SetInternalUpdates(updates)
+
+		updates = []schema.Update{}
+		for j := 0; j < int(t.upgradedLocalInfo.schemaExt)+1; j++ {
+			_, err = db.db.Exec(stmt, j, 1)
+			s.NoError(err)
+
+			updates = append(updates, func(ctx context.Context, tx *sql.Tx) error { return nil })
+		}
+
+		manager.SetExternalUpdates(updates)
+
+		if t.expectWait {
+			db.upgradeCh <- struct{}{}
+		}
+
+		// Set a no-op schema manager so that we can go through the schema upgrade logic without running any real updates.
+		db.schema = manager.Schema()
+
+		// Run the upgrade function to wait, error, or succeed.
+		err = db.waitUpgrade(false, t.upgradedLocalInfo.ext)
+		if t.expectErr != nil {
+			s.Equal(t.expectErr, err)
+		} else if t.expectWait {
+			s.Equal(schema.ErrGracefulAbort, err)
+		} else {
+			s.NoError(err)
+		}
+
+		tx, err = db.db.BeginTx(ctx, nil)
+		s.NoError(err)
+
+		schemaInternal, err := query.SelectIntegers(ctx, tx, "SELECT schema_internal FROM internal_cluster_members ORDER BY id")
+		s.NoError(err)
+
+		schemaExternal, err := query.SelectIntegers(ctx, tx, "SELECT schema_external FROM internal_cluster_members ORDER BY id")
+		s.NoError(err)
+
+		res, err := query.SelectStrings(ctx, tx, "SELECT api_extensions FROM internal_cluster_members ORDER BY id")
+		s.NoError(err)
+		allExtensions := make([]extensions.Extensions, 0)
+		for _, r := range res {
+			e := extensions.Extensions{}
+			err = json.Unmarshal([]byte(r), &e)
+			s.NoError(err)
+			allExtensions = append(allExtensions, e)
+		}
+
+		s.NoError(tx.Commit())
+
+		s.Equal(len(t.clusterMembers)+1, len(schemaInternal))
+		s.Equal(len(t.clusterMembers)+1, len(schemaExternal))
+
+		// If there's an error, the internal_cluster_members table will be rolled back.
+		minVersion := t.upgradedLocalInfo.schemaInt + 1
+		if t.expectErr != nil {
+			minVersion = 0
+		}
+
+		internalVersions := []int{int(minVersion)}
+		for _, c := range t.clusterMembers {
+			internalVersions = append(internalVersions, int(c.schemaInt)+1)
+		}
+
+		// If there's an error, the internal_cluster_members table will be rolled back.
+		minVersion = t.upgradedLocalInfo.schemaExt + 1
+		if t.expectErr != nil {
+			minVersion = 0
+		}
+
+		externalVersions := []int{int(minVersion)}
+		for _, c := range t.clusterMembers {
+			externalVersions = append(externalVersions, int(c.schemaExt)+1)
+		}
+
+		s.Equal(internalVersions, schemaInternal)
+		s.Equal(externalVersions, schemaExternal)
+
+		s.Equal(len(t.clusterMembers)+1, len(allExtensions))
+
+		if t.expectErr == nil && t.expectWait == false {
+			for _, c := range t.clusterMembers {
+				err = t.upgradedLocalInfo.ext.IsSameVersion(c.ext)
+				s.NoError(err)
+			}
+		}
 	}
 }
 

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -109,6 +109,8 @@ func (db *DB) Bootstrap(extensions extensions.Extensions, project string, addr a
 		return err
 	}
 
+	// Apply initial API extensions on the bootstrap node.
+	clusterRecord.APIExtensions = extensions
 	err = db.Transaction(db.ctx, func(ctx context.Context, tx *sql.Tx) error {
 
 		_, err := cluster.CreateInternalClusterMember(ctx, tx, clusterRecord)

--- a/internal/db/update/update_test.go
+++ b/internal/db/update/update_test.go
@@ -43,7 +43,9 @@ func (s *updateSuite) Test_updateFromV1ClusterMembers() {
 	// Update the schemas table to reflect the 3 new nodes. Assume there are 2 pre-existing external updates.
 	stmt := `INSERT INTO schemas (version, updated_at) VALUES (?, strftime("%s"))`
 	_, err = db.Exec(stmt, 1)
+	s.NoError(err)
 	_, err = db.Exec(stmt, 2)
+	s.NoError(err)
 	_, err = db.Exec(stmt, 3)
 	s.NoError(err)
 
@@ -78,7 +80,7 @@ func (s *updateSuite) Test_updateFromV1ClusterMembers() {
 	// The schema_internal column won't be updated to 2 until `waitUpgrade` is called on each node, but it should still reflect the pre-existing updateFromV0.
 	s.Equal([]int{1, 1, 1}, schemaInternal)
 	s.Equal([]int{2, 2, 2}, schemaExternal)
-	s.Equal([]int{1, 2}, versionsInternal)
+	s.Equal([]int{1, 2, 3}, versionsInternal)
 	s.Equal([]int{1, 2}, versionsExternal)
 
 	s.NoError(db.Close())

--- a/internal/extensions/extensions.go
+++ b/internal/extensions/extensions.go
@@ -1,0 +1,195 @@
+package extensions
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"fmt"
+	"regexp"
+
+	"github.com/canonical/lxd/shared"
+)
+
+var internalExtensionRegex = regexp.MustCompile(`^internal:([a-z0-9]|[a-z0-9]_[a-z0-9])+$`)
+var externalExtensionRegex = regexp.MustCompile(`^([a-z0-9]|[a-z0-9]_[a-z0-9])+$`)
+
+// Extensions represents a registry of extensions.
+//
+// `internal` extensions are related to MicroCluster capabilities, not capabilities of
+// MicroCluster-backed services.
+//
+// To distinguish between `internal` and `external` extensions, `internal` extensions
+// are prefixed with a `internal:` value.
+// e.g, `internal:runtime_extension_v1`, `internal:runtime_extension_v2`, ...
+//
+// External extensions are related to capabilities of MicroCluster-backed services.
+// e.g, `microovn_custom_encapsulation_ip`
+type Extensions []string
+
+// Populate internal extensions here.
+var internalExtensions = Extensions{
+	"internal:runtime_extension_v1",
+}
+
+// validateExternalExtension validates the given external extension.
+func validateExternalExtension(extension string) error {
+	if extension == "" {
+		return fmt.Errorf("Extension cannot be empty")
+	}
+
+	// Aside from the internal extensions, we let the extension to be like
+	// `<extension>` with only lowercase letters and underscores.
+	if !externalExtensionRegex.MatchString(extension) {
+		return fmt.Errorf("External extension name %q is invalid: Extension name must contain only lowercase letters and underscores, and must not begin or end with an underscore", extension)
+	}
+
+	return nil
+}
+
+// validateInternalExtension validates the given internal extension.
+func validateInternalExtension(extension string) error {
+	if extension == "" {
+		return fmt.Errorf("Extension cannot be empty")
+	}
+
+	// Internal extensions should be in the format `internal:<extension>` with only lowercase letters and underscores.
+	if !internalExtensionRegex.MatchString(extension) {
+		return fmt.Errorf("Internal extension name %q is invalid: Extension name must contain only lowercase letters and underscores, and must begin by `internal:`", extension)
+	}
+
+	return nil
+}
+
+// HasExtension reports whether the extension set supports the given extension.
+func (e Extensions) HasExtension(ext string) bool {
+	for _, extension := range e {
+		if extension == ext {
+			return true
+		}
+	}
+
+	return false
+}
+
+// Version returns the number of extensions in the set, representing its version number.
+func (e Extensions) Version() int {
+	return len(e)
+}
+
+// NewExtensionRegistry creates a new instance of the Extensions struct, which represents a registry of extensions.
+// We have the option to populate the internal extensions or not. Having s option becomes handy
+// when we want to create a custom registry of extensions (see `NewExtensionRegistryFromList`)
+func NewExtensionRegistry(populateInternal bool) (Extensions, error) {
+	extensions := Extensions{}
+	var err error
+	if populateInternal {
+		extensions = make(Extensions, 0, len(internalExtensions))
+		for _, internalExtension := range internalExtensions {
+			err = validateInternalExtension(internalExtension)
+			if err != nil {
+				return nil, err
+			}
+
+			extensions = append(extensions, internalExtension)
+		}
+	}
+
+	return extensions, nil
+}
+
+// NewExtensionRegistryFromList creates a new instance of the Extensions struct, from a list of extensions.
+// The passed extensions could be internal or external or just invalid.
+// The function is typically used to create a registry from an API response in order to compare
+// the source and the target systems' extensions for compatibility.
+// The returned registry is always sorted with internal extensions first.
+func NewExtensionRegistryFromList(extensions []string) (Extensions, error) {
+	registry, err := NewExtensionRegistry(false)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, extension := range extensions {
+		err = validateExternalExtension(extension)
+		if err != nil {
+			// The extension could be an internal extension.
+			err = validateInternalExtension(extension)
+			if err != nil {
+				// The extension is invalid in both case.
+				return nil, fmt.Errorf("Extension %q is invalid", extension)
+			}
+
+			// The extension is an internal extension.
+			registry = append(registry, extension)
+		} else {
+			// The extension is an external extension.
+			registry = append(registry, extension)
+		}
+	}
+
+	return registry, nil
+}
+
+// Register registers new external extensions to the Extensions struct.
+func (e *Extensions) Register(newExtensions []string) error {
+	// Check for duplicates for internal and External extensions
+	for _, extension := range newExtensions {
+		if shared.ValueInSlice[string](extension, *e) {
+			return fmt.Errorf("Extension %q already registered", extension)
+		}
+
+		err := validateExternalExtension(extension)
+		if err != nil {
+			return err
+		}
+
+		*e = append(*e, extension)
+	}
+
+	return nil
+}
+
+// Value implements the driver.Valuer interface to serialize the Extensions struct for database storage.
+func (e Extensions) Value() (driver.Value, error) {
+	if len(e) == 0 {
+		return "[]", nil
+	}
+
+	return json.Marshal(e)
+}
+
+// Scan implements the sql.Scanner interface to deserialize the Extensions struct from database storage.
+func (e *Extensions) Scan(value any) error {
+	if value == nil {
+		*e = nil
+		return nil
+	}
+
+	var bytes []byte
+	switch v := value.(type) {
+	case []byte:
+		bytes = v
+	case string:
+		bytes = []byte(v)
+	default:
+		return fmt.Errorf("type assertion to []byte or string failed, incompatible type (%T) for value: %v", value, value)
+	}
+
+	return json.Unmarshal(bytes, e)
+}
+
+// IsSameVersion checks if the source registry supports the target registry.
+func (e Extensions) IsSameVersion(t Extensions) error {
+	// First, check if the number of extensions are the same.
+	if len(e) != len(t) {
+		return fmt.Errorf("The source (%v) and target (%v) registries have different number of extensions", e, t)
+	}
+
+	// Then, check if the extensions are the same.
+	// The two extensions are already sorted so we can compare by index directly.
+	for i := range e {
+		if (e)[i] != (t)[i] {
+			return fmt.Errorf("The source and target registries have different extensions")
+		}
+	}
+
+	return nil
+}

--- a/internal/extensions/extensions_test.go
+++ b/internal/extensions/extensions_test.go
@@ -1,0 +1,151 @@
+package extensions
+
+import (
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"log"
+	"testing"
+
+	_ "github.com/mattn/go-sqlite3"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidateExternalExtension(t *testing.T) {
+	cases := []struct {
+		name      string
+		extension string
+		wantError bool
+	}{
+		{"Valid Extension", "valid_extension", false},
+		{"Empty Extension", "", true},
+		{"Invalid Characters", "Invalid-Extension!", true},
+		{"Invalid Start Underscore", "_invalidextension", true},
+		{"Invalid End Underscore", "invalidextension_", true},
+		{"Invalid Non Alphanumeric", "invalid-extension", true},
+		{"Valid Start Numeric", "123_invalid", false},
+		{"Invalid Start Underscore", "_invalid_123", true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateExternalExtension(c.extension)
+			if c.wantError {
+				assert.Error(t, err, "Expected an error for invalid extension")
+			} else {
+				assert.NoError(t, err, "Expected no error for valid extension")
+			}
+		})
+	}
+}
+
+func TestValidateInternalExtension(t *testing.T) {
+	cases := []struct {
+		name      string
+		extension string
+		wantError bool
+	}{
+		{"Valid Internal Extension", "internal:runtime_extension_v1", false},
+		{"Missing Prefix", "runtime_extension_v1", true},
+		{"Empty Extension", "", true},
+		{"Invalid Format", "internal:_invalid_extension", true},
+		{"Valid with Numbers", "internal:valid_extension_123", false},
+		{"Invalid Character", "internal:invalid-extension", true},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			err := validateInternalExtension(c.extension)
+			if c.wantError {
+				assert.Error(t, err, "Expected an error for invalid internal extension")
+			} else {
+				assert.NoError(t, err, "Expected no error for valid internal extension")
+			}
+		})
+	}
+}
+
+func TestNewExtensionRegistry(t *testing.T) {
+	registry, err := NewExtensionRegistry(true)
+	assert.NoError(t, err)
+	assert.NotNil(t, registry)
+	assert.Contains(t, registry, "internal:runtime_extension_v1", "Should contain internal extensions")
+}
+
+func TestNewExtensionRegistryFromList(t *testing.T) {
+	extensions := []string{"internal:runtime_extension_v1", "valid_extension"}
+	registry, err := NewExtensionRegistryFromList(extensions)
+	assert.NoError(t, err)
+	assert.NotNil(t, registry)
+	assert.Equal(t, 2, len(registry))
+	assert.Contains(t, registry, "internal:runtime_extension_v1")
+	assert.Contains(t, registry, "valid_extension")
+}
+
+func TestJSONSerialization(t *testing.T) {
+	registry := Extensions{"internal:runtime_extension_v1", "valid_extension"}
+	data, err := json.Marshal(registry)
+	assert.NoError(t, err)
+
+	var newRegistry Extensions
+	err = json.Unmarshal(data, &newRegistry)
+	assert.NoError(t, err)
+	assert.Equal(t, registry, newRegistry)
+}
+
+func TestIsSameVersion(t *testing.T) {
+	registry1 := Extensions{"internal:runtime_extension_v1", "valid_extension"}
+	registry2 := Extensions{"internal:runtime_extension_v1", "valid_extension"}
+	registry3 := Extensions{"internal:runtime_extension_v1"}
+
+	err := registry1.IsSameVersion(registry2)
+	assert.NoError(t, err)
+
+	err = registry1.IsSameVersion(registry3)
+	assert.Error(t, err)
+}
+
+func TestRegisterALotOfExtensions(t *testing.T) {
+	registry, _ := NewExtensionRegistry(false)
+	for i := 0; i < 10000; i++ {
+		ext := fmt.Sprintf("valid_extension_%d", i)
+		err := registry.Register([]string{ext})
+		if err != nil {
+			t.Fatalf("Failed to register extension: %s, error: %v", ext, err)
+		}
+	}
+
+	if len(registry) != 10000 {
+		t.Errorf("Expected 10000 extensions, got %d", len(registry))
+	}
+}
+
+func TestExtensionsValuerAndScanner(t *testing.T) {
+	var err error
+	db, err := sql.Open("sqlite3", ":memory:")
+	assert.NoError(t, err)
+
+	defer db.Close()
+
+	_, err = db.Exec("CREATE TABLE internal_cluster_members (api_extensions TEXT NOT NULL DEFAULT '[]')")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	exts := Extensions{"internal:runtime_extension_v1", "microovn_custom_encapsulation_ip"}
+	res, err := db.Exec("INSERT INTO internal_cluster_members (api_extensions) VALUES (?)", exts)
+	assert.NoError(t, err)
+	n, err := res.RowsAffected()
+	assert.NoError(t, err)
+	assert.Equal(t, n, int64(1))
+
+	// Retrieve the data
+	var retrievedExts Extensions
+	row := db.QueryRow("SELECT api_extensions FROM internal_cluster_members")
+	row.Scan(&retrievedExts)
+	assert.NoError(t, err)
+
+	// Check if the retrieved data is equal to the original data
+	err = exts.IsSameVersion(retrievedExts)
+	assert.NoError(t, err)
+}

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -117,6 +117,12 @@ func clusterPost(s *state.State, r *http.Request) response.Response {
 		return response.SyncResponse(true, tokenResponse)
 	}
 
+	// Check if the joining node's extensions are compatible with the leader's.
+	err = s.Extensions.IsSameVersion(req.Extensions)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	err = s.Database.Transaction(s.Context, func(ctx context.Context, tx *sql.Tx) error {
 		dbClusterMember := cluster.InternalClusterMember{
 			Name:           req.Name,
@@ -124,6 +130,7 @@ func clusterPost(s *state.State, r *http.Request) response.Response {
 			Certificate:    req.Certificate.String(),
 			SchemaInternal: req.SchemaInternalVersion,
 			SchemaExternal: req.SchemaExternalVersion,
+			APIExtensions:  req.Extensions,
 			Heartbeat:      time.Time{},
 			Role:           cluster.Pending,
 		}

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -81,6 +81,7 @@ func joinWithToken(state *state.State, req *internalTypes.Control) response.Resp
 		SchemaInternalVersion: internalVersion,
 		SchemaExternalVersion: externalVersion,
 		Secret:                token.Secret,
+		Extensions:            state.Extensions,
 	}
 
 	// Get a client to the target address.

--- a/internal/rest/types/cluster.go
+++ b/internal/rest/types/cluster.go
@@ -3,18 +3,20 @@ package types
 import (
 	"time"
 
+	"github.com/canonical/microcluster/internal/extensions"
 	"github.com/canonical/microcluster/rest/types"
 )
 
 // ClusterMember represents information about a dqlite cluster member.
 type ClusterMember struct {
 	ClusterMemberLocal
-	Role                  string       `json:"role" yaml:"role"`
-	SchemaInternalVersion uint64       `json:"schema_internal_version" yaml:"schema_internal_version"`
-	SchemaExternalVersion uint64       `json:"schema_external_version" yaml:"schema_external_version"`
-	LastHeartbeat         time.Time    `json:"last_heartbeat" yaml:"last_heartbeat"`
-	Status                MemberStatus `json:"status" yaml:"status"`
-	Secret                string       `json:"secret" yaml:"secret"`
+	Role                  string                `json:"role" yaml:"role"`
+	SchemaInternalVersion uint64                `json:"schema_internal_version" yaml:"schema_internal_version"`
+	SchemaExternalVersion uint64                `json:"schema_external_version" yaml:"schema_external_version"`
+	LastHeartbeat         time.Time             `json:"last_heartbeat" yaml:"last_heartbeat"`
+	Status                MemberStatus          `json:"status" yaml:"status"`
+	Extensions            extensions.Extensions `json:"extensions" yaml:"extensions"`
+	Secret                string                `json:"secret" yaml:"secret"`
 }
 
 // ClusterMemberLocal represents local information about a new cluster member.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -10,6 +10,7 @@ import (
 	"github.com/canonical/microcluster/client"
 	"github.com/canonical/microcluster/internal/db"
 	"github.com/canonical/microcluster/internal/endpoints"
+	"github.com/canonical/microcluster/internal/extensions"
 	internalClient "github.com/canonical/microcluster/internal/rest/client"
 	"github.com/canonical/microcluster/internal/sys"
 	"github.com/canonical/microcluster/internal/trust"
@@ -55,6 +56,9 @@ type State struct {
 
 	// Stop fully stops the daemon, its database, and all listeners.
 	Stop func() (exit func(), stopErr error)
+
+	// Runtime extensions.
+	Extensions extensions.Extensions
 }
 
 // StopListeners stops the network listeners and the fsnotify listener.

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -72,7 +72,7 @@ func App(args Args) (*MicroCluster, error) {
 // - `extensionsSchema` is a list of schema updates in the order that they should be applied.
 // - `extensionsAPI` is a list of endpoints to be served over `/1.0`.
 // - `hooks` are a set of functions that trigger at certain points during cluster communication.
-func (m *MicroCluster) Start(ctx context.Context, extensionsAPI []rest.Endpoint, extensionsSchema []schema.Update, hooks *config.Hooks) error {
+func (m *MicroCluster) Start(ctx context.Context, extensionsAPI []rest.Endpoint, extensionsSchema []schema.Update, apiExtensions []string, hooks *config.Hooks) error {
 	// Initialize the logger.
 	err := logger.InitLogger(m.FileSystem.LogFile, "", m.args.Verbose, m.args.Debug, nil)
 	if err != nil {
@@ -89,7 +89,7 @@ func (m *MicroCluster) Start(ctx context.Context, extensionsAPI []rest.Endpoint,
 	ctx, cancel := signal.NotifyContext(ctx, unix.SIGPWR, unix.SIGTERM, unix.SIGINT, unix.SIGQUIT)
 	defer cancel()
 
-	err = d.Run(ctx, m.args.ListenPort, m.FileSystem.StateDir, m.FileSystem.SocketGroup, extensionsAPI, extensionsSchema, hooks)
+	err = d.Run(ctx, m.args.ListenPort, m.FileSystem.StateDir, m.FileSystem.SocketGroup, extensionsAPI, extensionsSchema, apiExtensions, hooks)
 	if err != nil {
 		return fmt.Errorf("Daemon stopped with error: %w", err)
 	}


### PR DESCRIPTION
Introducing an 'extensions' endpoint in MicroCluster would help in scenarios where service A (backed by MicroCluster) needs to check that service B (also backed by MicroCluster) has a certain feature (e.g, does the installed version of MicroOVN supports custom encapsulation ip that has been entered by a user in a MicroCloud setup)

Required by https://github.com/canonical/microovn/pull/121 and https://github.com/canonical/microovn/pull/113 and https://github.com/canonical/microcloud/pull/245 