### PR TITLE
Fix bug introduced with truststore API

### DIFF
--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -344,10 +344,9 @@ func (db *DB) Stop() error {
 	db.cancel()
 
 	if db.IsOpen() {
-		err := db.db.Close()
-		if err != nil {
-			return err
-		}
+		// The database might refuse to close if many nodes are stopping at the same time,
+		// because the dqlite connection will have been lost.
+		_ = db.db.Close()
 	}
 
 	if db.dqlite != nil {


### PR DESCRIPTION
Couple things:

* The truststore API was being used to update the cluster member's local node records each time their databases start, but this was causing a quorum loss loop because if the daemon restarts, no node will be available to handle the request and the database will close prematurely.

* Additionally slightly related is that when we close the dqlite connection, we first try to shut down the database, but if other nodes have already closed their dqlite connections then we won't be able to close the database and the defunct connection will be left open, causing problems if the daemon restarts too quickly. I've changed this to skip the error check for `db.Close` since `dqlite.Close` will close it for us. This is the same behaviour as in LXD today.