### PR TITLE
ensure daemon stop sequence runs with if context is cancelled

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -70,7 +70,7 @@ func NewDaemon(ctx context.Context, project string) *Daemon {
 	return &Daemon{
 		ShutdownCtx:    ctx,
 		ShutdownCancel: cancel,
-		ShutdownDoneCh: make(chan error),
+		ShutdownDoneCh: make(chan error, 1),
 		ReadyChan:      make(chan struct{}),
 		project:        project,
 	}


### PR DESCRIPTION
### Summary

Ensure `microcluster` shutdown sequence does not hang

### Changes

- Use a `sync.Once` to call the daemon.Stop() sequence
- Don't check if ShutdownCtx is already cancelled, that will fail the check if the parent context is cancelled by other means.
- Use a buffered channel to retrieve the result of the Stop(), otherwise the goroutine can block while sending at `ShutdownDoneCh`

### Details

Without the proposed changes, trying to stop a microcluster service often hangs with. This could be because there is a race condition: if the shutdownCtx is already cancelled, then the goroutine that calls `d.Stop()` will never be called.

```
Mar 15 08:05:24 t1 k8s.k8sd[1677]: + exec /snap/k8s/x1/bin/k8sd --port=6400 --state-dir=/var/snap/k8s/common/var/lib/k8sd/state
Mar 15 08:05:24 t1 k8s.k8sd[1677]: time="2024-03-15T08:05:24Z" level=warning msg="Failed to parse new remotes from truststore"
Mar 15 08:05:24 t1 k8s.k8sd[1677]: time="2024-03-15T08:05:24Z" level=info msg=" - binding control socket" socket=/var/snap/k8s/common/var/lib/k8sd/state/control.socket
Mar 15 08:05:24 t1 k8s.k8sd[1677]: time="2024-03-15T08:05:24Z" level=warning msg="microcluster database is uninitialized"
Mar 15 08:05:24 t1 k8s.k8sd[1677]: time="2024-03-15T08:05:24Z" level=warning msg="Failed to parse new remotes from truststore"
Mar 15 08:05:24 t1 k8s.k8sd[1677]: time="2024-03-15T08:05:24Z" level=info msg=" - binding https socket" network="[::]:6400"

<--- issued "snap stop k8s.k8sd"

Mar 15 08:05:36 t1 k8s.k8sd[1677]: time="2024-03-15T08:05:36Z" level=info msg="Closing filesystem watcher"
Mar 15 08:05:36 t1 k8s.k8sd[1677]: time="2024-03-15T08:05:36Z" level=info msg="Received signal" signal=terminated
Mar 15 08:05:36 t1 k8s.k8sd[1677]: time="2024-03-15T08:05:36Z" level=warning msg="Ignoring signal, shutdown already in progress" signal=terminated
Mar 15 08:05:36 t1 systemd[1]: Stopping Service for snap application k8s.k8sd...
Mar 15 08:06:06 t1 systemd[1]: snap.k8s.k8sd.service: State 'stop-sigterm' timed out. Killing.
Mar 15 08:06:06 t1 systemd[1]: snap.k8s.k8sd.service: Killing process 1677 (k8sd) with signal SIGKILL.
Mar 15 08:06:06 t1 systemd[1]: snap.k8s.k8sd.service: Killing process 1702 (k8sd) with signal SIGKILL.
Mar 15 08:06:06 t1 systemd[1]: snap.k8s.k8sd.service: Killing process 1703 (k8sd) with signal SIGKILL.
Mar 15 08:06:06 t1 systemd[1]: snap.k8s.k8sd.service: Killing process 1705 (k8sd) with signal SIGKILL.
Mar 15 08:06:06 t1 systemd[1]: snap.k8s.k8sd.service: Killing process 1706 (k8sd) with signal SIGKILL.
Mar 15 08:06:06 t1 systemd[1]: snap.k8s.k8sd.service: Killing process 1707 (k8sd) with signal SIGKILL.
Mar 15 08:06:06 t1 systemd[1]: snap.k8s.k8sd.service: Killing process 1708 (k8sd) with signal SIGKILL.
Mar 15 08:06:06 t1 systemd[1]: snap.k8s.k8sd.service: Killing process 1709 (k8sd) with signal SIGKILL.
Mar 15 08:06:06 t1 systemd[1]: snap.k8s.k8sd.service: Killing process 1710 (k8sd) with signal SIGKILL.
Mar 15 08:06:06 t1 systemd[1]: snap.k8s.k8sd.service: Killing process 1712 (k8sd) with signal SIGKILL.
Mar 15 08:06:06 t1 systemd[1]: snap.k8s.k8sd.service: Killing process 1713 (k8sd) with signal SIGKILL.
Mar 15 08:06:06 t1 systemd[1]: snap.k8s.k8sd.service: Killing process 1714 (n/a) with signal SIGKILL.
Mar 15 08:06:06 t1 systemd[1]: snap.k8s.k8sd.service: Killing process 1715 (n/a) with signal SIGKILL.
Mar 15 08:06:06 t1 systemd[1]: snap.k8s.k8sd.service: Main process exited, code=killed, status=9/KILL
Mar 15 08:06:06 t1 systemd[1]: snap.k8s.k8sd.service: Failed with result 'timeout'.
Mar 15 08:06:06 t1 systemd[1]: Stopped Service for snap application k8s.k8sd.
Mar 15 08:06:20 t1 systemd[1]: Started Service for snap application k8s.k8sd.
```


### With changes

Below are the shutdown logs with the applied changes (does not hang anymore):

```
Mar 15 08:09:03 t1 k8s.k8sd[3586]: time="2024-03-15T08:09:03Z" level=info msg="Preparing statements for Go project \"k8sd\""


<-- issued "snap stop k8s.k8sd"


Mar 15 08:10:06 t1 k8s.k8sd[3586]: time="2024-03-15T08:10:06Z" level=info msg="Received signal" signal=terminated
Mar 15 08:10:06 t1 k8s.k8sd[3586]: time="2024-03-15T08:10:06Z" level=warning msg="Ignoring signal, shutdown already in progress" signal=terminated
Mar 15 08:10:06 t1 k8s.k8sd[3586]: time="2024-03-15T08:10:06Z" level=info msg="Initiate daemon stop sequence"
Mar 15 08:10:06 t1 k8s.k8sd[3586]: time="2024-03-15T08:10:06Z" level=info msg="Closing filesystem watcher"
Mar 15 08:10:06 t1 k8s.k8sd[3586]: time="2024-03-15T08:10:06Z" level=error msg="Failed to initiate heartbeat round" address="10.0.0.47:6400" error="Post \"http://control.socket/cluster/internal/heartbeat\": context canceled"
Mar 15 08:10:06 t1 systemd[1]: Stopping Service for snap application k8s.k8sd...
Mar 15 08:10:06 t1 k8s.k8sd[3586]: time="2024-03-15T08:10:06Z" level=info msg="Stopping REST API handler - closing socket" socket=/var/snap/k8s/common/var/lib/k8sd/state/control.socket
Mar 15 08:10:06 t1 k8s.k8sd[3586]: time="2024-03-15T08:10:06Z" level=info msg="Received shutdown signal - aborting unix socket server startup"
Mar 15 08:10:06 t1 k8s.k8sd[3586]: time="2024-03-15T08:10:06Z" level=info msg="Stopping REST API handler - closing https socket" address="10.0.0.47:6400"
Mar 15 08:10:06 t1 k8s.k8sd[3586]: time="2024-03-15T08:10:06Z" level=info msg="Received shutdown signal - aborting https socket server startup"
Mar 15 08:10:06 t1 k8s.k8sd[3586]: time="2024-03-15T08:10:06Z" level=info msg="Daemon stopped"
Mar 15 08:10:06 t1 systemd[1]: snap.k8s.k8sd.service: Succeeded.
Mar 15 08:10:06 t1 systemd[1]: Stopped Service for snap application k8s.k8sd.
Mar 15 08:10:06 t1 systemd[1]: Started Service for snap application k8s.k8sd.
```