### PR TITLE
Add truststore API

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -15,8 +15,8 @@ type Client struct {
 	client.Client
 }
 
-// IsForwardedRequest determines if this request has been forwarded from another cluster member.
-func IsForwardedRequest(r *http.Request) bool {
+// IsNotification determines if this request is to be considered a cluster-wide notification.
+func IsNotification(r *http.Request) bool {
 	return r.Header.Get("User-Agent") == clusterRequest.UserAgentNotifier
 }
 

--- a/example/api/extended.go
+++ b/example/api/extended.go
@@ -27,9 +27,9 @@ var extendedCmd = rest.Endpoint{
 // This example shows how to forward a request to other cluster members.
 func cmdPost(state *state.State, r *http.Request) response.Response {
 	// Check the user agent header to check if we are the notifying cluster member.
-	if !client.IsForwardedRequest(r) {
+	if !client.IsNotification(r) {
 		// Get a collection of clients every other cluster member, with the notification user-agent set.
-		cluster, err := state.Cluster(r)
+		cluster, err := state.Cluster(true)
 		if err != nil {
 			return response.SmartError(fmt.Errorf("Failed to get a client for every cluster member: %w", err))
 		}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -445,26 +445,17 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 	}
 
 	// Get a client for every other cluster member in the newly refreshed local store.
-	cluster := make(client.Cluster, 0, d.trustStore.Remotes().Count()-1)
-	for _, addr := range d.trustStore.Remotes().Addresses() {
-		if d.address.URL.Host == addr.String() {
-			continue
-		}
-
-		publicKey, err := d.ClusterCert().PublicKeyX509()
-		if err != nil {
-			return err
-		}
-
-		url := api.NewURL().Scheme("https").Host(addr.String())
-		c, err := internalClient.New(*url, d.ServerCert(), publicKey, true)
-		if err != nil {
-			return err
-		}
-
-		cluster = append(cluster, client.Client{Client: *c})
+	publicKey, err := d.ClusterCert().PublicKeyX509()
+	if err != nil {
+		return err
 	}
 
+	cluster, err := d.trustStore.Remotes().Cluster(true, d.ServerCert(), publicKey)
+	if err != nil {
+		return err
+	}
+
+	localMemberInfo := internalTypes.ClusterMemberLocal{Name: localNode.Name, Address: localNode.Address, Certificate: localNode.Certificate}
 	if len(joinAddresses) > 0 {
 		err = d.hooks.PreJoin(d.State(), initConfig)
 		if err != nil {
@@ -472,38 +463,21 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 		}
 	}
 
-	// Send notification that this node is upgraded to all other cluster members.
+	// Tell the other nodes that this system is up.
 	err = cluster.Query(d.shutdownCtx, true, func(ctx context.Context, c *client.Client) error {
-		path := c.URL()
-		parts := strings.Split(string(internalClient.InternalEndpoint), "/")
-		parts = append(parts, "database")
-		path = *path.Path(parts...)
-		upgradeRequest, err := http.NewRequest("PATCH", path.String(), nil)
+		// No need to send a request to ourselves.
+		if d.address.URL.Host == c.URL().URL.Host {
+			return nil
+		}
+
+		// Send notification about this node's dqlite version to all other cluster members.
+		err = d.sendUpgradeNotification(ctx, c)
 		if err != nil {
 			return err
 		}
 
-		upgradeRequest.Header.Set("X-Dqlite-Version", fmt.Sprintf("%d", 1))
-		upgradeRequest = upgradeRequest.WithContext(ctx)
-
-		resp, err := c.Client.Do(upgradeRequest)
-		if err != nil {
-			logger.Error("Failed to send database upgrade request", logger.Ctx{"error": err})
-			return nil
-		}
-
-		defer resp.Body.Close()
-		_, err = io.Copy(io.Discard, resp.Body)
-		if err != nil {
-			logger.Error("Failed to read upgrade notification response body", logger.Ctx{"error": err})
-		}
-
-		if resp.StatusCode != http.StatusOK {
-			return fmt.Errorf("Database upgrade notification failed: %s", resp.Status)
-		}
-
+		// If this was a join request, instruct all peers to run their OnNewMember hook.
 		if len(joinAddresses) > 0 {
-			localMemberInfo := internalTypes.ClusterMemberLocal{Name: localNode.Name, Address: localNode.Address, Certificate: localNode.Certificate}
 			_, err = c.AddClusterMember(ctx, internalTypes.ClusterMember{ClusterMemberLocal: localMemberInfo})
 			if err != nil {
 				return err
@@ -518,6 +492,38 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 
 	if len(joinAddresses) > 0 {
 		return d.hooks.PostJoin(d.State(), initConfig)
+	}
+
+	return nil
+}
+
+func (d *Daemon) sendUpgradeNotification(ctx context.Context, c *client.Client) error {
+	path := c.URL()
+	parts := strings.Split(string(internalClient.InternalEndpoint), "/")
+	parts = append(parts, "database")
+	path = *path.Path(parts...)
+	upgradeRequest, err := http.NewRequest("PATCH", path.String(), nil)
+	if err != nil {
+		return err
+	}
+
+	upgradeRequest.Header.Set("X-Dqlite-Version", fmt.Sprintf("%d", 1))
+	upgradeRequest = upgradeRequest.WithContext(ctx)
+
+	resp, err := c.Client.Do(upgradeRequest)
+	if err != nil {
+		logger.Error("Failed to send database upgrade request", logger.Ctx{"error": err})
+		return nil
+	}
+
+	defer resp.Body.Close()
+	_, err = io.Copy(io.Discard, resp.Body)
+	if err != nil {
+		logger.Error("Failed to read upgrade notification response body", logger.Ctx{"error": err})
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Database upgrade notification failed: %s", resp.Status)
 	}
 
 	return nil

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -450,7 +450,7 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 		return err
 	}
 
-	cluster, err := d.trustStore.Remotes().Cluster(true, d.ServerCert(), publicKey)
+	cluster, err := d.trustStore.Remotes().Cluster(false, d.ServerCert(), publicKey)
 	if err != nil {
 		return err
 	}
@@ -463,8 +463,39 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 		}
 	}
 
+	var lastErr error
+	var clusterConfirmation bool
+	err = cluster.Query(d.shutdownCtx, true, func(ctx context.Context, c *client.Client) error {
+		// No need to send a request to ourselves.
+		if d.address.URL.Host == c.URL().URL.Host {
+			return nil
+		}
+
+		// At this point the joiner is only trusted on the node that was leader at the time,
+		// so find it and have it instruct all dqlite members to trust this system now that it is functional.
+		if !clusterConfirmation {
+			err := internalClient.AddTrustStoreEntry(ctx, &c.Client, localMemberInfo)
+			if err != nil {
+				lastErr = err
+			} else {
+				clusterConfirmation = true
+			}
+		}
+
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	if !clusterConfirmation {
+		return fmt.Errorf("Failed to confirm new member %q on any existing system (%d): %w", localMemberInfo.Name, len(cluster)-1, lastErr)
+	}
+
 	// Tell the other nodes that this system is up.
 	err = cluster.Query(d.shutdownCtx, true, func(ctx context.Context, c *client.Client) error {
+		c.SetClusterNotification()
+
 		// No need to send a request to ourselves.
 		if d.address.URL.Host == c.URL().URL.Host {
 			return nil

--- a/internal/rest/client/client.go
+++ b/internal/rest/client/client.go
@@ -177,6 +177,11 @@ func tlsHTTPClient(clientCert *shared.CertInfo, remoteCert *x509.Certificate, pr
 	return client, nil
 }
 
+// SetClusterNotification sets the client's proxy to apply the forwarding headers to a request.
+func (c *Client) SetClusterNotification() {
+	c.Transport.(*http.Transport).Proxy = forwardingProxy
+}
+
 func forwardingProxy(r *http.Request) (*url.URL, error) {
 	r.Header.Set("User-Agent", clusterRequest.UserAgentNotifier)
 

--- a/internal/rest/client/truststore.go
+++ b/internal/rest/client/truststore.go
@@ -1,0 +1,25 @@
+package client
+
+import (
+	"context"
+	"time"
+
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/microcluster/internal/rest/types"
+)
+
+// AddTrustStoreEntry adds a new record to the truststore on all cluster members.
+func AddTrustStoreEntry(ctx context.Context, c *Client, args types.ClusterMemberLocal) error {
+	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	return c.QueryStruct(queryCtx, "POST", InternalEndpoint, api.NewURL().Path("truststore"), args, nil)
+}
+
+// DeleteTrustStoreEntry deletes the record corresponding to the given cluster member from the trust store.
+func DeleteTrustStoreEntry(ctx context.Context, c *Client, name string) error {
+	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	return c.QueryStruct(queryCtx, "DELETE", InternalEndpoint, api.NewURL().Path("truststore", name), nil, nil)
+}

--- a/internal/rest/resources/certificates.go
+++ b/internal/rest/resources/certificates.go
@@ -35,8 +35,8 @@ func clusterCertificatesPut(s *state.State, r *http.Request) response.Response {
 	}
 
 	// Forward the request to all other nodes if we are the first.
-	if !client.IsForwardedRequest(r) && s.Database.IsOpen() {
-		cluster, err := s.Cluster(r)
+	if !client.IsNotification(r) && s.Database.IsOpen() {
+		cluster, err := s.Cluster(true)
 		if err != nil {
 			return response.SmartError(err)
 		}

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -103,11 +103,6 @@ func clusterPost(s *state.State, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Remote with address %q exists", req.Address.String()))
 	}
 
-	newRemote := trust.Remote{
-		Location:    trust.Location{Name: req.Name, Address: req.Address},
-		Certificate: req.Certificate,
-	}
-
 	// Forward request to leader.
 	if leaderInfo.Address != s.Address().URL.Host {
 		client, err := s.Leader()
@@ -116,12 +111,6 @@ func clusterPost(s *state.State, r *http.Request) response.Response {
 		}
 
 		tokenResponse, err := client.AddClusterMember(s.Context, req)
-		if err != nil {
-			return response.SmartError(err)
-		}
-
-		// If we are not the leader, just add the cluster member to our local store for authentication.
-		err = s.Remotes().Add(s.OS.TrustDir, newRemote)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -178,6 +167,11 @@ func clusterPost(s *state.State, r *http.Request) response.Response {
 		ClusterKey:  string(s.ClusterCert().PrivateKey()),
 
 		ClusterMembers: clusterMembers,
+	}
+
+	newRemote := trust.Remote{
+		Location:    trust.Location{Name: req.Name, Address: req.Address},
+		Certificate: req.Certificate,
 	}
 
 	// Add the cluster member to our local store for authentication.

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -50,7 +50,7 @@ var clusterMemberCmd = rest.Endpoint{
 func clusterPost(s *state.State, r *http.Request) response.Response {
 	// If we received a forwarded request, assume the new member was successfully added on the leader,
 	// and execute the new member hook.
-	if client.IsForwardedRequest(r) {
+	if client.IsNotification(r) {
 		ctx, cancel := context.WithTimeout(s.Context, 30*time.Second)
 		defer cancel()
 
@@ -251,7 +251,7 @@ func clusterMemberPut(s *state.State, r *http.Request) response.Response {
 	force := r.URL.Query().Get("force") == "1"
 
 	// If we received a cluster notification, run the pre-removal hook and return.
-	if client.IsForwardedRequest(r) {
+	if client.IsNotification(r) {
 		err := state.PreRemoveHook(s, force)
 		if err != nil {
 			return response.SmartError(fmt.Errorf("Failed to run pre-removal hook: %w", err))
@@ -325,7 +325,7 @@ func clusterMemberDelete(s *state.State, r *http.Request) response.Response {
 
 	// If we received a forwarded request, assume the new member was successfully removed on the leader,
 	// and execute the post-remove hook.
-	if client.IsForwardedRequest(r) {
+	if client.IsNotification(r) {
 		err := state.PostRemoveHook(s, force)
 		if err != nil {
 			return response.SmartError(fmt.Errorf("Failed to run post cluster member remove actions: %w", err))
@@ -584,7 +584,7 @@ func clusterMemberDelete(s *state.State, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	cluster, err := s.Cluster(nil)
+	cluster, err := s.Cluster(true)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/internal/rest/resources/heartbeat.go
+++ b/internal/rest/resources/heartbeat.go
@@ -208,7 +208,7 @@ func beginHeartbeat(s *state.State, r *http.Request) response.Response {
 		}
 	}
 
-	clusterClients, err := s.Cluster(nil)
+	clusterClients, err := s.Cluster(false)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -41,6 +41,8 @@ var InternalEndpoints = &Resources{
 		sqlCmd,
 		tokenCmd,
 		heartbeatCmd,
+		trustCmd,
+		trustEntryCmd,
 	},
 }
 

--- a/internal/rest/resources/truststore.go
+++ b/internal/rest/resources/truststore.go
@@ -1,0 +1,143 @@
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/gorilla/mux"
+
+	"github.com/canonical/microcluster/client"
+	"github.com/canonical/microcluster/internal/rest/access"
+	internalClient "github.com/canonical/microcluster/internal/rest/client"
+	internalTypes "github.com/canonical/microcluster/internal/rest/types"
+	"github.com/canonical/microcluster/internal/state"
+	"github.com/canonical/microcluster/internal/trust"
+	"github.com/canonical/microcluster/rest"
+)
+
+var trustCmd = rest.Endpoint{
+	Path:              "truststore",
+	AllowedBeforeInit: true,
+
+	Post: rest.EndpointAction{Handler: trustPost, AccessHandler: access.AllowAuthenticated},
+}
+
+var trustEntryCmd = rest.Endpoint{
+	Path:              "truststore/{name}",
+	AllowedBeforeInit: true,
+
+	Delete: rest.EndpointAction{Handler: trustDelete, AccessHandler: access.AllowAuthenticated},
+}
+
+func trustPost(s *state.State, r *http.Request) response.Response {
+	req := internalTypes.ClusterMemberLocal{}
+
+	// Parse the request.
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
+	newRemote := trust.Remote{
+		Location:    trust.Location{Name: req.Name, Address: req.Address},
+		Certificate: req.Certificate,
+	}
+
+	ctx, cancel := context.WithTimeout(s.Context, 30*time.Second)
+	defer cancel()
+
+	if !client.IsNotification(r) {
+		cluster, err := s.Cluster(true)
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		err = cluster.Query(ctx, true, func(ctx context.Context, c *client.Client) error {
+			// No need to send a request to ourselves, or to the node we are adding.
+			if s.Address().URL.Host == c.URL().URL.Host || req.Address.String() == c.URL().URL.Host {
+				return nil
+			}
+
+			return internalClient.AddTrustStoreEntry(ctx, &c.Client, req)
+		})
+		if err != nil {
+			return response.SmartError(err)
+		}
+	}
+
+	// At this point, the node has joined dqlite so we can add a local record for it if we haven't already from a heartbeat (or if we are the leader).
+	remotes := s.Remotes()
+	_, ok := remotes.RemotesByName()[newRemote.Name]
+	if !ok {
+		err = remotes.Add(s.OS.TrustDir, newRemote)
+		if err != nil {
+			return response.SmartError(fmt.Errorf("Failed adding local record of newly joined node %q: %w", req.Name, err))
+		}
+	}
+
+	return response.EmptySyncResponse
+}
+
+func trustDelete(s *state.State, r *http.Request) response.Response {
+	name, err := url.PathUnescape(mux.Vars(r)["name"])
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	ctx, cancel := context.WithTimeout(s.Context, 30*time.Second)
+	defer cancel()
+
+	remotesMap := s.Remotes().RemotesByName()
+	nodeToRemove, ok := remotesMap[name]
+	if !ok {
+		return response.SmartError(fmt.Errorf("No truststore entry found for node with name %q", name))
+	}
+
+	if !client.IsNotification(r) {
+		cluster, err := s.Cluster(true)
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		err = cluster.Query(ctx, true, func(ctx context.Context, c *client.Client) error {
+			// No need to send a request to ourselves, or to the node we are adding.
+			if s.Address().URL.Host == c.URL().URL.Host || nodeToRemove.URL().URL.Host == c.URL().URL.Host {
+				return nil
+			}
+
+			return internalClient.DeleteTrustStoreEntry(ctx, &c.Client, name)
+		})
+		if err != nil {
+			return response.SmartError(err)
+		}
+	}
+
+	remotes := s.Remotes()
+	remotesMap = remotes.RemotesByName()
+	delete(remotesMap, name)
+
+	newRemotes := make([]internalTypes.ClusterMember, 0, len(remotesMap))
+	for _, remote := range remotesMap {
+		newRemote := internalTypes.ClusterMember{
+			ClusterMemberLocal: internalTypes.ClusterMemberLocal{
+				Name:        remote.Name,
+				Address:     remote.Address,
+				Certificate: remote.Certificate,
+			},
+		}
+
+		newRemotes = append(newRemotes, newRemote)
+	}
+
+	err = remotes.Replace(s.OS.TrustDir, newRemotes...)
+	if err != nil {
+		return response.SmartError(fmt.Errorf("Failed to remove truststore entry for node with name %q: %w", name, err))
+	}
+
+	return response.EmptySyncResponse
+}

--- a/internal/trust/remotes.go
+++ b/internal/trust/remotes.go
@@ -16,6 +16,8 @@ import (
 	"github.com/google/renameio"
 	"gopkg.in/yaml.v2"
 
+	"github.com/canonical/microcluster/client"
+	internalClient "github.com/canonical/microcluster/internal/rest/client"
 	internalTypes "github.com/canonical/microcluster/internal/rest/types"
 	"github.com/canonical/microcluster/rest/types"
 )
@@ -212,6 +214,22 @@ func (r *Remotes) Addresses() map[string]types.AddrPort {
 	}
 
 	return addrs
+}
+
+// Cluster returns a set of clients for every remote, which can be concurrently queried.
+func (r *Remotes) Cluster(isNotification bool, serverCert *shared.CertInfo, publicKey *x509.Certificate) (client.Cluster, error) {
+	cluster := make(client.Cluster, 0, r.Count()-1)
+	for _, addr := range r.Addresses() {
+		url := api.NewURL().Scheme("https").Host(addr.String())
+		c, err := internalClient.New(*url, serverCert, publicKey, isNotification)
+		if err != nil {
+			return nil, err
+		}
+
+		cluster = append(cluster, client.Client{Client: *c})
+	}
+
+	return cluster, nil
 }
 
 // RemoteByAddress returns a Remote matching the given host address (or nil if none are found).


### PR DESCRIPTION
This PR cleans up some of the patchwork in the join API.

### API Changes 
#### `POST /cluster/internal/truststore`
* Adds an entry to the truststore of each node in the cluster. Accepts a `types.ClusterMemberLocal` which is usually used to convert to a `trust.Remote` type for the truststore.

#### `DELETE /cluster/internal/truststore`
* Replaces the truststore with the given entry excluded on each node of the cluster. Also accepts a `types.ClusterMemberLocal`.


#### Refactor local truststore management on joins
* Current behaviour 
  * Only the dqlite leader, and whichever node forwarded the request to the dqlite leader trust a joining node as it goes through the join process. The rest of the cluster is only updated 30 seconds later on the next heartbeat. 
* New behaviour
  * Just the dqlite leader will trust the joining node until it completes the join process. Finally, the joining node will inform the leader that it is done, at which point the leader will update the trust stores of all other nodes to include the joiner using the `/cluster/internal/truststore` endpoint.

### Other related changes
#### Cleans up confusing functions for using cluster notifications.
  * Adds a `SetClusterNotification` function to the client for applying it automatically to all requests made by the client.
  * Renames `IsForwardedRequest` to `IsNotification` to be more consistent.
  * Changes `state.Cluster`, which returns a set of clients for all nodes in dqlite except the local one, to take a boolean flag as argument for setting the cluster notification header, as opposed to a request.
  
#### Adds non-dqlite version of `state.Cluster`
  * In case we want to exclusively talk to systems in the local trust store, this adds a `Cluster` method to `trust.Remotes` to fetch a client for each `Remote`. This will be used to reach the node that accepted a joiner into the cluster, so it can confirm that the cluster has successfully joined.
  
#### Simplify `StartAPI` using helpers.
* Using the `remote.Cluster` helper defined above, as well as moving the schema upgrade notification handling to its own helper reduces some of the complexity of `StartAPI` and makes it a bit easier to read.
