### PR TITLE
Specify context in all microcluster methods

### DIFF
--- a/example/cmd/microctl/cluster_members.go
+++ b/example/cmd/microctl/cluster_members.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"sort"
 
 	cli "github.com/canonical/lxd/shared/cmd"
@@ -54,7 +53,7 @@ func (c *cmdClusterMembersList) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	// Get all state information for MicroCluster.
-	m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
+	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
 	if err != nil {
 		return err
 	}
@@ -74,7 +73,7 @@ func (c *cmdClusterMembersList) Run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	clusterMembers, err := client.GetClusterMembers(context.Background())
+	clusterMembers, err := client.GetClusterMembers(cmd.Context())
 	if err != nil {
 		return err
 	}
@@ -113,7 +112,7 @@ func (c *cmdClusterMemberRemove) Run(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
 	}
 
-	m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
+	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
 	if err != nil {
 		return err
 	}
@@ -123,7 +122,7 @@ func (c *cmdClusterMemberRemove) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = client.DeleteClusterMember(context.Background(), args[0], c.flagForce)
+	err = client.DeleteClusterMember(cmd.Context(), args[0], c.flagForce)
 	if err != nil {
 		return err
 	}

--- a/example/cmd/microctl/extended_cmd.go
+++ b/example/cmd/microctl/extended_cmd.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 
 	microClient "github.com/canonical/microcluster/client"
@@ -29,7 +28,7 @@ func (c *cmdExtended) Run(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
 	}
 
-	m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
+	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
 	if err != nil {
 		return err
 	}
@@ -45,7 +44,7 @@ func (c *cmdExtended) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	outMsg, err := client.ExtendedPostCmd(context.Background(), cli, nil)
+	outMsg, err := client.ExtendedPostCmd(cmd.Context(), cli, nil)
 	if err != nil {
 		return err
 	}

--- a/example/cmd/microctl/main_init.go
+++ b/example/cmd/microctl/main_init.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -54,12 +55,15 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 		conf[key] = value
 	}
 
+	ctx, cancel := context.WithTimeout(cmd.Context(), 30*time.Second)
+	defer cancel()
+
 	if c.flagBootstrap {
-		return m.NewCluster(cmd.Context(), args[0], args[1], conf, time.Second*30)
+		return m.NewCluster(ctx, args[0], args[1], conf)
 	}
 
 	if c.flagToken != "" {
-		return m.JoinCluster(cmd.Context(), args[0], args[1], c.flagToken, conf, time.Second*30)
+		return m.JoinCluster(ctx, args[0], args[1], c.flagToken, conf)
 	}
 
 	return fmt.Errorf("Option must be one of bootstrap or token")

--- a/example/cmd/microctl/main_init.go
+++ b/example/cmd/microctl/main_init.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -40,7 +39,7 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
 	}
 
-	m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
+	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
 	if err != nil {
 		return fmt.Errorf("Unable to configure MicroCluster: %w", err)
 	}
@@ -56,11 +55,11 @@ func (c *cmdInit) Run(cmd *cobra.Command, args []string) error {
 	}
 
 	if c.flagBootstrap {
-		return m.NewCluster(args[0], args[1], conf, time.Second*30)
+		return m.NewCluster(cmd.Context(), args[0], args[1], conf, time.Second*30)
 	}
 
 	if c.flagToken != "" {
-		return m.JoinCluster(args[0], args[1], c.flagToken, conf, time.Second*30)
+		return m.JoinCluster(cmd.Context(), args[0], args[1], c.flagToken, conf, time.Second*30)
 	}
 
 	return fmt.Errorf("Option must be one of bootstrap or token")

--- a/example/cmd/microctl/shutdown.go
+++ b/example/cmd/microctl/shutdown.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"context"
-
 	"github.com/canonical/microcluster/microcluster"
 	"github.com/spf13/cobra"
 )
@@ -26,7 +24,7 @@ func (c *cmdShutdown) Run(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
 	}
 
-	m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
+	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
 	if err != nil {
 		return err
 	}
