### PR TITLE
Misc fixes

### DIFF
--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -98,7 +98,7 @@ func (c *cmdDaemon) Run(cmd *cobra.Command, args []string) error {
 
 			// You can also create a new registry of extensions from a list of extensions.
 			// This is useful to communicate a system's extensions to other systems, for comparison purposes for example.
-			newExt, err := extensions.NewExtensionRegistryFromList([]string{"internal:runtime_extension_v1", "new_extension_at_runtime_1", "new_extension_at_runtime_2", "custom_extension_a_0", "custom_extension_a_1"})
+			newExt, err := extensions.NewExtensionRegistryFromList([]string{"internal:runtime_extension_v1", "custom_extension_a_0", "custom_extension_a_1", "new_extension_at_runtime_1", "new_extension_at_runtime_2"})
 			if err != nil {
 				return err
 			}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -82,7 +82,7 @@ func (db *DB) waitUpgrade(bootstrap bool, ext extensions.Extensions) error {
 	}
 
 	checkAPIExtensions := func(currentAPIExtensions extensions.Extensions, clusterMemberAPIExtensions []extensions.Extensions) (otherNodesBehind bool, err error) {
-		logger.Warnf("Local API extensions: %v, cluster members API extensions: %v", currentAPIExtensions, clusterMemberAPIExtensions)
+		logger.Debugf("Local API extensions: %v, cluster members API extensions: %v", currentAPIExtensions, clusterMemberAPIExtensions)
 
 		nodeIsBehind := false
 		for _, extensions := range clusterMemberAPIExtensions {


### PR DESCRIPTION
Cleans up a noisy log and fixes the example package, which was failing to run the `OnStart` hook because of an incorrectly ordered set of external API extensions.