### PR TITLE
Add hooks API

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -539,7 +539,7 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 
 			// Run the OnNewMember hook, and skip errors on any nodes that are still in the process of joining.
 			err = internalClient.RunNewMemberHook(ctx, c.Client.UseTarget(remote.Name), internalTypes.HookNewMemberOptions{Name: localMemberInfo.Name})
-			if err != nil {
+			if err != nil && err.Error() != "Daemon not yet initialized" {
 				return err
 			}
 		}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -510,6 +510,7 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 	}
 
 	// Tell the other nodes that this system is up.
+	remotes := d.trustStore.Remotes()
 	err = cluster.Query(d.shutdownCtx, true, func(ctx context.Context, c *client.Client) error {
 		c.SetClusterNotification()
 
@@ -526,7 +527,18 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 
 		// If this was a join request, instruct all peers to run their OnNewMember hook.
 		if len(joinAddresses) > 0 {
-			_, err = c.AddClusterMember(ctx, internalTypes.ClusterMember{ClusterMemberLocal: localMemberInfo})
+			addrPort, err := types.ParseAddrPort(c.URL().URL.Host)
+			if err != nil {
+				return err
+			}
+
+			remote := remotes.RemoteByAddress(addrPort)
+			if remote == nil {
+				return fmt.Errorf("No remote found at address %q run the post-remove hook", c.URL().URL.Host)
+			}
+
+			// Run the OnNewMember hook, and skip errors on any nodes that are still in the process of joining.
+			err = internalClient.RunNewMemberHook(ctx, c.Client.UseTarget(remote.Name), internalTypes.HookNewMemberOptions{Name: localMemberInfo.Name})
 			if err != nil {
 				return err
 			}

--- a/internal/rest/client/hooks.go
+++ b/internal/rest/client/hooks.go
@@ -1,0 +1,34 @@
+package client
+
+import (
+	"context"
+	"time"
+
+	"github.com/canonical/lxd/shared/api"
+
+	"github.com/canonical/microcluster/internal/rest/types"
+)
+
+// RunPreRemoveHook executes the PreRemove hook with the given configuration on the cluster member targetted by this client.
+func RunPreRemoveHook(ctx context.Context, c *Client, config types.HookRemoveMemberOptions) error {
+	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	return c.QueryStruct(queryCtx, "POST", InternalEndpoint, api.NewURL().Path("hooks", string(types.PreRemove)), config, nil)
+}
+
+// RunPostRemoveHook executes the PostRemove hook with the given configuration on the cluster member targetted by this client.
+func RunPostRemoveHook(ctx context.Context, c *Client, config types.HookRemoveMemberOptions) error {
+	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	return c.QueryStruct(queryCtx, "POST", InternalEndpoint, api.NewURL().Path("hooks", string(types.PostRemove)), config, nil)
+}
+
+// RunNewMemberHook executes the OnNewMember hook with the given configuration on the cluster member targetted by this client.
+func RunNewMemberHook(ctx context.Context, c *Client, config types.HookNewMemberOptions) error {
+	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	return c.QueryStruct(queryCtx, "POST", InternalEndpoint, api.NewURL().Path("hooks", string(types.OnNewMember)), config, nil)
+}

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -34,8 +34,7 @@ import (
 )
 
 var clusterCmd = rest.Endpoint{
-	Path:              "cluster",
-	AllowedBeforeInit: true,
+	Path: "cluster",
 
 	Post: rest.EndpointAction{Handler: clusterPost, AllowUntrusted: true},
 	Get:  rest.EndpointAction{Handler: clusterGet, AccessHandler: access.AllowAuthenticated},
@@ -49,10 +48,6 @@ var clusterMemberCmd = rest.Endpoint{
 }
 
 func clusterPost(s *state.State, r *http.Request) response.Response {
-	if !s.Database.IsOpen() {
-		return response.Unavailable(fmt.Errorf("Daemon not yet initialized"))
-	}
-
 	req := internalTypes.ClusterMember{}
 
 	// Parse the request.
@@ -173,10 +168,6 @@ func clusterPost(s *state.State, r *http.Request) response.Response {
 }
 
 func clusterGet(s *state.State, r *http.Request) response.Response {
-	if !s.Database.IsOpen() {
-		return response.Unavailable(fmt.Errorf("Daemon not yet initialized"))
-	}
-
 	var apiClusterMembers []internalTypes.ClusterMember
 	err := s.Database.Transaction(s.Context, func(ctx context.Context, tx *sql.Tx) error {
 		clusterMembers, err := cluster.GetInternalClusterMembers(ctx, tx)

--- a/internal/rest/resources/hooks.go
+++ b/internal/rest/resources/hooks.go
@@ -1,0 +1,74 @@
+package resources
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/gorilla/mux"
+
+	"github.com/canonical/microcluster/internal/rest/types"
+	"github.com/canonical/microcluster/internal/state"
+	"github.com/canonical/microcluster/rest"
+	"github.com/canonical/microcluster/rest/access"
+)
+
+var hooksCmd = rest.Endpoint{
+	Path: "hooks/{hookType}",
+
+	Post: rest.EndpointAction{Handler: hooksPost, AccessHandler: access.AllowAuthenticated, ProxyTarget: true},
+}
+
+func hooksPost(s *state.State, r *http.Request) response.Response {
+	hookTypeStr, err := url.PathUnescape(mux.Vars(r)["hookType"])
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	switch types.HookType(hookTypeStr) {
+	case types.PreRemove:
+		var req types.HookRemoveMemberOptions
+		err = json.NewDecoder(r.Body).Decode(&req)
+		if err != nil {
+			return response.BadRequest(err)
+		}
+
+		err = state.PreRemoveHook(s, req.Force)
+		if err != nil {
+			return response.SmartError(fmt.Errorf("Failed to execute pre-remove hook on cluster member %q: %w", s.Name(), err))
+		}
+	case types.PostRemove:
+		var req types.HookRemoveMemberOptions
+		err = json.NewDecoder(r.Body).Decode(&req)
+		if err != nil {
+			return response.BadRequest(err)
+		}
+
+		err = state.PostRemoveHook(s, req.Force)
+		if err != nil {
+			return response.SmartError(fmt.Errorf("Failed to execute post-remove hook on cluster member %q: %w", s.Name(), err))
+		}
+
+	case types.OnNewMember:
+		var req types.HookNewMemberOptions
+		err = json.NewDecoder(r.Body).Decode(&req)
+		if err != nil {
+			return response.BadRequest(err)
+		}
+
+		if req.Name == "" {
+			return response.SmartError(fmt.Errorf("No new member name given for NewMember hook execution"))
+		}
+
+		err = state.OnNewMemberHook(s)
+		if err != nil {
+			return response.SmartError(fmt.Errorf("Failed to run hook after system %q has joined the cluster: %w", req.Name, err))
+		}
+	default:
+		return response.SmartError(fmt.Errorf("No valid hook found for the given type"))
+	}
+
+	return response.EmptySyncResponse
+}

--- a/internal/rest/resources/hooks_test.go
+++ b/internal/rest/resources/hooks_test.go
@@ -1,0 +1,153 @@
+package resources
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/microcluster/internal/rest/types"
+	"github.com/canonical/microcluster/internal/state"
+	"github.com/gorilla/mux"
+	"github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/suite"
+)
+
+type hooksSuite struct {
+	suite.Suite
+}
+
+func TestHooksSuite(t *testing.T) {
+	suite.Run(t, new(hooksSuite))
+}
+
+func (t *hooksSuite) Test_hooks() {
+	s := &state.State{
+		Context: context.TODO(),
+		Name:    func() string { return "n0" },
+	}
+
+	var ranHook types.HookType
+	var isForce bool
+	state.PostRemoveHook = func(state *state.State, force bool) error {
+		ranHook = types.PostRemove
+		isForce = force
+		return nil
+	}
+
+	state.PreRemoveHook = func(state *state.State, force bool) error {
+		ranHook = types.PreRemove
+		isForce = force
+		return nil
+	}
+
+	state.OnNewMemberHook = func(state *state.State) error {
+		ranHook = types.OnNewMember
+		return nil
+	}
+
+	tests := []struct {
+		name      string
+		req       any
+		hookType  types.HookType
+		expectErr bool
+	}{
+		{
+			name:      "Run OnNewMember hook",
+			req:       types.HookNewMemberOptions{Name: "n1"},
+			hookType:  types.OnNewMember,
+			expectErr: false,
+		},
+		{
+			name:      "Run PostRemove hook with force",
+			req:       types.HookRemoveMemberOptions{Force: true},
+			hookType:  types.PostRemove,
+			expectErr: false,
+		},
+		{
+			name:      "Run PostRemove hook without force",
+			req:       types.HookRemoveMemberOptions{},
+			hookType:  types.PostRemove,
+			expectErr: false,
+		},
+		{
+			name:      "Run PreRemove hook with force",
+			req:       types.HookRemoveMemberOptions{Force: true},
+			hookType:  types.PreRemove,
+			expectErr: false,
+		},
+		{
+			name:      "Run PreRemove hook without force",
+			req:       types.HookRemoveMemberOptions{},
+			hookType:  types.PreRemove,
+			expectErr: false,
+		},
+		{
+			name:      "Fail to run any other hook",
+			req:       types.HookNewMemberOptions{Name: "n1"},
+			hookType:  types.PostBootstrap,
+			expectErr: true,
+		},
+		{
+			name:      "Fail to run a nonexistent hook",
+			req:       types.HookNewMemberOptions{Name: "n1"},
+			hookType:  "this is not a hook type",
+			expectErr: true,
+		},
+		{
+			name:      "Fail to run a hook with the wrong payload type",
+			req:       types.HookRemoveMemberOptions{Force: true},
+			hookType:  types.OnNewMember,
+			expectErr: true,
+		},
+	}
+
+	for i, c := range tests {
+		t.T().Logf("%s (case %d)", c.name, i)
+
+		ranHook = ""
+		isForce = false
+		expectForce := false
+		req := &http.Request{}
+		payload, ok := c.req.(types.HookRemoveMemberOptions)
+		if !ok {
+			payload, ok := c.req.(types.HookNewMemberOptions)
+			t.True(ok)
+			req.Body = io.NopCloser(strings.NewReader(fmt.Sprintf(`{"name": %q}`, payload.Name)))
+		} else {
+			expectForce = payload.Force
+			req.Body = io.NopCloser(strings.NewReader(fmt.Sprintf(`{"force": %v}`, expectForce)))
+		}
+
+		req = mux.SetURLVars(req, map[string]string{"hookType": string(c.hookType)})
+
+		response := hooksPost(s, req)
+		recorder := httptest.NewRecorder()
+		err := response.Render(recorder)
+		require.NoError(t.T(), err)
+
+		var resp api.Response
+		err = json.NewDecoder(recorder.Result().Body).Decode(&resp)
+		require.NoError(t.T(), err)
+
+		if !c.expectErr {
+			t.Equal(api.SyncResponse, resp.Type)
+			t.Equal(api.Success.String(), resp.Status)
+			t.Equal(http.StatusOK, resp.StatusCode)
+			t.Equal(c.hookType, ranHook)
+			t.Equal(expectForce, isForce)
+		} else {
+			t.Equal(api.ErrorResponse, resp.Type)
+			t.NotEqual(api.Success.String(), resp.Status)
+			t.NotEqual(http.StatusOK, resp.StatusCode)
+			t.Equal(types.HookType(""), ranHook)
+			t.Equal(false, isForce)
+		}
+	}
+
+}

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -43,6 +43,7 @@ var InternalEndpoints = &Resources{
 		heartbeatCmd,
 		trustCmd,
 		trustEntryCmd,
+		hooksCmd,
 	},
 }
 

--- a/internal/rest/types/hooks.go
+++ b/internal/rest/types/hooks.go
@@ -1,0 +1,46 @@
+package types
+
+// HookType represents the various types of hooks available to microcluster.
+type HookType string
+
+const (
+	// OnStart is run after the daemon is started.
+	OnStart HookType = "on-start"
+
+	// PreBootstrap is run before the daemon is initialized and bootstrapped.
+	PreBootstrap HookType = "pre-bootstrap"
+
+	// PostBootstrap is run after the daemon is initialized and bootstrapped.
+	PostBootstrap HookType = "post-bootstrap"
+
+	// PreJoin is run after the daemon is initialized and joined the cluster but before existing members triggered
+	// their 'OnNewMember' hooks.
+	PreJoin HookType = "pre-join"
+
+	// PostJoin is run after the daemon is initialized, joined the cluster and existing members triggered
+	// their 'OnNewMember' hooks.
+	PostJoin HookType = "post-join"
+
+	// PreRemove is run on a cluster member just before it is removed from the cluster.
+	PreRemove HookType = "pre-remove"
+
+	// PostRemove is run on all other peers after one is removed from the cluster.
+	PostRemove HookType = "post-remove"
+
+	// OnNewMember is run on each peer after a new cluster member has joined and executed their 'PreJoin' hook.
+	OnNewMember HookType = "on-new-member"
+
+	// OnHeartbeat is run after a successful heartbeat round.
+	OnHeartbeat HookType = "on-heartbeat"
+)
+
+// HookRemoveMemberOptions holds configuration pertaining to the PreRemove and PostRemove hooks.
+type HookRemoveMemberOptions struct {
+	// Force represents whether to run the hook with the `force` option.
+	Force bool `json:"force" yaml:"force"`
+}
+
+type HookNewMemberOptions struct {
+	// Name is the name of the new cluster member that joined the cluster, triggering this hook.
+	Name string `json:"name" yaml:"name"`
+}


### PR DESCRIPTION
Closes #109 

Depends on #113 

### API Changes
#### `POST /cluster/internal/hooks/{hookType}`
 * Adds an endpoint to execute multi-node hooks on a particular cluster member. The hook type is specified by a `types.HookType` integer, and the arguments of the hook are passed in with the `types.HookNewMemberOptions` struct and the `types.HookRemoveMemberOptions` struct. This replaces the current implementation which relies on cluster notifications, which is confusing and bloats the cluster management API.

 * The only multi-node hooks are currently `OnNewMember`, `PreRemove`, and `PostRemove`, so only these are supported by the API at this time. The other hooks are local to a particular node and so do not need to be run by a different node over the network.
 
#### `/cluster/1.0/cluster` is disallowed if not initialized.
* The cluster management network requires the database, and so the database must be open for the API to work. It doesn't make sense to allow this the cluster management API to work before initialization.

* The `OnNewMember` hook might run on some nodes before they have started their database. This shouldn't be allowed as we don't know where the node is in the setup process yet.

#### Cluster notifications on `/cluster/1.0/cluster` do not execute hooks anymore
* As the hooks have their own endpoint, we should just use that instead of running the hooks as a cluster notification on existing APIs, which makes it hard to read the code when we see client functions run twice with different outcomes. 