### PR TITLE
Clearer errors and logs

### DIFF
--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -83,7 +83,6 @@ func clusterPost(s *state.State, r *http.Request) response.Response {
 		return response.BadRequest(err)
 	}
 
-	// Set a 5 second timeout in case dqlite locks up.
 	ctx, cancel := context.WithTimeout(s.Context, time.Second*30)
 	defer cancel()
 

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -84,6 +84,7 @@ func joinWithToken(state *state.State, req *internalTypes.Control) response.Resp
 	}
 
 	// Get a client to the target address.
+	var lastErr error
 	var joinInfo *internalTypes.TokenResponse
 	for _, addr := range token.JoinAddresses {
 		url := api.NewURL().Scheme("https").Host(addr.String())
@@ -106,13 +107,14 @@ func joinWithToken(state *state.State, req *internalTypes.Control) response.Resp
 		joinInfo, err = d.AddClusterMember(context.Background(), newClusterMember)
 		if err != nil {
 			logger.Error("Unable to complete cluster join request", logger.Ctx{"address": addr.String(), "error": err})
+			lastErr = err
 		} else {
 			break
 		}
 	}
 
 	if joinInfo == nil {
-		return response.SmartError(fmt.Errorf("Failed to join cluster with the given join token"))
+		return response.SmartError(fmt.Errorf("%d join attempts were unsuccessful. Last error: %w", len(token.JoinAddresses), lastErr))
 	}
 
 	err = util.WriteCert(state.OS.StateDir, "cluster", []byte(joinInfo.ClusterCert.String()), []byte(joinInfo.ClusterKey), nil)

--- a/internal/trust/remotes.go
+++ b/internal/trust/remotes.go
@@ -73,7 +73,9 @@ func (r *Remotes) Load(dir string) error {
 		remoteData[remote.Name] = *remote
 	}
 
-	if len(remoteData) == 0 {
+	// If the refreshed truststore data is empty, and we already had data in the truststore,
+	// abort the refresh because an initialized system should always have truststore entries.
+	if len(remoteData) == 0 && len(r.data) != 0 {
 		logger.Warn("Failed to parse new remotes from truststore")
 
 		return nil


### PR DESCRIPTION
* Makes the cluster join token error more descriptive to help debug join errors.
* Suppresses truststore initialization error, as we won't have any entries when the daemon first starts.