### PR TITLE
Fix golangci lint

### DIFF
--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -3,9 +3,7 @@ package main
 
 import (
 	"context"
-	"math/rand"
 	"os"
-	"time"
 
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/spf13/cobra"
@@ -156,10 +154,6 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	return m.Start(api.Endpoints, database.SchemaExtensions, exampleHooks)
-}
-
-func init() {
-	rand.Seed(time.Now().UnixNano())
 }
 
 func main() {

--- a/internal/db/update/schema.go
+++ b/internal/db/update/schema.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"sort"
 	"strings"
@@ -233,7 +232,7 @@ func execFromFile(ctx context.Context, tx *sql.Tx, path string, hook schema.Hook
 		return nil
 	}
 
-	bytes, err := ioutil.ReadFile(path)
+	bytes, err := os.ReadFile(path)
 	if err != nil {
 		return fmt.Errorf("failed to read file: %w", err)
 	}

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -336,7 +336,7 @@ func (m *MicroCluster) RemoteClient(address string) (*client.Client, error) {
 func (m *MicroCluster) SQL(query string) (string, *internalTypes.SQLBatch, error) {
 	if query == "-" {
 		// Read from stdin
-		bytes, err := ioutil.ReadAll(os.Stdin)
+		bytes, err := io.ReadAll(os.Stdin)
 		if err != nil {
 			return "", nil, fmt.Errorf("Failed to read from stdin: %w", err)
 		}


### PR DESCRIPTION
I fixed these while trying to run the tests... before I discovered that there are none. Didn't want to waste the work.

Fixes golangci-lint `SA1019`

EDIT: This should probably wait to be merged until after #99, as the deprecation occurred at in go 1.20.