### PR TITLE
include name in encoded token when using `ListJoinTokens()`

### DIFF
--- a/cluster/token_records.go
+++ b/cluster/token_records.go
@@ -43,6 +43,7 @@ type InternalTokenRecordFilter struct {
 // ToAPI converts the InternalTokenRecord to a full token and returns an API compatible struct.
 func (t *InternalTokenRecord) ToAPI(clusterCert *x509.Certificate, joinAddresses []types.AddrPort) (*internalTypes.TokenRecord, error) {
 	token := internalTypes.Token{
+		Name:          t.Name,
 		Secret:        t.Secret,
 		Fingerprint:   shared.CertFingerprint(clusterCert),
 		JoinAddresses: joinAddresses,


### PR DESCRIPTION
### Summary

When using `ListJoinTokens()` the tokens do not match the join token that was given by `NewJoinToken()`, as it does not include the token name in the encoded string.

Note that this does not affect joining nodes, as either of the tokens works (the `name` field of the token is not used).