### PR TITLE
Remove name from join token

### DIFF
--- a/cluster/token_records.go
+++ b/cluster/token_records.go
@@ -43,7 +43,6 @@ type InternalTokenRecordFilter struct {
 // ToAPI converts the InternalTokenRecord to a full token and returns an API compatible struct.
 func (t *InternalTokenRecord) ToAPI(clusterCert *x509.Certificate, joinAddresses []types.AddrPort) (*internalTypes.TokenRecord, error) {
 	token := internalTypes.Token{
-		Name:          t.Name,
 		Secret:        t.Secret,
 		Fingerprint:   shared.CertFingerprint(clusterCert),
 		JoinAddresses: joinAddresses,

--- a/internal/rest/resources/tokens.go
+++ b/internal/rest/resources/tokens.go
@@ -68,7 +68,6 @@ func tokensPost(state *state.State, r *http.Request) response.Response {
 	}
 
 	token := internalTypes.Token{
-		Name:          req.Name,
 		Secret:        tokenKey,
 		Fingerprint:   shared.CertFingerprint(clusterCert),
 		JoinAddresses: joinAddresses,

--- a/internal/rest/types/tokens.go
+++ b/internal/rest/types/tokens.go
@@ -22,7 +22,6 @@ type TokenResponse struct {
 
 // Token holds the information that is presented to the joining node when requesting a token.
 type Token struct {
-	Name          string           `json:"name" yaml:"name"`
 	Secret        string           `json:"secret" yaml:"secret"`
 	Fingerprint   string           `json:"fingerprint" yaml:"fingerprint"`
 	JoinAddresses []types.AddrPort `json:"join_addresses" yaml:"join_addresses"`


### PR DESCRIPTION
Resolves the titular concern in #96 

@masnax I had mentioned that this caused cluster join to fail and... I can't reproduce it. Cluster forms up nicely. Likely had a messy worktree at the end of the day or some such. This passes what tests there are in #110.