### PR TITLE
trust: expose trust.Location type

### DIFF
--- a/trust/trust.go
+++ b/trust/trust.go
@@ -1,0 +1,6 @@
+package trust
+
+import "github.com/canonical/microcluster/internal/trust"
+
+// Location exposes the internal trust location type for use with extended API handlers.
+type Location = trust.Location


### PR DESCRIPTION
### Summary

Expose `trust.Location` type so that extended handlers can use `state.StartAPI()`

This is similar to https://github.com/canonical/microcluster/blob/0dcc76f5a09c8288da6a5aebe31f4c8e00d26a5a/state/state.go#L6