### PR TITLE
Allow running extra network listeners

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -306,7 +306,7 @@ func (d *Daemon) initStore() error {
 	return nil
 }
 
-func (d *Daemon) initServer(resources ...*resources.Resources) *http.Server {
+func (d *Daemon) initServer(resources ...rest.Resources) *http.Server {
 	/* Setup the web server */
 	mux := mux.NewRouter()
 	mux.StrictSlash(false)

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -12,7 +12,7 @@ type Resources struct {
 }
 
 // UnixEndpoints are the endpoints available over the unix socket.
-var UnixEndpoints = &Resources{
+var UnixEndpoints = Resources{
 	Path: client.ControlEndpoint,
 	Endpoints: []rest.Endpoint{
 		controlCmd,
@@ -21,7 +21,7 @@ var UnixEndpoints = &Resources{
 }
 
 // PublicEndpoints are the /cluster/1.0 API endpoints available without authentication.
-var PublicEndpoints = &Resources{
+var PublicEndpoints = Resources{
 	Path: client.PublicEndpoint,
 	Endpoints: []rest.Endpoint{
 		api10Cmd,
@@ -33,7 +33,7 @@ var PublicEndpoints = &Resources{
 }
 
 // InternalEndpoints are the /cluster/internal API endpoints available at the listen address.
-var InternalEndpoints = &Resources{
+var InternalEndpoints = Resources{
 	Path: client.InternalEndpoint,
 	Endpoints: []rest.Endpoint{
 		databaseCmd,
@@ -48,7 +48,7 @@ var InternalEndpoints = &Resources{
 }
 
 // ExtendedEndpoints holds all the endpoints added by external usage of MicroCluster.
-var ExtendedEndpoints = &Resources{
+var ExtendedEndpoints = Resources{
 	Path:      client.ExtendedEndpoint,
 	Endpoints: []rest.Endpoint{},
 }

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -5,12 +5,6 @@ import (
 	"github.com/canonical/microcluster/rest"
 )
 
-// Resources represents all the resources served over the same path.
-type Resources struct {
-	Path      client.EndpointType
-	Endpoints []rest.Endpoint
-}
-
 // UnixEndpoints are the endpoints available over the unix socket.
 var UnixEndpoints = Resources{
 	Path: client.ControlEndpoint,

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -6,8 +6,8 @@ import (
 )
 
 // UnixEndpoints are the endpoints available over the unix socket.
-var UnixEndpoints = Resources{
-	Path: client.ControlEndpoint,
+var UnixEndpoints = rest.Resources{
+	Path: rest.EndpointType(client.ControlEndpoint),
 	Endpoints: []rest.Endpoint{
 		controlCmd,
 		shutdownCmd,
@@ -15,8 +15,8 @@ var UnixEndpoints = Resources{
 }
 
 // PublicEndpoints are the /cluster/1.0 API endpoints available without authentication.
-var PublicEndpoints = Resources{
-	Path: client.PublicEndpoint,
+var PublicEndpoints = rest.Resources{
+	Path: rest.EndpointType(client.PublicEndpoint),
 	Endpoints: []rest.Endpoint{
 		api10Cmd,
 		clusterCmd,
@@ -27,8 +27,8 @@ var PublicEndpoints = Resources{
 }
 
 // InternalEndpoints are the /cluster/internal API endpoints available at the listen address.
-var InternalEndpoints = Resources{
-	Path: client.InternalEndpoint,
+var InternalEndpoints = rest.Resources{
+	Path: rest.EndpointType(client.InternalEndpoint),
 	Endpoints: []rest.Endpoint{
 		databaseCmd,
 		clusterCertificatesCmd,
@@ -42,7 +42,7 @@ var InternalEndpoints = Resources{
 }
 
 // ExtendedEndpoints holds all the endpoints added by external usage of MicroCluster.
-var ExtendedEndpoints = Resources{
-	Path:      client.ExtendedEndpoint,
+var ExtendedEndpoints = rest.Resources{
+	Path:      rest.EndpointType(client.ExtendedEndpoint),
 	Endpoints: []rest.Endpoint{},
 }

--- a/internal/rest/rest.go
+++ b/internal/rest/rest.go
@@ -3,6 +3,7 @@ package rest
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -201,8 +202,8 @@ func HandleEndpoint(state *state.State, mux *mux.Router, version string, e rest.
 			handleRequest = handleDatabaseRequest
 		}
 
-		trusted, err := access.Authenticate(state, r, state.Remotes().CertificatesNative())
-		if err != nil {
+		trusted, err := access.Authenticate(state, r, state.Address().URL.Host, state.Remotes().CertificatesNative())
+		if err != nil && !errors.As(err, &access.ErrInvalidHost{}) {
 			resp = response.Forbidden(fmt.Errorf("Failed to authenticate request: %w", err))
 		} else {
 			r = internalAccess.SetRequestAuthentication(r, trusted)

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -45,6 +45,8 @@ type Args struct {
 	ListenPort string
 	Client     *client.Client
 	Proxy      func(*http.Request) (*url.URL, error)
+
+	ExtensionServers []rest.Server
 }
 
 // App returns an instance of MicroCluster with a newly initialized filesystem if one does not exist.
@@ -89,7 +91,7 @@ func (m *MicroCluster) Start(ctx context.Context, extensionsAPI []rest.Endpoint,
 	ctx, cancel := signal.NotifyContext(ctx, unix.SIGPWR, unix.SIGTERM, unix.SIGINT, unix.SIGQUIT)
 	defer cancel()
 
-	err = d.Run(ctx, m.args.ListenPort, m.FileSystem.StateDir, m.FileSystem.SocketGroup, extensionsAPI, extensionsSchema, apiExtensions, hooks)
+	err = d.Run(ctx, m.args.ListenPort, m.FileSystem.StateDir, m.FileSystem.SocketGroup, extensionsAPI, extensionsSchema, apiExtensions, m.args.ExtensionServers, hooks)
 	if err != nil {
 		return fmt.Errorf("Daemon stopped with error: %w", err)
 	}

--- a/rest/access/handlers.go
+++ b/rest/access/handlers.go
@@ -10,7 +10,18 @@ import (
 	"github.com/canonical/lxd/shared/logger"
 
 	"github.com/canonical/microcluster/internal/state"
+	"github.com/canonical/microcluster/rest/types"
 )
+
+// ErrInvalidHost is used to indicate that a request host is invalid.
+type ErrInvalidHost struct {
+	error
+}
+
+// Unwrap implements xerrors.Unwrap for ErrInvalidHost.
+func (e ErrInvalidHost) Unwrap() error {
+	return e.error
+}
 
 // AllowAuthenticated is an AccessHandler which allows all requests.
 // This function doesn't do anything itself, except return the EmptySyncResponse that allows the request to
@@ -23,7 +34,7 @@ func AllowAuthenticated(state *state.State, r *http.Request) response.Response {
 // Authenticate ensures the request certificates are trusted against the given set of trusted certificates.
 // - Requests over the unix socket are always allowed.
 // - HTTP requests require the TLS Peer certificate to match an entry in the supplied map of certificates.
-func Authenticate(state *state.State, r *http.Request, trustedCerts map[string]x509.Certificate) (bool, error) {
+func Authenticate(state *state.State, r *http.Request, hostAddress string, trustedCerts map[string]x509.Certificate) (bool, error) {
 	if r.RemoteAddr == "@" {
 		return true, nil
 	}
@@ -33,8 +44,14 @@ func Authenticate(state *state.State, r *http.Request, trustedCerts map[string]x
 		return true, nil
 	}
 
+	// Ensure the given host address is valid.
+	hostAddrPort, err := types.ParseAddrPort(hostAddress)
+	if err != nil {
+		return false, fmt.Errorf("Invalid host address %q", hostAddress)
+	}
+
 	switch r.Host {
-	case state.Address().URL.Host:
+	case hostAddrPort.String():
 		if r.TLS != nil {
 			for _, cert := range r.TLS.PeerCertificates {
 				trusted, fingerprint := util.CheckTrustState(*cert, trustedCerts, nil, false)
@@ -46,7 +63,7 @@ func Authenticate(state *state.State, r *http.Request, trustedCerts map[string]x
 			}
 		}
 	default:
-		return false, fmt.Errorf("Invalid request address %q", r.Host)
+		return false, ErrInvalidHost{error: fmt.Errorf("Invalid request address %q", r.Host)}
 	}
 
 	return false, nil

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/canonical/lxd/lxd/response"
-
+	"github.com/canonical/microcluster/internal/rest/client"
 	"github.com/canonical/microcluster/state"
 )
 
@@ -36,3 +36,6 @@ type Endpoint struct {
 	AllowedDuringShutdown bool // Whether we should return Unavailable Error (503) if daemon is shutting down.
 	AllowedBeforeInit     bool // Whether we should return Unavailabel Error (503) if the daemon has not been initialized (is not yet part of a cluster).
 }
+
+// EndpointType is a type specifying the endpoint on which the resource exists.
+type EndpointType client.EndpointType

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -37,5 +37,11 @@ type Endpoint struct {
 	AllowedBeforeInit     bool // Whether we should return Unavailabel Error (503) if the daemon has not been initialized (is not yet part of a cluster).
 }
 
+// Resources represents all the resources served over the same path.
+type Resources struct {
+	Path      EndpointType
+	Endpoints []Endpoint
+}
+
 // EndpointType is a type specifying the endpoint on which the resource exists.
 type EndpointType client.EndpointType

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -4,7 +4,10 @@ import (
 	"net/http"
 
 	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/lxd/shared"
+
 	"github.com/canonical/microcluster/internal/rest/client"
+	"github.com/canonical/microcluster/rest/types"
 	"github.com/canonical/microcluster/state"
 )
 
@@ -45,3 +48,11 @@ type Resources struct {
 
 // EndpointType is a type specifying the endpoint on which the resource exists.
 type EndpointType client.EndpointType
+
+// Server contains configuration and handlers for additional listeners to be instantiated after app startup.
+type Server struct {
+	Protocol    string
+	Address     types.AddrPort
+	Certificate *shared.CertInfo
+	Resources   []Resources
+}


### PR DESCRIPTION
Allows microcluster downstreams to specify extra servers that they would like microcluster to set up. Handlers in the extension servers will have access to microcluster state.

To do:
- [x] Discuss implications for authentication.
- [x] Separate commits