### PR TITLE
Fix long timeout when API & Schema updates happen at once

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -443,12 +443,12 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 	}
 
 	if len(joinAddresses) != 0 {
-		err = d.db.Join(d.Extensions, d.project, d.address, joinAddresses...)
+		err = d.db.Join(d.project, d.address, joinAddresses...)
 		if err != nil {
 			return fmt.Errorf("Failed to join cluster: %w", err)
 		}
 	} else {
-		err = d.db.StartWithCluster(d.Extensions, d.project, d.address, d.trustStore.Remotes().Addresses())
+		err = d.db.StartWithCluster(d.project, d.address, d.trustStore.Remotes().Addresses())
 		if err != nil {
 			return fmt.Errorf("Failed to re-establish cluster connection: %w", err)
 		}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -19,6 +19,14 @@ import (
 	"github.com/canonical/microcluster/internal/sys"
 )
 
+type UpgradeType string
+
+const (
+	UpgradeAPI UpgradeType = "api"
+
+	UpgradeSchema UpgradeType = "schema"
+)
+
 // Open opens the dqlite database and loads the schema.
 // Returns true if we need to wait for other nodes to catch up to our version.
 func (db *DB) Open(ext extensions.Extensions, bootstrap bool, project string) error {

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -106,7 +106,12 @@ func (db *DB) Bootstrap(extensions extensions.Extensions, project string, addr a
 		return fmt.Errorf("Failed to bootstrap dqlite: %w", err)
 	}
 
-	err = db.Open(extensions, true, project)
+	err = db.Init(true, project)
+	if err != nil {
+		return err
+	}
+
+	err = db.Open(true, extensions)
 	if err != nil {
 		return err
 	}
@@ -129,7 +134,7 @@ func (db *DB) Bootstrap(extensions extensions.Extensions, project string, addr a
 }
 
 // Join a dqlite cluster with the address of a member.
-func (db *DB) Join(extensions extensions.Extensions, project string, addr api.URL, joinAddresses ...string) error {
+func (db *DB) Join(project string, addr api.URL, joinAddresses ...string) error {
 	for {
 		var err error
 		db.listenAddr = addr
@@ -142,7 +147,7 @@ func (db *DB) Join(extensions extensions.Extensions, project string, addr api.UR
 			return fmt.Errorf("Failed to join dqlite cluster %w", err)
 		}
 
-		err = db.Open(extensions, false, project)
+		err = db.Init(false, project)
 		if err == nil {
 			break
 		}
@@ -167,13 +172,13 @@ func (db *DB) Join(extensions extensions.Extensions, project string, addr api.UR
 }
 
 // StartWithCluster starts up dqlite and joins the cluster.
-func (db *DB) StartWithCluster(extensions extensions.Extensions, project string, addr api.URL, clusterMembers map[string]types.AddrPort) error {
+func (db *DB) StartWithCluster(project string, addr api.URL, clusterMembers map[string]types.AddrPort) error {
 	allClusterAddrs := []string{}
 	for _, clusterMemberAddrs := range clusterMembers {
 		allClusterAddrs = append(allClusterAddrs, clusterMemberAddrs.String())
 	}
 
-	return db.Join(extensions, project, addr, allClusterAddrs...)
+	return db.Join(project, addr, allClusterAddrs...)
 }
 
 // Leader returns a client connected to the leader of the dqlite cluster.


### PR DESCRIPTION
Because the API extension system is contingent on the presence of a particular schema update, we fall into a temporary deadlock when applying the first API extension. This PR addresses that by splitting up the notification for an upgraded API and upgraded schema.

To give an example, imagine 3 nodes.

1. `node01` runs `snap refresh` and detects that its expected schema version is ahead of the other cluster members, so it waits.
2.  `node02` runs `snap refresh` and detects the same thing, but is only blocked on `node03`
3.  `node03` runs `snap refresh`, and since the previous two nodes have already updated their expected schema versions, this node can proceed with committing the changes to the schema.

4. `node03` now progresses to comparing API versions since its updated schema supports this. It detects that it has the highest expected API version because `node01` and `node02` did not have the necessary schema updates in the earlier steps to record their expected API version, so `node03` waits for those nodes to detect that `node03` has committed the schema, so they can record their expected API updates for `node03` to compare against.

So you get into a situation where all 3 nodes are waiting for each other. After 30s the loop repeats so `node01` will detect that its schema version matches the other nodes, and then waits on only `node02` to update its API version. Node02 then finally does this, and the database opens for access.

So because the schema update that introduces API updates is part of the same update that increments the number of API updates, the update process takes **at least** 30s in this case.

---

To fix this, we can split up how we notify other nodes that an upgrade can be performed.
In the above case at bullet 4, `node03` would instead immediately report to `node01` and `node02` when it completes the schema upgrade. Those nodes will unblock and be free to record their local API extensions to the database, repeating step 1, 2, and 3 but for API upgrades instead of schema upgrades, which have already completed.

To accomplish this, we need to split up the implementation of `db.Open`. Normally, `db.Open` sets the status of the database as available by closing its `openCanceller`. Instead, we will have 2 functions now:

* `Init` - starts dqlite, verifies and applies schema upgrades (or blocks), prepares statements.

* `Open`- verifies API upgrades, and finally sets the database to be available by closing the `openCanceller`.

When bootstrapping, we will run `Init` and `Open` in sequence. When joining or restarting, we will first run `Init`, then if we are not blocked, send a notification to the rest of the cluster that they may unblock on schema upgrades. Finally we run `Open` and send another notification that nodes may unblock on API upgrades.

We will distinguish between API/Schema upgrade notifications using a query parameter on the `/internal/database` endpoint.