@@ -40,7 +38,7 @@ func (c *cmdShutdown) Run(cmd *cobra.Command, args []string) error {
 	go func() {
 		defer close(chResult)
 
-		err := client.ShutdownDaemon(context.Background())
+		err := client.ShutdownDaemon(cmd.Context())
 		if err != nil {
 			chResult <- err
 			return

--- a/example/cmd/microctl/sql.go
+++ b/example/cmd/microctl/sql.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"os"
 
@@ -36,13 +35,13 @@ func (c *cmdSQL) Run(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
+	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
 	if err != nil {
 		return err
 	}
 
 	query := args[0]
-	dump, batch, err := m.SQL(query)
+	dump, batch, err := m.SQL(cmd.Context(), query)
 	if err != nil {
 		return err
 	}

--- a/example/cmd/microctl/tokens.go
+++ b/example/cmd/microctl/tokens.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"context"
 	"fmt"
 	"sort"
 
@@ -56,12 +55,12 @@ func (c *cmdTokensAdd) Run(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
 	}
 
-	m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
+	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
 	if err != nil {
 		return err
 	}
 
-	token, err := m.NewJoinToken(args[0])
+	token, err := m.NewJoinToken(cmd.Context(), args[0])
 	if err != nil {
 		return err
 	}
@@ -90,12 +89,12 @@ func (c *cmdTokensList) Run(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
 	}
 
-	m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
+	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
 	if err != nil {
 		return err
 	}
 
-	records, err := m.ListJoinTokens()
+	records, err := m.ListJoinTokens(cmd.Context())
 	if err != nil {
 		return err
 	}
@@ -130,12 +129,12 @@ func (c *cmdTokensRevoke) Run(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
 	}
 
-	m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
+	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
 	if err != nil {
 		return err
 	}
 
-	err = m.RevokeJoinToken(args[0])
+	err = m.RevokeJoinToken(cmd.Context(), args[0])
 	if err != nil {
 		return err
 	}

--- a/example/cmd/microctl/waitready.go
+++ b/example/cmd/microctl/waitready.go
@@ -1,6 +1,9 @@
 package main
 
 import (
+	"context"
+	"time"
+
 	"github.com/canonical/microcluster/microcluster"
 	"github.com/spf13/cobra"
 )
@@ -33,5 +36,11 @@ func (c *cmdWaitready) Run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	return m.Ready(cmd.Context(), c.flagTimeout)
+	ctx, cancel := cmd.Context(), func() {}
+	if c.flagTimeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(c.flagTimeout)*time.Second)
+	}
+	defer cancel()
+
+	return m.Ready(ctx)
 }

--- a/example/cmd/microctl/waitready.go
+++ b/example/cmd/microctl/waitready.go
@@ -1,8 +1,6 @@
 package main
 
 import (
-	"context"
-
 	"github.com/canonical/microcluster/microcluster"
 	"github.com/spf13/cobra"
 )
@@ -30,10 +28,10 @@ func (c *cmdWaitready) Run(cmd *cobra.Command, args []string) error {
 		return cmd.Help()
 	}
 
-	m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
+	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
 	if err != nil {
 		return err
 	}
 
-	return m.Ready(c.flagTimeout)
+	return m.Ready(cmd.Context(), c.flagTimeout)
 }

--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -2,7 +2,6 @@
 package main
 
 import (
-	"context"
 	"os"
 
 	"github.com/canonical/lxd/shared/logger"
@@ -59,7 +58,7 @@ func (c *cmdDaemon) Command() *cobra.Command {
 }
 
 func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
-	m, err := microcluster.App(context.Background(), microcluster.Args{StateDir: c.flagStateDir, SocketGroup: c.flagSocketGroup, Verbose: c.global.flagLogVerbose, Debug: c.global.flagLogDebug})
+	m, err := microcluster.App(microcluster.Args{StateDir: c.flagStateDir, SocketGroup: c.flagSocketGroup, Verbose: c.global.flagLogVerbose, Debug: c.global.flagLogDebug})
 	if err != nil {
 		return err
 	}
@@ -153,7 +152,7 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 		},
 	}
 
-	return m.Start(api.Endpoints, database.SchemaExtensions, exampleHooks)
+	return m.Start(cmd.Context(), api.Endpoints, database.SchemaExtensions, exampleHooks)
 }
 
 func main() {

--- a/internal/rest/client/control.go
+++ b/internal/rest/client/control.go
@@ -2,19 +2,11 @@ package client
 
 import (
 	"context"
-	"time"
 
 	"github.com/canonical/microcluster/internal/rest/types"
 )
 
 // ControlDaemon posts control data to the daemon.
-func (c *Client) ControlDaemon(ctx context.Context, args types.Control, timeout time.Duration) error {
-	if timeout == 0 {
-		return c.QueryStruct(ctx, "POST", ControlEndpoint, nil, args, nil)
-	}
-
-	queryCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
-
-	return c.QueryStruct(queryCtx, "POST", ControlEndpoint, nil, args, nil)
+func (c *Client) ControlDaemon(ctx context.Context, args types.Control) error {
+	return c.QueryStruct(ctx, "POST", ControlEndpoint, nil, args, nil)
 }


### PR DESCRIPTION
### Summary

- Remove context from `*microcluster.MicroCluster` struct
- Pass context during `(*MicroCluster).Start`, not during creation
- Update all `(*MicroCluster)` methods to accept a context and use that instead
- Update `microctl` for new API, use `cmd.Context()` instead of `context.Background()`
- Update `microd` for new API, use `cmd.Context()` instead of `context.Background()`
