### PR TITLE
Use one context for cancelling the daemon

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -65,11 +65,8 @@ type Daemon struct {
 }
 
 // NewDaemon initializes the Daemon context and channels.
-func NewDaemon(ctx context.Context, project string) *Daemon {
-	ctx, cancel := context.WithCancel(ctx)
+func NewDaemon(project string) *Daemon {
 	return &Daemon{
-		shutdownCtx:    ctx,
-		shutdownCancel: cancel,
 		shutdownDoneCh: make(chan error),
 		ReadyChan:      make(chan struct{}),
 		project:        project,
@@ -77,7 +74,9 @@ func NewDaemon(ctx context.Context, project string) *Daemon {
 }
 
 // Init initializes the Daemon with the given configuration, and starts the database.
-func (d *Daemon) Init(listenPort string, stateDir string, socketGroup string, extendedEndpoints []rest.Endpoint, schemaExtensions map[int]schema.Update, hooks *config.Hooks) error {
+func (d *Daemon) Init(ctx context.Context, listenPort string, stateDir string, socketGroup string, extendedEndpoints []rest.Endpoint, schemaExtensions map[int]schema.Update, hooks *config.Hooks) error {
+	d.shutdownCtx, d.shutdownCancel = context.WithCancel(ctx)
+
 	if stateDir == "" {
 		stateDir = os.Getenv(sys.StateDir)
 	}

--- a/internal/rest/resources/shutdown.go
+++ b/internal/rest/resources/shutdown.go
@@ -27,7 +27,7 @@ func shutdownPost(state *state.State, r *http.Request) response.Response {
 		<-state.ReadyCh // Wait for daemon to start.
 
 		// Run shutdown sequence synchronously.
-		stopErr := state.Stop()
+		exit, stopErr := state.Stop()
 		err := response.SmartError(stopErr).Render(w)
 		if err != nil {
 			return err
@@ -44,7 +44,7 @@ func shutdownPost(state *state.State, r *http.Request) response.Response {
 		// Send result of d.Stop() to cmdDaemon so that process stops with correct exit code from Stop().
 		go func() {
 			<-r.Context().Done() // Wait until request is finished.
-			state.ShutdownDoneCh <- stopErr
+			exit()
 		}()
 
 		return nil

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -56,7 +56,7 @@ type State struct {
 	StartAPI func(bootstrap bool, initConfig map[string]string, newConfig *trust.Location, joinAddresses ...string) error
 
 	// Stop fully stops the daemon, its database, and all listeners.
-	Stop func() error
+	Stop func() (exit func(), stopErr error)
 }
 
 // StopListeners stops the network listeners and the fsnotify listener.

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -82,14 +82,11 @@ func (m *MicroCluster) Start(apiEndpoints []rest.Endpoint, schemaExtensions map[
 	defer logger.Info("Daemon stopped")
 	d := daemon.NewDaemon(cluster.GetCallerProject())
 
-	sigCh := make(chan os.Signal, 1)
-	signal.Notify(sigCh, unix.SIGPWR)
-	signal.Notify(sigCh, unix.SIGINT)
-	signal.Notify(sigCh, unix.SIGQUIT)
-	signal.Notify(sigCh, unix.SIGTERM)
-
 	chIgnore := make(chan os.Signal, 1)
 	signal.Notify(chIgnore, unix.SIGHUP)
+
+	ctx, cancel := signal.NotifyContext(m.ctx, unix.SIGPWR, unix.SIGTERM, unix.SIGINT, unix.SIGQUIT)
+	defer cancel()
 
 	err = d.Init(ctx, m.args.ListenPort, m.FileSystem.StateDir, m.FileSystem.SocketGroup, apiEndpoints, schemaExtensions, hooks)
 	if err != nil {

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -80,7 +80,7 @@ func (m *MicroCluster) Start(apiEndpoints []rest.Endpoint, schemaExtensions map[
 
 	// Start up a daemon with a basic control socket.
 	defer logger.Info("Daemon stopped")
-	d := daemon.NewDaemon(m.ctx, cluster.GetCallerProject())
+	d := daemon.NewDaemon(cluster.GetCallerProject())
 
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, unix.SIGPWR)
@@ -91,7 +91,7 @@ func (m *MicroCluster) Start(apiEndpoints []rest.Endpoint, schemaExtensions map[
 	chIgnore := make(chan os.Signal, 1)
 	signal.Notify(chIgnore, unix.SIGHUP)
 
-	err = d.Init(m.args.ListenPort, m.FileSystem.StateDir, m.FileSystem.SocketGroup, apiEndpoints, schemaExtensions, hooks)
+	err = d.Init(ctx, m.args.ListenPort, m.FileSystem.StateDir, m.FileSystem.SocketGroup, apiEndpoints, schemaExtensions, hooks)
 	if err != nil {
 		return fmt.Errorf("Unable to start daemon: %w", err)
 	}


### PR DESCRIPTION
Simplifies the daemon's blocking action in response to #93 by @neoaggelos and a closer look at the `Daemon` and `App`.

This moves the blocking loop from `app.Start` into `daemon.Run` (previously `daemon.Init`) so that we no longer have to export the related context fields. Eventually they can be removed, but this prevents us from committing to them further in any solution to the bug that #93 addresses.

Additionally, `app.Start` now handles signals with `signal.NotifyContext`, which lets us treat all triggers of the daemon stop sequence in the same way, with one context. 

Any context passed to `app.Start` will be wrapped in a `signal.NotifyContext`, and the resulting child context will be used in `daemon.Run` to block on until it cancels from a signal or some other source outside the scope of `microcluster.App`. 

In order to not call `d.stop` more than once, l took some inspiration from #93, and made the method itself a `sync.OnceValue` when we instantiate the daemon. This also lets us catch the edge case where a REST API shutdown request and a direct shutdown signal happen concurrently by having `state.Stop` also use the same `sync.Once` stop function as the daemon itself.

All in all, this reduces the blocking loop to just 2 cases:
* Waiting for the parent context to cancel (from a signal, or unknown source), which means we should run the stop sequence
* Waiting to receive from `d.shutdownDoneCh`, which should be immediate in the above case, but might also come from the REST API.