### PR TITLE
Rename `internal` to `core`

### DIFF
--- a/cluster/cluster_members.go
+++ b/cluster/cluster_members.go
@@ -17,21 +17,21 @@ import (
 //go:generate -command mapper lxd-generate db mapper -t cluster_members.mapper.go
 //go:generate mapper reset
 //
-//go:generate mapper stmt -e internal_cluster_member objects table=internal_cluster_members
-//go:generate mapper stmt -e internal_cluster_member objects-by-Address table=internal_cluster_members
-//go:generate mapper stmt -e internal_cluster_member objects-by-Name table=internal_cluster_members
-//go:generate mapper stmt -e internal_cluster_member id table=internal_cluster_members
-//go:generate mapper stmt -e internal_cluster_member create table=internal_cluster_members
-//go:generate mapper stmt -e internal_cluster_member delete-by-Address table=internal_cluster_members
-//go:generate mapper stmt -e internal_cluster_member update table=internal_cluster_members
+//go:generate mapper stmt -e core_cluster_member objects table=core_cluster_members
+//go:generate mapper stmt -e core_cluster_member objects-by-Address table=core_cluster_members
+//go:generate mapper stmt -e core_cluster_member objects-by-Name table=core_cluster_members
+//go:generate mapper stmt -e core_cluster_member id table=core_cluster_members
+//go:generate mapper stmt -e core_cluster_member create table=core_cluster_members
+//go:generate mapper stmt -e core_cluster_member delete-by-Address table=core_cluster_members
+//go:generate mapper stmt -e core_cluster_member update table=core_cluster_members
 //
-//go:generate mapper method -i -e internal_cluster_member GetMany table=internal_cluster_members
-//go:generate mapper method -i -e internal_cluster_member GetOne table=internal_cluster_members
-//go:generate mapper method -i -e internal_cluster_member ID table=internal_cluster_members
-//go:generate mapper method -i -e internal_cluster_member Exists table=internal_cluster_members
-//go:generate mapper method -i -e internal_cluster_member Create table=internal_cluster_members
-//go:generate mapper method -i -e internal_cluster_member DeleteOne-by-Address table=internal_cluster_members
-//go:generate mapper method -i -e internal_cluster_member Update table=internal_cluster_members
+//go:generate mapper method -i -e core_cluster_member GetMany table=core_cluster_members
+//go:generate mapper method -i -e core_cluster_member GetOne table=core_cluster_members
+//go:generate mapper method -i -e core_cluster_member ID table=core_cluster_members
+//go:generate mapper method -i -e core_cluster_member Exists table=core_cluster_members
+//go:generate mapper method -i -e core_cluster_member Create table=core_cluster_members
+//go:generate mapper method -i -e core_cluster_member DeleteOne-by-Address table=core_cluster_members
+//go:generate mapper method -i -e core_cluster_member Update table=core_cluster_members
 
 // Role is the role of the dqlite cluster member.
 type Role string
@@ -39,8 +39,8 @@ type Role string
 // Pending indicates that a node is about to be added or removed.
 const Pending Role = "PENDING"
 
-// InternalClusterMember represents the global database entry for a dqlite cluster member.
-type InternalClusterMember struct {
+// CoreClusterMember represents the global database entry for a dqlite cluster member.
+type CoreClusterMember struct {
 	ID             int
 	Name           string `db:"primary=yes"`
 	Address        string
@@ -52,15 +52,15 @@ type InternalClusterMember struct {
 	Role           Role
 }
 
-// InternalClusterMemberFilter is used for filtering queries using generated methods.
-type InternalClusterMemberFilter struct {
+// CoreClusterMemberFilter is used for filtering queries using generated methods.
+type CoreClusterMemberFilter struct {
 	Address *string
 	Name    *string
 }
 
 // ToAPI returns the api struct for a ClusterMember database entity.
 // The cluster member's status will be reported as unreachable by default.
-func (c InternalClusterMember) ToAPI() (*internalTypes.ClusterMember, error) {
+func (c CoreClusterMember) ToAPI() (*internalTypes.ClusterMember, error) {
 	address, err := types.ParseAddrPort(c.Address)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to parse address %q of database cluster member: %w", c.Address, err)

--- a/cluster/cluster_members.go
+++ b/cluster/cluster_members.go
@@ -10,7 +10,6 @@ import (
 	"github.com/canonical/lxd/shared/logger"
 
 	"github.com/canonical/microcluster/internal/extensions"
-	internalTypes "github.com/canonical/microcluster/internal/rest/types"
 	"github.com/canonical/microcluster/rest/types"
 )
 
@@ -60,7 +59,7 @@ type CoreClusterMemberFilter struct {
 
 // ToAPI returns the api struct for a ClusterMember database entity.
 // The cluster member's status will be reported as unreachable by default.
-func (c CoreClusterMember) ToAPI() (*internalTypes.ClusterMember, error) {
+func (c CoreClusterMember) ToAPI() (*types.ClusterMember, error) {
 	address, err := types.ParseAddrPort(c.Address)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to parse address %q of database cluster member: %w", c.Address, err)
@@ -71,8 +70,8 @@ func (c CoreClusterMember) ToAPI() (*internalTypes.ClusterMember, error) {
 		return nil, fmt.Errorf("Failed to parse certificate of database cluster member with address %q: %w", c.Address, err)
 	}
 
-	return &internalTypes.ClusterMember{
-		ClusterMemberLocal: internalTypes.ClusterMemberLocal{
+	return &types.ClusterMember{
+		ClusterMemberLocal: types.ClusterMemberLocal{
 			Name:        c.Name,
 			Address:     address,
 			Certificate: *certificate,
@@ -81,7 +80,7 @@ func (c CoreClusterMember) ToAPI() (*internalTypes.ClusterMember, error) {
 		SchemaInternalVersion: c.SchemaInternal,
 		SchemaExternalVersion: c.SchemaExternal,
 		LastHeartbeat:         c.Heartbeat,
-		Status:                internalTypes.MemberUnreachable,
+		Status:                types.MemberUnreachable,
 		Extensions:            c.APIExtensions,
 	}, nil
 }

--- a/cluster/cluster_members.mapper.go
+++ b/cluster/cluster_members.mapper.go
@@ -16,107 +16,107 @@ import (
 
 var _ = api.ServerEnvironment{}
 
-var internalClusterMemberObjects = RegisterStmt(`
-SELECT internal_cluster_members.id, internal_cluster_members.name, internal_cluster_members.address, internal_cluster_members.certificate, internal_cluster_members.schema_internal, internal_cluster_members.schema_external, internal_cluster_members.api_extensions, internal_cluster_members.heartbeat, internal_cluster_members.role
-  FROM internal_cluster_members
-  ORDER BY internal_cluster_members.name
+var coreClusterMemberObjects = RegisterStmt(`
+SELECT core_cluster_members.id, core_cluster_members.name, core_cluster_members.address, core_cluster_members.certificate, core_cluster_members.schema_internal, core_cluster_members.schema_external, core_cluster_members.api_extensions, core_cluster_members.heartbeat, core_cluster_members.role
+  FROM core_cluster_members
+  ORDER BY core_cluster_members.name
 `)
 
-var internalClusterMemberObjectsByAddress = RegisterStmt(`
-SELECT internal_cluster_members.id, internal_cluster_members.name, internal_cluster_members.address, internal_cluster_members.certificate, internal_cluster_members.schema_internal, internal_cluster_members.schema_external, internal_cluster_members.api_extensions, internal_cluster_members.heartbeat, internal_cluster_members.role
-  FROM internal_cluster_members
-  WHERE ( internal_cluster_members.address = ? )
-  ORDER BY internal_cluster_members.name
+var coreClusterMemberObjectsByAddress = RegisterStmt(`
+SELECT core_cluster_members.id, core_cluster_members.name, core_cluster_members.address, core_cluster_members.certificate, core_cluster_members.schema_internal, core_cluster_members.schema_external, core_cluster_members.api_extensions, core_cluster_members.heartbeat, core_cluster_members.role
+  FROM core_cluster_members
+  WHERE ( core_cluster_members.address = ? )
+  ORDER BY core_cluster_members.name
 `)
 
-var internalClusterMemberObjectsByName = RegisterStmt(`
-SELECT internal_cluster_members.id, internal_cluster_members.name, internal_cluster_members.address, internal_cluster_members.certificate, internal_cluster_members.schema_internal, internal_cluster_members.schema_external, internal_cluster_members.api_extensions, internal_cluster_members.heartbeat, internal_cluster_members.role
-  FROM internal_cluster_members
-  WHERE ( internal_cluster_members.name = ? )
-  ORDER BY internal_cluster_members.name
+var coreClusterMemberObjectsByName = RegisterStmt(`
+SELECT core_cluster_members.id, core_cluster_members.name, core_cluster_members.address, core_cluster_members.certificate, core_cluster_members.schema_internal, core_cluster_members.schema_external, core_cluster_members.api_extensions, core_cluster_members.heartbeat, core_cluster_members.role
+  FROM core_cluster_members
+  WHERE ( core_cluster_members.name = ? )
+  ORDER BY core_cluster_members.name
 `)
 
-var internalClusterMemberID = RegisterStmt(`
-SELECT internal_cluster_members.id FROM internal_cluster_members
-  WHERE internal_cluster_members.name = ?
+var coreClusterMemberID = RegisterStmt(`
+SELECT core_cluster_members.id FROM core_cluster_members
+  WHERE core_cluster_members.name = ?
 `)
 
-var internalClusterMemberCreate = RegisterStmt(`
-INSERT INTO internal_cluster_members (name, address, certificate, schema_internal, schema_external, api_extensions, heartbeat, role)
+var coreClusterMemberCreate = RegisterStmt(`
+INSERT INTO core_cluster_members (name, address, certificate, schema_internal, schema_external, api_extensions, heartbeat, role)
   VALUES (?, ?, ?, ?, ?, ?, ?, ?)
 `)
 
-var internalClusterMemberDeleteByAddress = RegisterStmt(`
-DELETE FROM internal_cluster_members WHERE address = ?
+var coreClusterMemberDeleteByAddress = RegisterStmt(`
+DELETE FROM core_cluster_members WHERE address = ?
 `)
 
-var internalClusterMemberUpdate = RegisterStmt(`
-UPDATE internal_cluster_members
+var coreClusterMemberUpdate = RegisterStmt(`
+UPDATE core_cluster_members
   SET name = ?, address = ?, certificate = ?, schema_internal = ?, schema_external = ?, api_extensions = ?, heartbeat = ?, role = ?
  WHERE id = ?
 `)
 
-// internalClusterMemberColumns returns a string of column names to be used with a SELECT statement for the entity.
-// Use this function when building statements to retrieve database entries matching the InternalClusterMember entity.
-func internalClusterMemberColumns() string {
-	return "internal_cluster_members.id, internal_cluster_members.name, internal_cluster_members.address, internal_cluster_members.certificate, internal_cluster_members.schema_internal, internal_cluster_members.schema_external, internal_cluster_members.api_extensions, internal_cluster_members.heartbeat, internal_cluster_members.role"
+// coreClusterMemberColumns returns a string of column names to be used with a SELECT statement for the entity.
+// Use this function when building statements to retrieve database entries matching the CoreClusterMember entity.
+func coreClusterMemberColumns() string {
+	return "core_cluster_members.id, core_cluster_members.name, core_cluster_members.address, core_cluster_members.certificate, core_cluster_members.schema_internal, core_cluster_members.schema_external, core_cluster_members.api_extensions, core_cluster_members.heartbeat, core_cluster_members.role"
 }
 
-// getInternalClusterMembers can be used to run handwritten sql.Stmts to return a slice of objects.
-func getInternalClusterMembers(ctx context.Context, stmt *sql.Stmt, args ...any) ([]InternalClusterMember, error) {
-	objects := make([]InternalClusterMember, 0)
+// getCoreClusterMembers can be used to run handwritten sql.Stmts to return a slice of objects.
+func getCoreClusterMembers(ctx context.Context, stmt *sql.Stmt, args ...any) ([]CoreClusterMember, error) {
+	objects := make([]CoreClusterMember, 0)
 
 	dest := func(scan func(dest ...any) error) error {
-		i := InternalClusterMember{}
-		err := scan(&i.ID, &i.Name, &i.Address, &i.Certificate, &i.SchemaInternal, &i.SchemaExternal, &i.APIExtensions, &i.Heartbeat, &i.Role)
+		c := CoreClusterMember{}
+		err := scan(&c.ID, &c.Name, &c.Address, &c.Certificate, &c.SchemaInternal, &c.SchemaExternal, &c.APIExtensions, &c.Heartbeat, &c.Role)
 		if err != nil {
 			return err
 		}
 
-		objects = append(objects, i)
+		objects = append(objects, c)
 
 		return nil
 	}
 
 	err := query.SelectObjects(ctx, stmt, dest, args...)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to fetch from \"internal_cluster_members\" table: %w", err)
+		return nil, fmt.Errorf("Failed to fetch from \"core_cluster_members\" table: %w", err)
 	}
 
 	return objects, nil
 }
 
-// getInternalClusterMembersRaw can be used to run handwritten query strings to return a slice of objects.
-func getInternalClusterMembersRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]InternalClusterMember, error) {
-	objects := make([]InternalClusterMember, 0)
+// getCoreClusterMembersRaw can be used to run handwritten query strings to return a slice of objects.
+func getCoreClusterMembersRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]CoreClusterMember, error) {
+	objects := make([]CoreClusterMember, 0)
 
 	dest := func(scan func(dest ...any) error) error {
-		i := InternalClusterMember{}
-		err := scan(&i.ID, &i.Name, &i.Address, &i.Certificate, &i.SchemaInternal, &i.SchemaExternal, &i.APIExtensions, &i.Heartbeat, &i.Role)
+		c := CoreClusterMember{}
+		err := scan(&c.ID, &c.Name, &c.Address, &c.Certificate, &c.SchemaInternal, &c.SchemaExternal, &c.APIExtensions, &c.Heartbeat, &c.Role)
 		if err != nil {
 			return err
 		}
 
-		objects = append(objects, i)
+		objects = append(objects, c)
 
 		return nil
 	}
 
 	err := query.Scan(ctx, tx, sql, dest, args...)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to fetch from \"internal_cluster_members\" table: %w", err)
+		return nil, fmt.Errorf("Failed to fetch from \"core_cluster_members\" table: %w", err)
 	}
 
 	return objects, nil
 }
 
-// GetInternalClusterMembers returns all available internal_cluster_members.
-// generator: internal_cluster_member GetMany
-func GetInternalClusterMembers(ctx context.Context, tx *sql.Tx, filters ...InternalClusterMemberFilter) ([]InternalClusterMember, error) {
+// GetCoreClusterMembers returns all available core_cluster_members.
+// generator: core_cluster_member GetMany
+func GetCoreClusterMembers(ctx context.Context, tx *sql.Tx, filters ...CoreClusterMemberFilter) ([]CoreClusterMember, error) {
 	var err error
 
 	// Result slice.
-	objects := make([]InternalClusterMember, 0)
+	objects := make([]CoreClusterMember, 0)
 
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var sqlStmt *sql.Stmt
@@ -124,9 +124,9 @@ func GetInternalClusterMembers(ctx context.Context, tx *sql.Tx, filters ...Inter
 	queryParts := [2]string{}
 
 	if len(filters) == 0 {
-		sqlStmt, err = Stmt(tx, internalClusterMemberObjects)
+		sqlStmt, err = Stmt(tx, coreClusterMemberObjects)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"internalClusterMemberObjects\" prepared statement: %w", err)
+			return nil, fmt.Errorf("Failed to get \"coreClusterMemberObjects\" prepared statement: %w", err)
 		}
 	}
 
@@ -134,17 +134,17 @@ func GetInternalClusterMembers(ctx context.Context, tx *sql.Tx, filters ...Inter
 		if filter.Name != nil && filter.Address == nil {
 			args = append(args, []any{filter.Name}...)
 			if len(filters) == 1 {
-				sqlStmt, err = Stmt(tx, internalClusterMemberObjectsByName)
+				sqlStmt, err = Stmt(tx, coreClusterMemberObjectsByName)
 				if err != nil {
-					return nil, fmt.Errorf("Failed to get \"internalClusterMemberObjectsByName\" prepared statement: %w", err)
+					return nil, fmt.Errorf("Failed to get \"coreClusterMemberObjectsByName\" prepared statement: %w", err)
 				}
 
 				break
 			}
 
-			query, err := StmtString(internalClusterMemberObjectsByName)
+			query, err := StmtString(coreClusterMemberObjectsByName)
 			if err != nil {
-				return nil, fmt.Errorf("Failed to get \"internalClusterMemberObjects\" prepared statement: %w", err)
+				return nil, fmt.Errorf("Failed to get \"coreClusterMemberObjects\" prepared statement: %w", err)
 			}
 
 			parts := strings.SplitN(query, "ORDER BY", 2)
@@ -158,17 +158,17 @@ func GetInternalClusterMembers(ctx context.Context, tx *sql.Tx, filters ...Inter
 		} else if filter.Address != nil && filter.Name == nil {
 			args = append(args, []any{filter.Address}...)
 			if len(filters) == 1 {
-				sqlStmt, err = Stmt(tx, internalClusterMemberObjectsByAddress)
+				sqlStmt, err = Stmt(tx, coreClusterMemberObjectsByAddress)
 				if err != nil {
-					return nil, fmt.Errorf("Failed to get \"internalClusterMemberObjectsByAddress\" prepared statement: %w", err)
+					return nil, fmt.Errorf("Failed to get \"coreClusterMemberObjectsByAddress\" prepared statement: %w", err)
 				}
 
 				break
 			}
 
-			query, err := StmtString(internalClusterMemberObjectsByAddress)
+			query, err := StmtString(coreClusterMemberObjectsByAddress)
 			if err != nil {
-				return nil, fmt.Errorf("Failed to get \"internalClusterMemberObjects\" prepared statement: %w", err)
+				return nil, fmt.Errorf("Failed to get \"coreClusterMemberObjects\" prepared statement: %w", err)
 			}
 
 			parts := strings.SplitN(query, "ORDER BY", 2)
@@ -180,7 +180,7 @@ func GetInternalClusterMembers(ctx context.Context, tx *sql.Tx, filters ...Inter
 			_, where, _ := strings.Cut(parts[0], "WHERE")
 			queryParts[0] += "OR" + where
 		} else if filter.Address == nil && filter.Name == nil {
-			return nil, fmt.Errorf("Cannot filter on empty InternalClusterMemberFilter")
+			return nil, fmt.Errorf("Cannot filter on empty CoreClusterMemberFilter")
 		} else {
 			return nil, fmt.Errorf("No statement exists for the given Filter")
 		}
@@ -188,66 +188,66 @@ func GetInternalClusterMembers(ctx context.Context, tx *sql.Tx, filters ...Inter
 
 	// Select.
 	if sqlStmt != nil {
-		objects, err = getInternalClusterMembers(ctx, sqlStmt, args...)
+		objects, err = getCoreClusterMembers(ctx, sqlStmt, args...)
 	} else {
 		queryStr := strings.Join(queryParts[:], "ORDER BY")
-		objects, err = getInternalClusterMembersRaw(ctx, tx, queryStr, args...)
+		objects, err = getCoreClusterMembersRaw(ctx, tx, queryStr, args...)
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("Failed to fetch from \"internal_cluster_members\" table: %w", err)
+		return nil, fmt.Errorf("Failed to fetch from \"core_cluster_members\" table: %w", err)
 	}
 
 	return objects, nil
 }
 
-// GetInternalClusterMember returns the internal_cluster_member with the given key.
-// generator: internal_cluster_member GetOne
-func GetInternalClusterMember(ctx context.Context, tx *sql.Tx, name string) (*InternalClusterMember, error) {
-	filter := InternalClusterMemberFilter{}
+// GetCoreClusterMember returns the core_cluster_member with the given key.
+// generator: core_cluster_member GetOne
+func GetCoreClusterMember(ctx context.Context, tx *sql.Tx, name string) (*CoreClusterMember, error) {
+	filter := CoreClusterMemberFilter{}
 	filter.Name = &name
 
-	objects, err := GetInternalClusterMembers(ctx, tx, filter)
+	objects, err := GetCoreClusterMembers(ctx, tx, filter)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to fetch from \"internal_cluster_members\" table: %w", err)
+		return nil, fmt.Errorf("Failed to fetch from \"core_cluster_members\" table: %w", err)
 	}
 
 	switch len(objects) {
 	case 0:
-		return nil, api.StatusErrorf(http.StatusNotFound, "InternalClusterMember not found")
+		return nil, api.StatusErrorf(http.StatusNotFound, "CoreClusterMember not found")
 	case 1:
 		return &objects[0], nil
 	default:
-		return nil, fmt.Errorf("More than one \"internal_cluster_members\" entry matches")
+		return nil, fmt.Errorf("More than one \"core_cluster_members\" entry matches")
 	}
 }
 
-// GetInternalClusterMemberID return the ID of the internal_cluster_member with the given key.
-// generator: internal_cluster_member ID
-func GetInternalClusterMemberID(ctx context.Context, tx *sql.Tx, name string) (int64, error) {
-	stmt, err := Stmt(tx, internalClusterMemberID)
+// GetCoreClusterMemberID return the ID of the core_cluster_member with the given key.
+// generator: core_cluster_member ID
+func GetCoreClusterMemberID(ctx context.Context, tx *sql.Tx, name string) (int64, error) {
+	stmt, err := Stmt(tx, coreClusterMemberID)
 	if err != nil {
-		return -1, fmt.Errorf("Failed to get \"internalClusterMemberID\" prepared statement: %w", err)
+		return -1, fmt.Errorf("Failed to get \"coreClusterMemberID\" prepared statement: %w", err)
 	}
 
 	row := stmt.QueryRowContext(ctx, name)
 	var id int64
 	err = row.Scan(&id)
 	if errors.Is(err, sql.ErrNoRows) {
-		return -1, api.StatusErrorf(http.StatusNotFound, "InternalClusterMember not found")
+		return -1, api.StatusErrorf(http.StatusNotFound, "CoreClusterMember not found")
 	}
 
 	if err != nil {
-		return -1, fmt.Errorf("Failed to get \"internal_cluster_members\" ID: %w", err)
+		return -1, fmt.Errorf("Failed to get \"core_cluster_members\" ID: %w", err)
 	}
 
 	return id, nil
 }
 
-// InternalClusterMemberExists checks if a internal_cluster_member with the given key exists.
-// generator: internal_cluster_member Exists
-func InternalClusterMemberExists(ctx context.Context, tx *sql.Tx, name string) (bool, error) {
-	_, err := GetInternalClusterMemberID(ctx, tx, name)
+// CoreClusterMemberExists checks if a core_cluster_member with the given key exists.
+// generator: core_cluster_member Exists
+func CoreClusterMemberExists(ctx context.Context, tx *sql.Tx, name string) (bool, error) {
+	_, err := GetCoreClusterMemberID(ctx, tx, name)
 	if err != nil {
 		if api.StatusErrorCheck(err, http.StatusNotFound) {
 			return false, nil
@@ -259,17 +259,17 @@ func InternalClusterMemberExists(ctx context.Context, tx *sql.Tx, name string) (
 	return true, nil
 }
 
-// CreateInternalClusterMember adds a new internal_cluster_member to the database.
-// generator: internal_cluster_member Create
-func CreateInternalClusterMember(ctx context.Context, tx *sql.Tx, object InternalClusterMember) (int64, error) {
-	// Check if a internal_cluster_member with the same key exists.
-	exists, err := InternalClusterMemberExists(ctx, tx, object.Name)
+// CreateCoreClusterMember adds a new core_cluster_member to the database.
+// generator: core_cluster_member Create
+func CreateCoreClusterMember(ctx context.Context, tx *sql.Tx, object CoreClusterMember) (int64, error) {
+	// Check if a core_cluster_member with the same key exists.
+	exists, err := CoreClusterMemberExists(ctx, tx, object.Name)
 	if err != nil {
 		return -1, fmt.Errorf("Failed to check for duplicates: %w", err)
 	}
 
 	if exists {
-		return -1, api.StatusErrorf(http.StatusConflict, "This \"internal_cluster_members\" entry already exists")
+		return -1, api.StatusErrorf(http.StatusConflict, "This \"core_cluster_members\" entry already exists")
 	}
 
 	args := make([]any, 8)
@@ -285,36 +285,36 @@ func CreateInternalClusterMember(ctx context.Context, tx *sql.Tx, object Interna
 	args[7] = object.Role
 
 	// Prepared statement to use.
-	stmt, err := Stmt(tx, internalClusterMemberCreate)
+	stmt, err := Stmt(tx, coreClusterMemberCreate)
 	if err != nil {
-		return -1, fmt.Errorf("Failed to get \"internalClusterMemberCreate\" prepared statement: %w", err)
+		return -1, fmt.Errorf("Failed to get \"coreClusterMemberCreate\" prepared statement: %w", err)
 	}
 
 	// Execute the statement.
 	result, err := stmt.Exec(args...)
 	if err != nil {
-		return -1, fmt.Errorf("Failed to create \"internal_cluster_members\" entry: %w", err)
+		return -1, fmt.Errorf("Failed to create \"core_cluster_members\" entry: %w", err)
 	}
 
 	id, err := result.LastInsertId()
 	if err != nil {
-		return -1, fmt.Errorf("Failed to fetch \"internal_cluster_members\" entry ID: %w", err)
+		return -1, fmt.Errorf("Failed to fetch \"core_cluster_members\" entry ID: %w", err)
 	}
 
 	return id, nil
 }
 
-// DeleteInternalClusterMember deletes the internal_cluster_member matching the given key parameters.
-// generator: internal_cluster_member DeleteOne-by-Address
-func DeleteInternalClusterMember(ctx context.Context, tx *sql.Tx, address string) error {
-	stmt, err := Stmt(tx, internalClusterMemberDeleteByAddress)
+// DeleteCoreClusterMember deletes the core_cluster_member matching the given key parameters.
+// generator: core_cluster_member DeleteOne-by-Address
+func DeleteCoreClusterMember(ctx context.Context, tx *sql.Tx, address string) error {
+	stmt, err := Stmt(tx, coreClusterMemberDeleteByAddress)
 	if err != nil {
-		return fmt.Errorf("Failed to get \"internalClusterMemberDeleteByAddress\" prepared statement: %w", err)
+		return fmt.Errorf("Failed to get \"coreClusterMemberDeleteByAddress\" prepared statement: %w", err)
 	}
 
 	result, err := stmt.Exec(address)
 	if err != nil {
-		return fmt.Errorf("Delete \"internal_cluster_members\": %w", err)
+		return fmt.Errorf("Delete \"core_cluster_members\": %w", err)
 	}
 
 	n, err := result.RowsAffected()
@@ -323,30 +323,30 @@ func DeleteInternalClusterMember(ctx context.Context, tx *sql.Tx, address string
 	}
 
 	if n == 0 {
-		return api.StatusErrorf(http.StatusNotFound, "InternalClusterMember not found")
+		return api.StatusErrorf(http.StatusNotFound, "CoreClusterMember not found")
 	} else if n > 1 {
-		return fmt.Errorf("Query deleted %d InternalClusterMember rows instead of 1", n)
+		return fmt.Errorf("Query deleted %d CoreClusterMember rows instead of 1", n)
 	}
 
 	return nil
 }
 
-// UpdateInternalClusterMember updates the internal_cluster_member matching the given key parameters.
-// generator: internal_cluster_member Update
-func UpdateInternalClusterMember(ctx context.Context, tx *sql.Tx, name string, object InternalClusterMember) error {
-	id, err := GetInternalClusterMemberID(ctx, tx, name)
+// UpdateCoreClusterMember updates the core_cluster_member matching the given key parameters.
+// generator: core_cluster_member Update
+func UpdateCoreClusterMember(ctx context.Context, tx *sql.Tx, name string, object CoreClusterMember) error {
+	id, err := GetCoreClusterMemberID(ctx, tx, name)
 	if err != nil {
 		return err
 	}
 
-	stmt, err := Stmt(tx, internalClusterMemberUpdate)
+	stmt, err := Stmt(tx, coreClusterMemberUpdate)
 	if err != nil {
-		return fmt.Errorf("Failed to get \"internalClusterMemberUpdate\" prepared statement: %w", err)
+		return fmt.Errorf("Failed to get \"coreClusterMemberUpdate\" prepared statement: %w", err)
 	}
 
 	result, err := stmt.Exec(object.Name, object.Address, object.Certificate, object.SchemaInternal, object.SchemaExternal, object.APIExtensions, object.Heartbeat, object.Role, id)
 	if err != nil {
-		return fmt.Errorf("Update \"internal_cluster_members\" entry failed: %w", err)
+		return fmt.Errorf("Update \"core_cluster_members\" entry failed: %w", err)
 	}
 
 	n, err := result.RowsAffected()

--- a/cluster/token_records.go
+++ b/cluster/token_records.go
@@ -14,35 +14,35 @@ import (
 //go:generate -command mapper lxd-generate db mapper -t token_records.mapper.go
 //go:generate mapper reset
 //
-//go:generate mapper stmt -e internal_token_record objects table=internal_token_records
-//go:generate mapper stmt -e internal_token_record objects-by-Secret table=internal_token_records
-//go:generate mapper stmt -e internal_token_record id table=internal_token_records
-//go:generate mapper stmt -e internal_token_record create table=internal_token_records
-//go:generate mapper stmt -e internal_token_record delete-by-Name table=internal_token_records
+//go:generate mapper stmt -e core_token_record objects table=core_token_records
+//go:generate mapper stmt -e core_token_record objects-by-Secret table=core_token_records
+//go:generate mapper stmt -e core_token_record id table=core_token_records
+//go:generate mapper stmt -e core_token_record create table=core_token_records
+//go:generate mapper stmt -e core_token_record delete-by-Name table=core_token_records
 //
-//go:generate mapper method -e internal_token_record ID table=internal_token_records
-//go:generate mapper method -e internal_token_record Exists table=internal_token_records
-//go:generate mapper method -e internal_token_record GetOne table=internal_token_records
-//go:generate mapper method -e internal_token_record GetMany table=internal_token_records
-//go:generate mapper method -e internal_token_record Create table=internal_token_records
-//go:generate mapper method -e internal_token_record DeleteOne-by-Name table=internal_token_records
+//go:generate mapper method -e core_token_record ID table=core_token_records
+//go:generate mapper method -e core_token_record Exists table=core_token_records
+//go:generate mapper method -e core_token_record GetOne table=core_token_records
+//go:generate mapper method -e core_token_record GetMany table=core_token_records
+//go:generate mapper method -e core_token_record Create table=core_token_records
+//go:generate mapper method -e core_token_record DeleteOne-by-Name table=core_token_records
 
-// InternalTokenRecord is the database representation of a join token record.
-type InternalTokenRecord struct {
+// CoreTokenRecord is the database representation of a join token record.
+type CoreTokenRecord struct {
 	ID     int
 	Secret string `db:"primary=yes"`
 	Name   string
 }
 
-// InternalTokenRecordFilter is the filter struct for filtering results from generated methods.
-type InternalTokenRecordFilter struct {
+// CoreTokenRecordFilter is the filter struct for filtering results from generated methods.
+type CoreTokenRecordFilter struct {
 	ID     *int
 	Secret *string
 	Name   *string
 }
 
-// ToAPI converts the InternalTokenRecord to a full token and returns an API compatible struct.
-func (t *InternalTokenRecord) ToAPI(clusterCert *x509.Certificate, joinAddresses []types.AddrPort) (*internalTypes.TokenRecord, error) {
+// ToAPI converts the CoreTokenRecord to a full token and returns an API compatible struct.
+func (t *CoreTokenRecord) ToAPI(clusterCert *x509.Certificate, joinAddresses []types.AddrPort) (*internalTypes.TokenRecord, error) {
 	token := internalTypes.Token{
 		Secret:        t.Secret,
 		Fingerprint:   shared.CertFingerprint(clusterCert),

--- a/cluster/token_records.mapper.go
+++ b/cluster/token_records.mapper.go
@@ -16,59 +16,59 @@ import (
 
 var _ = api.ServerEnvironment{}
 
-var internalTokenRecordObjects = RegisterStmt(`
-SELECT internal_token_records.id, internal_token_records.secret, internal_token_records.name
-  FROM internal_token_records
-  ORDER BY internal_token_records.secret
+var coreTokenRecordObjects = RegisterStmt(`
+SELECT core_token_records.id, core_token_records.secret, core_token_records.name
+  FROM core_token_records
+  ORDER BY core_token_records.secret
 `)
 
-var internalTokenRecordObjectsBySecret = RegisterStmt(`
-SELECT internal_token_records.id, internal_token_records.secret, internal_token_records.name
-  FROM internal_token_records
-  WHERE ( internal_token_records.secret = ? )
-  ORDER BY internal_token_records.secret
+var coreTokenRecordObjectsBySecret = RegisterStmt(`
+SELECT core_token_records.id, core_token_records.secret, core_token_records.name
+  FROM core_token_records
+  WHERE ( core_token_records.secret = ? )
+  ORDER BY core_token_records.secret
 `)
 
-var internalTokenRecordID = RegisterStmt(`
-SELECT internal_token_records.id FROM internal_token_records
-  WHERE internal_token_records.secret = ?
+var coreTokenRecordID = RegisterStmt(`
+SELECT core_token_records.id FROM core_token_records
+  WHERE core_token_records.secret = ?
 `)
 
-var internalTokenRecordCreate = RegisterStmt(`
-INSERT INTO internal_token_records (secret, name)
+var coreTokenRecordCreate = RegisterStmt(`
+INSERT INTO core_token_records (secret, name)
   VALUES (?, ?)
 `)
 
-var internalTokenRecordDeleteByName = RegisterStmt(`
-DELETE FROM internal_token_records WHERE name = ?
+var coreTokenRecordDeleteByName = RegisterStmt(`
+DELETE FROM core_token_records WHERE name = ?
 `)
 
-// GetInternalTokenRecordID return the ID of the internal_token_record with the given key.
-// generator: internal_token_record ID
-func GetInternalTokenRecordID(ctx context.Context, tx *sql.Tx, secret string) (int64, error) {
-	stmt, err := Stmt(tx, internalTokenRecordID)
+// GetCoreTokenRecordID return the ID of the core_token_record with the given key.
+// generator: core_token_record ID
+func GetCoreTokenRecordID(ctx context.Context, tx *sql.Tx, secret string) (int64, error) {
+	stmt, err := Stmt(tx, coreTokenRecordID)
 	if err != nil {
-		return -1, fmt.Errorf("Failed to get \"internalTokenRecordID\" prepared statement: %w", err)
+		return -1, fmt.Errorf("Failed to get \"coreTokenRecordID\" prepared statement: %w", err)
 	}
 
 	row := stmt.QueryRowContext(ctx, secret)
 	var id int64
 	err = row.Scan(&id)
 	if errors.Is(err, sql.ErrNoRows) {
-		return -1, api.StatusErrorf(http.StatusNotFound, "InternalTokenRecord not found")
+		return -1, api.StatusErrorf(http.StatusNotFound, "CoreTokenRecord not found")
 	}
 
 	if err != nil {
-		return -1, fmt.Errorf("Failed to get \"internal_token_records\" ID: %w", err)
+		return -1, fmt.Errorf("Failed to get \"core_token_records\" ID: %w", err)
 	}
 
 	return id, nil
 }
 
-// InternalTokenRecordExists checks if a internal_token_record with the given key exists.
-// generator: internal_token_record Exists
-func InternalTokenRecordExists(ctx context.Context, tx *sql.Tx, secret string) (bool, error) {
-	_, err := GetInternalTokenRecordID(ctx, tx, secret)
+// CoreTokenRecordExists checks if a core_token_record with the given key exists.
+// generator: core_token_record Exists
+func CoreTokenRecordExists(ctx context.Context, tx *sql.Tx, secret string) (bool, error) {
+	_, err := GetCoreTokenRecordID(ctx, tx, secret)
 	if err != nil {
 		if api.StatusErrorCheck(err, http.StatusNotFound) {
 			return false, nil
@@ -80,88 +80,88 @@ func InternalTokenRecordExists(ctx context.Context, tx *sql.Tx, secret string) (
 	return true, nil
 }
 
-// GetInternalTokenRecord returns the internal_token_record with the given key.
-// generator: internal_token_record GetOne
-func GetInternalTokenRecord(ctx context.Context, tx *sql.Tx, secret string) (*InternalTokenRecord, error) {
-	filter := InternalTokenRecordFilter{}
+// GetCoreTokenRecord returns the core_token_record with the given key.
+// generator: core_token_record GetOne
+func GetCoreTokenRecord(ctx context.Context, tx *sql.Tx, secret string) (*CoreTokenRecord, error) {
+	filter := CoreTokenRecordFilter{}
 	filter.Secret = &secret
 
-	objects, err := GetInternalTokenRecords(ctx, tx, filter)
+	objects, err := GetCoreTokenRecords(ctx, tx, filter)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to fetch from \"internal_token_records\" table: %w", err)
+		return nil, fmt.Errorf("Failed to fetch from \"core_token_records\" table: %w", err)
 	}
 
 	switch len(objects) {
 	case 0:
-		return nil, api.StatusErrorf(http.StatusNotFound, "InternalTokenRecord not found")
+		return nil, api.StatusErrorf(http.StatusNotFound, "CoreTokenRecord not found")
 	case 1:
 		return &objects[0], nil
 	default:
-		return nil, fmt.Errorf("More than one \"internal_token_records\" entry matches")
+		return nil, fmt.Errorf("More than one \"core_token_records\" entry matches")
 	}
 }
 
-// internalTokenRecordColumns returns a string of column names to be used with a SELECT statement for the entity.
-// Use this function when building statements to retrieve database entries matching the InternalTokenRecord entity.
-func internalTokenRecordColumns() string {
-	return "internal_token_records.id, internal_token_records.secret, internal_token_records.name"
+// coreTokenRecordColumns returns a string of column names to be used with a SELECT statement for the entity.
+// Use this function when building statements to retrieve database entries matching the CoreTokenRecord entity.
+func coreTokenRecordColumns() string {
+	return "core_token_records.id, core_token_records.secret, core_token_records.name"
 }
 
-// getInternalTokenRecords can be used to run handwritten sql.Stmts to return a slice of objects.
-func getInternalTokenRecords(ctx context.Context, stmt *sql.Stmt, args ...any) ([]InternalTokenRecord, error) {
-	objects := make([]InternalTokenRecord, 0)
+// getCoreTokenRecords can be used to run handwritten sql.Stmts to return a slice of objects.
+func getCoreTokenRecords(ctx context.Context, stmt *sql.Stmt, args ...any) ([]CoreTokenRecord, error) {
+	objects := make([]CoreTokenRecord, 0)
 
 	dest := func(scan func(dest ...any) error) error {
-		i := InternalTokenRecord{}
-		err := scan(&i.ID, &i.Secret, &i.Name)
+		c := CoreTokenRecord{}
+		err := scan(&c.ID, &c.Secret, &c.Name)
 		if err != nil {
 			return err
 		}
 
-		objects = append(objects, i)
+		objects = append(objects, c)
 
 		return nil
 	}
 
 	err := query.SelectObjects(ctx, stmt, dest, args...)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to fetch from \"internal_token_records\" table: %w", err)
+		return nil, fmt.Errorf("Failed to fetch from \"core_token_records\" table: %w", err)
 	}
 
 	return objects, nil
 }
 
-// getInternalTokenRecordsRaw can be used to run handwritten query strings to return a slice of objects.
-func getInternalTokenRecordsRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]InternalTokenRecord, error) {
-	objects := make([]InternalTokenRecord, 0)
+// getCoreTokenRecordsRaw can be used to run handwritten query strings to return a slice of objects.
+func getCoreTokenRecordsRaw(ctx context.Context, tx *sql.Tx, sql string, args ...any) ([]CoreTokenRecord, error) {
+	objects := make([]CoreTokenRecord, 0)
 
 	dest := func(scan func(dest ...any) error) error {
-		i := InternalTokenRecord{}
-		err := scan(&i.ID, &i.Secret, &i.Name)
+		c := CoreTokenRecord{}
+		err := scan(&c.ID, &c.Secret, &c.Name)
 		if err != nil {
 			return err
 		}
 
-		objects = append(objects, i)
+		objects = append(objects, c)
 
 		return nil
 	}
 
 	err := query.Scan(ctx, tx, sql, dest, args...)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to fetch from \"internal_token_records\" table: %w", err)
+		return nil, fmt.Errorf("Failed to fetch from \"core_token_records\" table: %w", err)
 	}
 
 	return objects, nil
 }
 
-// GetInternalTokenRecords returns all available internal_token_records.
-// generator: internal_token_record GetMany
-func GetInternalTokenRecords(ctx context.Context, tx *sql.Tx, filters ...InternalTokenRecordFilter) ([]InternalTokenRecord, error) {
+// GetCoreTokenRecords returns all available core_token_records.
+// generator: core_token_record GetMany
+func GetCoreTokenRecords(ctx context.Context, tx *sql.Tx, filters ...CoreTokenRecordFilter) ([]CoreTokenRecord, error) {
 	var err error
 
 	// Result slice.
-	objects := make([]InternalTokenRecord, 0)
+	objects := make([]CoreTokenRecord, 0)
 
 	// Pick the prepared statement and arguments to use based on active criteria.
 	var sqlStmt *sql.Stmt
@@ -169,9 +169,9 @@ func GetInternalTokenRecords(ctx context.Context, tx *sql.Tx, filters ...Interna
 	queryParts := [2]string{}
 
 	if len(filters) == 0 {
-		sqlStmt, err = Stmt(tx, internalTokenRecordObjects)
+		sqlStmt, err = Stmt(tx, coreTokenRecordObjects)
 		if err != nil {
-			return nil, fmt.Errorf("Failed to get \"internalTokenRecordObjects\" prepared statement: %w", err)
+			return nil, fmt.Errorf("Failed to get \"coreTokenRecordObjects\" prepared statement: %w", err)
 		}
 	}
 
@@ -179,17 +179,17 @@ func GetInternalTokenRecords(ctx context.Context, tx *sql.Tx, filters ...Interna
 		if filter.Secret != nil && filter.ID == nil && filter.Name == nil {
 			args = append(args, []any{filter.Secret}...)
 			if len(filters) == 1 {
-				sqlStmt, err = Stmt(tx, internalTokenRecordObjectsBySecret)
+				sqlStmt, err = Stmt(tx, coreTokenRecordObjectsBySecret)
 				if err != nil {
-					return nil, fmt.Errorf("Failed to get \"internalTokenRecordObjectsBySecret\" prepared statement: %w", err)
+					return nil, fmt.Errorf("Failed to get \"coreTokenRecordObjectsBySecret\" prepared statement: %w", err)
 				}
 
 				break
 			}
 
-			query, err := StmtString(internalTokenRecordObjectsBySecret)
+			query, err := StmtString(coreTokenRecordObjectsBySecret)
 			if err != nil {
-				return nil, fmt.Errorf("Failed to get \"internalTokenRecordObjects\" prepared statement: %w", err)
+				return nil, fmt.Errorf("Failed to get \"coreTokenRecordObjects\" prepared statement: %w", err)
 			}
 
 			parts := strings.SplitN(query, "ORDER BY", 2)
@@ -201,7 +201,7 @@ func GetInternalTokenRecords(ctx context.Context, tx *sql.Tx, filters ...Interna
 			_, where, _ := strings.Cut(parts[0], "WHERE")
 			queryParts[0] += "OR" + where
 		} else if filter.ID == nil && filter.Secret == nil && filter.Name == nil {
-			return nil, fmt.Errorf("Cannot filter on empty InternalTokenRecordFilter")
+			return nil, fmt.Errorf("Cannot filter on empty CoreTokenRecordFilter")
 		} else {
 			return nil, fmt.Errorf("No statement exists for the given Filter")
 		}
@@ -209,30 +209,30 @@ func GetInternalTokenRecords(ctx context.Context, tx *sql.Tx, filters ...Interna
 
 	// Select.
 	if sqlStmt != nil {
-		objects, err = getInternalTokenRecords(ctx, sqlStmt, args...)
+		objects, err = getCoreTokenRecords(ctx, sqlStmt, args...)
 	} else {
 		queryStr := strings.Join(queryParts[:], "ORDER BY")
-		objects, err = getInternalTokenRecordsRaw(ctx, tx, queryStr, args...)
+		objects, err = getCoreTokenRecordsRaw(ctx, tx, queryStr, args...)
 	}
 
 	if err != nil {
-		return nil, fmt.Errorf("Failed to fetch from \"internal_token_records\" table: %w", err)
+		return nil, fmt.Errorf("Failed to fetch from \"core_token_records\" table: %w", err)
 	}
 
 	return objects, nil
 }
 
-// CreateInternalTokenRecord adds a new internal_token_record to the database.
-// generator: internal_token_record Create
-func CreateInternalTokenRecord(ctx context.Context, tx *sql.Tx, object InternalTokenRecord) (int64, error) {
-	// Check if a internal_token_record with the same key exists.
-	exists, err := InternalTokenRecordExists(ctx, tx, object.Secret)
+// CreateCoreTokenRecord adds a new core_token_record to the database.
+// generator: core_token_record Create
+func CreateCoreTokenRecord(ctx context.Context, tx *sql.Tx, object CoreTokenRecord) (int64, error) {
+	// Check if a core_token_record with the same key exists.
+	exists, err := CoreTokenRecordExists(ctx, tx, object.Secret)
 	if err != nil {
 		return -1, fmt.Errorf("Failed to check for duplicates: %w", err)
 	}
 
 	if exists {
-		return -1, api.StatusErrorf(http.StatusConflict, "This \"internal_token_records\" entry already exists")
+		return -1, api.StatusErrorf(http.StatusConflict, "This \"core_token_records\" entry already exists")
 	}
 
 	args := make([]any, 2)
@@ -242,36 +242,36 @@ func CreateInternalTokenRecord(ctx context.Context, tx *sql.Tx, object InternalT
 	args[1] = object.Name
 
 	// Prepared statement to use.
-	stmt, err := Stmt(tx, internalTokenRecordCreate)
+	stmt, err := Stmt(tx, coreTokenRecordCreate)
 	if err != nil {
-		return -1, fmt.Errorf("Failed to get \"internalTokenRecordCreate\" prepared statement: %w", err)
+		return -1, fmt.Errorf("Failed to get \"coreTokenRecordCreate\" prepared statement: %w", err)
 	}
 
 	// Execute the statement.
 	result, err := stmt.Exec(args...)
 	if err != nil {
-		return -1, fmt.Errorf("Failed to create \"internal_token_records\" entry: %w", err)
+		return -1, fmt.Errorf("Failed to create \"core_token_records\" entry: %w", err)
 	}
 
 	id, err := result.LastInsertId()
 	if err != nil {
-		return -1, fmt.Errorf("Failed to fetch \"internal_token_records\" entry ID: %w", err)
+		return -1, fmt.Errorf("Failed to fetch \"core_token_records\" entry ID: %w", err)
 	}
 
 	return id, nil
 }
 
-// DeleteInternalTokenRecord deletes the internal_token_record matching the given key parameters.
-// generator: internal_token_record DeleteOne-by-Name
-func DeleteInternalTokenRecord(ctx context.Context, tx *sql.Tx, name string) error {
-	stmt, err := Stmt(tx, internalTokenRecordDeleteByName)
+// DeleteCoreTokenRecord deletes the core_token_record matching the given key parameters.
+// generator: core_token_record DeleteOne-by-Name
+func DeleteCoreTokenRecord(ctx context.Context, tx *sql.Tx, name string) error {
+	stmt, err := Stmt(tx, coreTokenRecordDeleteByName)
 	if err != nil {
-		return fmt.Errorf("Failed to get \"internalTokenRecordDeleteByName\" prepared statement: %w", err)
+		return fmt.Errorf("Failed to get \"coreTokenRecordDeleteByName\" prepared statement: %w", err)
 	}
 
 	result, err := stmt.Exec(name)
 	if err != nil {
-		return fmt.Errorf("Delete \"internal_token_records\": %w", err)
+		return fmt.Errorf("Delete \"core_token_records\": %w", err)
 	}
 
 	n, err := result.RowsAffected()
@@ -280,9 +280,9 @@ func DeleteInternalTokenRecord(ctx context.Context, tx *sql.Tx, name string) err
 	}
 
 	if n == 0 {
-		return api.StatusErrorf(http.StatusNotFound, "InternalTokenRecord not found")
+		return api.StatusErrorf(http.StatusNotFound, "CoreTokenRecord not found")
 	} else if n > 1 {
-		return fmt.Errorf("Query deleted %d InternalTokenRecord rows instead of 1", n)
+		return fmt.Errorf("Query deleted %d CoreTokenRecord rows instead of 1", n)
 	}
 
 	return nil

--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -167,8 +167,8 @@ func (c *cmdDaemon) run(cmd *cobra.Command, args []string) error {
 		},
 
 		// OnNewMember is run after a new member has joined.
-		OnNewMember: func(s state.State) error {
-			logger.Infof("This is a hook that is run on peer %q when a new cluster member has joined", s.Name())
+		OnNewMember: func(s state.State, newMember types.ClusterMemberLocal) error {
+			logger.Infof("This is a hook that is run on peer %q when the new cluster member %q has joined", s.Name(), newMember.Name)
 
 			return nil
 		},

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -582,7 +582,7 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 		return err
 	}
 
-	localMemberInfo := internalTypes.ClusterMemberLocal{Name: localNode.Name, Address: localNode.Address, Certificate: localNode.Certificate}
+	localMemberInfo := types.ClusterMemberLocal{Name: localNode.Name, Address: localNode.Address, Certificate: localNode.Certificate}
 	if len(joinAddresses) > 0 {
 		err = d.hooks.PreJoin(d.State(), initConfig)
 		if err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -298,6 +298,7 @@ func (d *Daemon) applyHooks(hooks *state.Hooks) {
 	noOpRemoveHook := func(s state.State, force bool) error { return nil }
 	noOpInitHook := func(s state.State, initConfig map[string]string) error { return nil }
 	noOpConfigHook := func(s state.State, config types.DaemonConfig) error { return nil }
+	noOpNewMemberHook := func(s state.State, newMember types.ClusterMemberLocal) error { return nil }
 
 	if hooks == nil {
 		d.hooks = state.Hooks{}
@@ -330,7 +331,7 @@ func (d *Daemon) applyHooks(hooks *state.Hooks) {
 	}
 
 	if d.hooks.OnNewMember == nil {
-		d.hooks.OnNewMember = noOpHook
+		d.hooks.OnNewMember = noOpNewMemberHook
 	}
 
 	if d.hooks.PreRemove == nil {
@@ -650,7 +651,7 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 			}
 
 			// Run the OnNewMember hook, and skip errors on any nodes that are still in the process of joining.
-			err = internalClient.RunNewMemberHook(ctx, c.Client.UseTarget(remote.Name), internalTypes.HookNewMemberOptions{Name: localMemberInfo.Name})
+			err = internalClient.RunNewMemberHook(ctx, c.Client.UseTarget(remote.Name), internalTypes.HookNewMemberOptions{NewMember: localMemberInfo})
 			if err != nil && !api.StatusErrorCheck(err, http.StatusServiceUnavailable) {
 				return err
 			}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -525,7 +525,7 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 
 	// If bootstrapping the first node, just open the database and create an entry for ourselves.
 	if bootstrap {
-		clusterMember := cluster.InternalClusterMember{
+		clusterMember := cluster.CoreClusterMember{
 			Name:        localNode.Name,
 			Address:     localNode.Address.String(),
 			Certificate: localNode.Certificate.String(),

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -150,6 +150,13 @@ func (db *DB) waitUpgrade(bootstrap bool, ext extensions.Extensions) error {
 				return fmt.Errorf("Failed to update schema version when joining cluster: %w", err)
 			}
 
+			// Attempt to update the API extensions right away in case the daemon already supports it.
+			// This means we won't need to wait longer after the final member commits all schema updates.
+			err = cluster.UpdateClusterMemberAPIExtensions(ctx, tx, ext, db.listenAddr.URL.Host)
+			if err != nil {
+				return fmt.Errorf("Failed to update API extensions when joining cluster: %w", err)
+			}
+
 			versionsInternal, versionsExternal, err := cluster.GetClusterMemberSchemaVersions(ctx, tx)
 			if err != nil {
 				return fmt.Errorf("Failed to get other members' schema versions: %w", err)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -145,7 +145,7 @@ func (db *DB) waitUpgrade(bootstrap bool, ext extensions.Extensions) error {
 	if !bootstrap {
 		checkVersions := func(ctx context.Context, current int, tx *sql.Tx) error {
 			schemaVersionInternal, schemaVersionExternal, _ := newSchema.Version()
-			err := cluster.UpdateClusterMemberSchemaVersion(tx, schemaVersionInternal, schemaVersionExternal, db.listenAddr.URL.Host)
+			err := cluster.UpdateClusterMemberSchemaVersion(ctx, tx, schemaVersionInternal, schemaVersionExternal, db.listenAddr.URL.Host)
 			if err != nil {
 				return fmt.Errorf("Failed to update schema version when joining cluster: %w", err)
 			}
@@ -189,7 +189,7 @@ func (db *DB) waitUpgrade(bootstrap bool, ext extensions.Extensions) error {
 			otherNodesBehindAPI := false
 			// Perform the API extensions check.
 			err = query.Transaction(context.TODO(), db.db, func(ctx context.Context, tx *sql.Tx) error {
-				err := cluster.UpdateClusterMemberAPIExtensions(tx, ext, db.listenAddr.URL.Host)
+				err := cluster.UpdateClusterMemberAPIExtensions(ctx, tx, ext, db.listenAddr.URL.Host)
 				if err != nil {
 					return fmt.Errorf("Failed to update API extensions when joining cluster: %w", err)
 				}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -168,7 +168,7 @@ func (s *dbSuite) Test_waitUpgradeSchema() {
 		s.NoError(err)
 
 		// Generate a cluster member for the local node.
-		_, err = cluster.CreateInternalClusterMember(ctx, tx, cluster.InternalClusterMember{
+		_, err = cluster.CreateCoreClusterMember(ctx, tx, cluster.CoreClusterMember{
 			Name:           fmt.Sprintf("cluster-member-%d", 0),
 			Address:        fmt.Sprintf("10.0.0.%d:8443", 0),
 			Certificate:    fmt.Sprintf("test-cert-%d", 0),
@@ -183,7 +183,7 @@ func (s *dbSuite) Test_waitUpgradeSchema() {
 
 		// Generate a cluster member entry for all other expected nodes.
 		for j, clusterMember := range t.clusterMembers {
-			_, err = cluster.CreateInternalClusterMember(ctx, tx, cluster.InternalClusterMember{
+			_, err = cluster.CreateCoreClusterMember(ctx, tx, cluster.CoreClusterMember{
 				Name:           fmt.Sprintf("cluster-member-%d", j+1),
 				Address:        fmt.Sprintf("10.0.0.%d:8443", j+1),
 				Certificate:    fmt.Sprintf("test-cert-%d", j+1),
@@ -247,10 +247,10 @@ func (s *dbSuite) Test_waitUpgradeSchema() {
 		tx, err = db.db.BeginTx(ctx, nil)
 		s.NoError(err)
 
-		schemaInternal, err := query.SelectIntegers(ctx, tx, "SELECT schema_internal FROM internal_cluster_members ORDER BY id")
+		schemaInternal, err := query.SelectIntegers(ctx, tx, "SELECT schema_internal FROM core_cluster_members ORDER BY id")
 		s.NoError(err)
 
-		schemaExternal, err := query.SelectIntegers(ctx, tx, "SELECT schema_external FROM internal_cluster_members ORDER BY id")
+		schemaExternal, err := query.SelectIntegers(ctx, tx, "SELECT schema_external FROM core_cluster_members ORDER BY id")
 		s.NoError(err)
 
 		s.NoError(tx.Commit())
@@ -258,7 +258,7 @@ func (s *dbSuite) Test_waitUpgradeSchema() {
 		s.Equal(len(t.clusterMembers)+1, len(schemaInternal))
 		s.Equal(len(t.clusterMembers)+1, len(schemaExternal))
 
-		// If there's an error, the internal_cluster_members table will be rolled back.
+		// If there's an error, the core_cluster_members table will be rolled back.
 		minVersion := t.upgradedLocalInfo.schemaInt + 1
 		if t.expectErr != nil {
 			minVersion = 0
@@ -269,7 +269,7 @@ func (s *dbSuite) Test_waitUpgradeSchema() {
 			internalVersions = append(internalVersions, int(c.schemaInt)+1)
 		}
 
-		// If there's an error, the internal_cluster_members table will be rolled back.
+		// If there's an error, the core_cluster_members table will be rolled back.
 		minVersion = t.upgradedLocalInfo.schemaExt + 1
 		if t.expectErr != nil {
 			minVersion = 0
@@ -344,7 +344,7 @@ func (s *dbSuite) Test_waitUpgradeAPI() {
 		s.NoError(err)
 
 		// Generate a cluster member for the local node.
-		_, err = cluster.CreateInternalClusterMember(ctx, tx, cluster.InternalClusterMember{
+		_, err = cluster.CreateCoreClusterMember(ctx, tx, cluster.CoreClusterMember{
 			Name:           fmt.Sprintf("cluster-member-%d", 0),
 			Address:        fmt.Sprintf("10.0.0.%d:8443", 0),
 			Certificate:    fmt.Sprintf("test-cert-%d", 0),
@@ -359,7 +359,7 @@ func (s *dbSuite) Test_waitUpgradeAPI() {
 
 		// Generate a cluster member entry for all other expected nodes.
 		for j, clusterMemberExtensions := range t.clusterMembersExtensions {
-			_, err = cluster.CreateInternalClusterMember(ctx, tx, cluster.InternalClusterMember{
+			_, err = cluster.CreateCoreClusterMember(ctx, tx, cluster.CoreClusterMember{
 				Name:           fmt.Sprintf("cluster-member-%d", j+1),
 				Address:        fmt.Sprintf("10.0.0.%d:8443", j+1),
 				Certificate:    fmt.Sprintf("test-cert-%d", j+1),
@@ -414,7 +414,7 @@ func (s *dbSuite) Test_waitUpgradeAPI() {
 		tx, err = db.db.BeginTx(ctx, nil)
 		s.NoError(err)
 
-		res, err := query.SelectStrings(ctx, tx, "SELECT api_extensions FROM internal_cluster_members ORDER BY id")
+		res, err := query.SelectStrings(ctx, tx, "SELECT api_extensions FROM core_cluster_members ORDER BY id")
 		s.NoError(err)
 		allExtensions := make([]extensions.Extensions, 0)
 		for _, r := range res {
@@ -511,7 +511,7 @@ func (s *dbSuite) Test_waitUpgradeSchemaAndAPI() {
 		s.NoError(err)
 
 		// Generate a cluster member for the local node.
-		_, err = cluster.CreateInternalClusterMember(ctx, tx, cluster.InternalClusterMember{
+		_, err = cluster.CreateCoreClusterMember(ctx, tx, cluster.CoreClusterMember{
 			Name:           fmt.Sprintf("cluster-member-%d", 0),
 			Address:        fmt.Sprintf("10.0.0.%d:8443", 0),
 			Certificate:    fmt.Sprintf("test-cert-%d", 0),
@@ -526,7 +526,7 @@ func (s *dbSuite) Test_waitUpgradeSchemaAndAPI() {
 
 		// Generate a cluster member entry for all other expected nodes.
 		for j, clusterMember := range t.clusterMembers {
-			_, err = cluster.CreateInternalClusterMember(ctx, tx, cluster.InternalClusterMember{
+			_, err = cluster.CreateCoreClusterMember(ctx, tx, cluster.CoreClusterMember{
 				Name:           fmt.Sprintf("cluster-member-%d", j+1),
 				Address:        fmt.Sprintf("10.0.0.%d:8443", j+1),
 				Certificate:    fmt.Sprintf("test-cert-%d", j+1),
@@ -590,13 +590,13 @@ func (s *dbSuite) Test_waitUpgradeSchemaAndAPI() {
 		tx, err = db.db.BeginTx(ctx, nil)
 		s.NoError(err)
 
-		schemaInternal, err := query.SelectIntegers(ctx, tx, "SELECT schema_internal FROM internal_cluster_members ORDER BY id")
+		schemaInternal, err := query.SelectIntegers(ctx, tx, "SELECT schema_internal FROM core_cluster_members ORDER BY id")
 		s.NoError(err)
 
-		schemaExternal, err := query.SelectIntegers(ctx, tx, "SELECT schema_external FROM internal_cluster_members ORDER BY id")
+		schemaExternal, err := query.SelectIntegers(ctx, tx, "SELECT schema_external FROM core_cluster_members ORDER BY id")
 		s.NoError(err)
 
-		res, err := query.SelectStrings(ctx, tx, "SELECT api_extensions FROM internal_cluster_members ORDER BY id")
+		res, err := query.SelectStrings(ctx, tx, "SELECT api_extensions FROM core_cluster_members ORDER BY id")
 		s.NoError(err)
 		allExtensions := make([]extensions.Extensions, 0)
 		for _, r := range res {
@@ -611,7 +611,7 @@ func (s *dbSuite) Test_waitUpgradeSchemaAndAPI() {
 		s.Equal(len(t.clusterMembers)+1, len(schemaInternal))
 		s.Equal(len(t.clusterMembers)+1, len(schemaExternal))
 
-		// If there's an error, the internal_cluster_members table will be rolled back.
+		// If there's an error, the core_cluster_members table will be rolled back.
 		minVersion := t.upgradedLocalInfo.schemaInt + 1
 		if t.expectErr != nil {
 			minVersion = 0
@@ -622,7 +622,7 @@ func (s *dbSuite) Test_waitUpgradeSchemaAndAPI() {
 			internalVersions = append(internalVersions, int(c.schemaInt)+1)
 		}
 
-		// If there's an error, the internal_cluster_members table will be rolled back.
+		// If there's an error, the core_cluster_members table will be rolled back.
 		minVersion = t.upgradedLocalInfo.schemaExt + 1
 		if t.expectErr != nil {
 			minVersion = 0

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -114,7 +114,7 @@ func (db *DB) Schema() *update.SchemaUpdate {
 }
 
 // Bootstrap dqlite.
-func (db *DB) Bootstrap(extensions extensions.Extensions, project string, addr api.URL, clusterRecord cluster.InternalClusterMember) error {
+func (db *DB) Bootstrap(extensions extensions.Extensions, project string, addr api.URL, clusterRecord cluster.CoreClusterMember) error {
 	var err error
 	db.listenAddr = addr
 	db.dqlite, err = dqlite.New(db.os.DatabaseDir,
@@ -133,7 +133,7 @@ func (db *DB) Bootstrap(extensions extensions.Extensions, project string, addr a
 	// Apply initial API extensions on the bootstrap node.
 	clusterRecord.APIExtensions = extensions
 	err = db.Transaction(db.ctx, func(ctx context.Context, tx *sql.Tx) error {
-		_, err := cluster.CreateInternalClusterMember(ctx, tx, clusterRecord)
+		_, err := cluster.CreateCoreClusterMember(ctx, tx, clusterRecord)
 
 		return err
 	})

--- a/internal/db/update/schema.go
+++ b/internal/db/update/schema.go
@@ -104,7 +104,7 @@ func (s *SchemaUpdate) Ensure(db *sql.DB) (int, error) {
 	}
 
 	// If we need to update the schemas table, disable foreign keys
-	// so references to the `internal_cluster_members` table do not get dropped.
+	// so references to the `core_cluster_members` table do not get dropped.
 	if updateSchemaTable {
 		_, err = db.Exec("PRAGMA foreign_keys=OFF; PRAGMA legacy_alter_table=ON")
 		if err != nil {

--- a/internal/db/update/update.go
+++ b/internal/db/update/update.go
@@ -36,6 +36,7 @@ func NewSchema() *SchemaUpdateManager {
 			updateFromV1,
 			updateFromV2,
 			mgr.updateFromV3,
+			updateFromV4,
 		},
 	}
 
@@ -73,7 +74,20 @@ func (s *SchemaUpdateManager) AppendSchema(schemaExtensions []schema.Update, api
 	s.apiExtensions = apiExtensions
 }
 
-// updateFromV3 auto-applies the initial set of API extensions to the internal_cluster_members table.
+// updateFromV4 renames the internal_ prefixed tables to core_ to signify that
+// they are accessible outside of the internal microcluster implementation.
+func updateFromV4(ctx context.Context, tx *sql.Tx) error {
+	stmt := `
+ALTER TABLE internal_cluster_members RENAME TO core_cluster_members;
+ALTER TABLE internal_token_records RENAME TO core_token_records;
+	`
+
+	_, err := tx.ExecContext(ctx, stmt)
+
+	return err
+}
+
+// updateFromV3 auto-applies the initial set of API extensions to the core_cluster_members table.
 // This is done so that the cluster won't have to be notified twice,
 // once for the schema update that introduces API extensions to be applied,
 // and another time for API extensions to be applied.

--- a/internal/db/update/update_test.go
+++ b/internal/db/update/update_test.go
@@ -20,7 +20,7 @@ func TestUpdateSuite(t *testing.T) {
 	suite.Run(t, new(updateSuite))
 }
 
-// Ensures the internal_cluster_members table is properly updated by updateFromV1 if it already exists.
+// Ensures the core_cluster_members table is properly updated by updateFromV1 if it already exists.
 func (s *updateSuite) Test_updateFromV1ClusterMembers() {
 	db, err := sql.Open("sqlite3", ":memory:")
 	s.NoError(err)
@@ -60,10 +60,10 @@ func (s *updateSuite) Test_updateFromV1ClusterMembers() {
 
 	tx, err = db.BeginTx(ctx, nil)
 	s.NoError(err)
-	schemaInternal, err := query.SelectIntegers(ctx, tx, "SELECT schema_internal FROM internal_cluster_members")
+	schemaInternal, err := query.SelectIntegers(ctx, tx, "SELECT schema_internal FROM core_cluster_members")
 	s.NoError(err)
 
-	schemaExternal, err := query.SelectIntegers(ctx, tx, "SELECT schema_external FROM internal_cluster_members")
+	schemaExternal, err := query.SelectIntegers(ctx, tx, "SELECT schema_external FROM core_cluster_members")
 	s.NoError(err)
 
 	versionsInternal, err := query.SelectIntegers(ctx, tx, "SELECT version from schemas where type = 0")
@@ -73,7 +73,7 @@ func (s *updateSuite) Test_updateFromV1ClusterMembers() {
 	s.NoError(err)
 	s.NoError(tx.Commit())
 
-	// Ensure schema versions are split across internal and external updates in the internal_cluster_members table.
+	// Ensure schema versions are split across internal and external updates in the core_cluster_members table.
 	s.Equal(3, len(schemaInternal))
 	s.Equal(3, len(schemaExternal))
 

--- a/internal/extensions/extensions.go
+++ b/internal/extensions/extensions.go
@@ -29,6 +29,7 @@ type Extensions []string
 // Populate internal extensions here.
 var internalExtensions = Extensions{
 	"internal:runtime_extension_v1",
+	"internal:rename_core_endpoints",
 }
 
 // validateExternalExtension validates the given external extension.

--- a/internal/extensions/extensions_test.go
+++ b/internal/extensions/extensions_test.go
@@ -137,11 +137,11 @@ func TestExtensionsValuerAndScanner(t *testing.T) {
 
 	defer db.Close() //nolint:errcheck // Not relevant for the test.
 
-	_, err = db.Exec("CREATE TABLE internal_cluster_members (api_extensions TEXT NOT NULL DEFAULT '[]')")
+	_, err = db.Exec("CREATE TABLE core_cluster_members (api_extensions TEXT NOT NULL DEFAULT '[]')")
 	require.NoError(t, err)
 
 	exts := Extensions{"internal:runtime_extension_v1", "microovn_custom_encapsulation_ip"}
-	res, err := db.Exec("INSERT INTO internal_cluster_members (api_extensions) VALUES (?)", exts)
+	res, err := db.Exec("INSERT INTO core_cluster_members (api_extensions) VALUES (?)", exts)
 	assert.NoError(t, err)
 	n, err := res.RowsAffected()
 	assert.NoError(t, err)
@@ -149,7 +149,7 @@ func TestExtensionsValuerAndScanner(t *testing.T) {
 
 	// Retrieve the data
 	var retrievedExts Extensions
-	row := db.QueryRow("SELECT api_extensions FROM internal_cluster_members")
+	row := db.QueryRow("SELECT api_extensions FROM core_cluster_members")
 	err = row.Scan(&retrievedExts)
 	assert.NoError(t, err)
 

--- a/internal/rest/client/client.go
+++ b/internal/rest/client/client.go
@@ -26,6 +26,23 @@ import (
 	"github.com/canonical/microcluster/rest/types"
 )
 
+// EndpointType is a type specifying the endpoint on with the resource exists.
+type EndpointType string
+
+const (
+	// ExtendedEndpoint - All endpoints added managed by external usage of MicroCluster.
+	ExtendedEndpoint EndpointType = "1.0"
+
+	// PublicEndpoint - Internally managed APIs available without authentication.
+	PublicEndpoint EndpointType = "core/1.0"
+
+	// InternalEndpoint - all endpoints restricted to trusted servers.
+	InternalEndpoint EndpointType = "core/internal"
+
+	// ControlEndpoint - all endpoints available on the local unix socket.
+	ControlEndpoint EndpointType = "core/control"
+)
+
 // Client is a rest client for the daemon.
 type Client struct {
 	*http.Client

--- a/internal/rest/client/cluster.go
+++ b/internal/rest/client/cluster.go
@@ -6,17 +6,17 @@ import (
 
 	"github.com/canonical/lxd/shared/api"
 
-	"github.com/canonical/microcluster/internal/rest/types"
-	apiTypes "github.com/canonical/microcluster/rest/types"
+	internalTypes "github.com/canonical/microcluster/internal/rest/types"
+	"github.com/canonical/microcluster/rest/types"
 )
 
 // AddClusterMember records a new cluster member in the trust store of each current cluster member.
-func (c *Client) AddClusterMember(ctx context.Context, args types.ClusterMember) (*types.TokenResponse, error) {
+func (c *Client) AddClusterMember(ctx context.Context, args types.ClusterMember) (*internalTypes.TokenResponse, error) {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	tokenResponse := types.TokenResponse{}
-	err := c.QueryStruct(queryCtx, "POST", types.PublicEndpoint, api.NewURL().Path("cluster"), args, &tokenResponse)
+	tokenResponse := internalTypes.TokenResponse{}
+	err := c.QueryStruct(queryCtx, "POST", internalTypes.PublicEndpoint, api.NewURL().Path("cluster"), args, &tokenResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +30,7 @@ func (c *Client) GetClusterMembers(ctx context.Context) ([]types.ClusterMember, 
 	defer cancel()
 
 	clusterMembers := []types.ClusterMember{}
-	err := c.QueryStruct(queryCtx, "GET", types.PublicEndpoint, api.NewURL().Path("cluster"), nil, &clusterMembers)
+	err := c.QueryStruct(queryCtx, "GET", internalTypes.PublicEndpoint, api.NewURL().Path("cluster"), nil, &clusterMembers)
 
 	return clusterMembers, err
 }
@@ -45,7 +45,7 @@ func (c *Client) DeleteClusterMember(ctx context.Context, name string, force boo
 		endpoint = endpoint.WithQuery("force", "1")
 	}
 
-	return c.QueryStruct(queryCtx, "DELETE", types.PublicEndpoint, endpoint, nil, nil)
+	return c.QueryStruct(queryCtx, "DELETE", internalTypes.PublicEndpoint, endpoint, nil, nil)
 }
 
 // ResetClusterMember clears the state directory of the cluster member, and re-execs its daemon.
@@ -58,14 +58,14 @@ func (c *Client) ResetClusterMember(ctx context.Context, name string, force bool
 		endpoint = endpoint.WithQuery("force", "1")
 	}
 
-	return c.QueryStruct(queryCtx, "PUT", types.PublicEndpoint, endpoint, nil, nil)
+	return c.QueryStruct(queryCtx, "PUT", internalTypes.PublicEndpoint, endpoint, nil, nil)
 }
 
 // UpdateCertificate sets a new keypair and CA.
-func (c *Client) UpdateCertificate(ctx context.Context, name apiTypes.CertificateName, args apiTypes.KeyPair) error {
+func (c *Client) UpdateCertificate(ctx context.Context, name types.CertificateName, args types.KeyPair) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	endpoint := api.NewURL().Path("cluster", "certificates", string(name))
-	return c.QueryStruct(queryCtx, "PUT", types.InternalEndpoint, endpoint, args, nil)
+	return c.QueryStruct(queryCtx, "PUT", internalTypes.InternalEndpoint, endpoint, args, nil)
 }

--- a/internal/rest/client/truststore.go
+++ b/internal/rest/client/truststore.go
@@ -6,7 +6,8 @@ import (
 
 	"github.com/canonical/lxd/shared/api"
 
-	"github.com/canonical/microcluster/internal/rest/types"
+	internalTypes "github.com/canonical/microcluster/internal/rest/types"
+	"github.com/canonical/microcluster/rest/types"
 )
 
 // AddTrustStoreEntry adds a new record to the truststore on all cluster members.
@@ -14,7 +15,7 @@ func AddTrustStoreEntry(ctx context.Context, c *Client, args types.ClusterMember
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "POST", types.InternalEndpoint, api.NewURL().Path("truststore"), args, nil)
+	return c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, api.NewURL().Path("truststore"), args, nil)
 }
 
 // DeleteTrustStoreEntry deletes the record corresponding to the given cluster member from the trust store.
@@ -22,5 +23,5 @@ func DeleteTrustStoreEntry(ctx context.Context, c *Client, name string) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "DELETE", types.InternalEndpoint, api.NewURL().Path("truststore", name), nil, nil)
+	return c.QueryStruct(queryCtx, "DELETE", internalTypes.InternalEndpoint, api.NewURL().Path("truststore", name), nil, nil)
 }

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -109,8 +109,8 @@ func joinWithToken(state state.State, r *http.Request, req *internalTypes.Contro
 
 	// Prepare the cluster for the incoming dqlite request by creating a database entry.
 	internalVersion, externalVersion, _ := state.Database().Schema().Version()
-	newClusterMember := internalTypes.ClusterMember{
-		ClusterMemberLocal: internalTypes.ClusterMemberLocal{
+	newClusterMember := types.ClusterMember{
+		ClusterMemberLocal: types.ClusterMemberLocal{
 			Name:        localClusterMember.Name,
 			Address:     localClusterMember.Address,
 			Certificate: localClusterMember.Certificate,

--- a/internal/rest/resources/heartbeat.go
+++ b/internal/rest/resources/heartbeat.go
@@ -58,7 +58,7 @@ func heartbeatPost(s state.State, r *http.Request) response.Response {
 
 	var internalSchemaVersion, externalSchemaVersion uint64
 	err = s.Database().Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		localClusterMember, err := cluster.GetInternalClusterMember(ctx, tx, s.Name())
+		localClusterMember, err := cluster.GetCoreClusterMember(ctx, tx, s.Name())
 		if err != nil {
 			return err
 		}
@@ -109,7 +109,7 @@ func beginHeartbeat(s state.State, r *http.Request) response.Response {
 	// Get the database record of cluster members.
 	var clusterMembers []types.ClusterMember
 	err = s.Database().Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		dbClusterMembers, err := cluster.GetInternalClusterMembers(ctx, tx)
+		dbClusterMembers, err := cluster.GetCoreClusterMembers(ctx, tx)
 		if err != nil {
 			return err
 		}
@@ -256,7 +256,7 @@ func beginHeartbeat(s state.State, r *http.Request) response.Response {
 
 	// Having sent a heartbeat to each valid cluster member, update the database record of members.
 	err = s.Database().Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		dbClusterMembers, err := cluster.GetInternalClusterMembers(ctx, tx)
+		dbClusterMembers, err := cluster.GetCoreClusterMembers(ctx, tx)
 		if err != nil {
 			return err
 		}
@@ -269,7 +269,7 @@ func beginHeartbeat(s state.State, r *http.Request) response.Response {
 
 			clusterMember.Heartbeat = heartbeatInfo.LastHeartbeat
 			clusterMember.Role = cluster.Role(heartbeatInfo.Role)
-			err = cluster.UpdateInternalClusterMember(ctx, tx, clusterMember.Name, clusterMember)
+			err = cluster.UpdateCoreClusterMember(ctx, tx, clusterMember.Name, clusterMember)
 			if err != nil {
 				return err
 			}

--- a/internal/rest/resources/heartbeat.go
+++ b/internal/rest/resources/heartbeat.go
@@ -15,9 +15,10 @@ import (
 	"github.com/canonical/microcluster/client"
 	"github.com/canonical/microcluster/cluster"
 	internalClient "github.com/canonical/microcluster/internal/rest/client"
-	"github.com/canonical/microcluster/internal/rest/types"
+	internalTypes "github.com/canonical/microcluster/internal/rest/types"
 	internalState "github.com/canonical/microcluster/internal/state"
 	"github.com/canonical/microcluster/rest"
+	"github.com/canonical/microcluster/rest/types"
 	"github.com/canonical/microcluster/state"
 )
 
@@ -28,7 +29,7 @@ var heartbeatCmd = rest.Endpoint{
 }
 
 func heartbeatPost(s state.State, r *http.Request) response.Response {
-	var hbInfo types.HeartbeatInfo
+	var hbInfo internalTypes.HeartbeatInfo
 	err := json.NewDecoder(r.Body).Decode(&hbInfo)
 	if err != nil {
 		return response.SmartError(err)
@@ -199,7 +200,7 @@ func beginHeartbeat(s state.State, r *http.Request) response.Response {
 	clusterMap[s.Address().URL.Host] = leaderEntry
 
 	// Record the maximum schema version discovered.
-	hbInfo := types.HeartbeatInfo{ClusterMembers: clusterMap}
+	hbInfo := internalTypes.HeartbeatInfo{ClusterMembers: clusterMap}
 	for _, node := range clusterMembers {
 		if node.SchemaInternalVersion > hbInfo.MaxSchemaInternal {
 			hbInfo.MaxSchemaInternal = node.SchemaInternalVersion

--- a/internal/rest/resources/hooks.go
+++ b/internal/rest/resources/hooks.go
@@ -65,13 +65,13 @@ func hooksPost(s state.State, r *http.Request) response.Response {
 			return response.BadRequest(err)
 		}
 
-		if req.Name == "" {
+		if req.NewMember == (types.ClusterMemberLocal{}) {
 			return response.SmartError(fmt.Errorf("No new member name given for NewMember hook execution"))
 		}
 
-		err = intState.Hooks.OnNewMember(s)
+		err = intState.Hooks.OnNewMember(s, req.NewMember)
 		if err != nil {
-			return response.SmartError(fmt.Errorf("Failed to run hook after system %q has joined the cluster: %w", req.Name, err))
+			return response.SmartError(fmt.Errorf("Failed to run hook after system %q has joined the cluster: %w", req.NewMember.Name, err))
 		}
 	case internalTypes.OnDaemonConfigUpdate:
 		var req types.DaemonConfig

--- a/internal/rest/resources/tokens.go
+++ b/internal/rest/resources/tokens.go
@@ -79,7 +79,7 @@ func tokensPost(state state.State, r *http.Request) response.Response {
 	}
 
 	err = state.Database().Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		_, err = cluster.CreateInternalTokenRecord(ctx, tx, cluster.InternalTokenRecord{Name: req.Name, Secret: tokenKey})
+		_, err = cluster.CreateCoreTokenRecord(ctx, tx, cluster.CoreTokenRecord{Name: req.Name, Secret: tokenKey})
 		return err
 	})
 	if err != nil {
@@ -103,7 +103,7 @@ func tokensGet(state state.State, r *http.Request) response.Response {
 	var records []internalTypes.TokenRecord
 	err = state.Database().Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		var err error
-		tokens, err := cluster.GetInternalTokenRecords(ctx, tx)
+		tokens, err := cluster.GetCoreTokenRecords(ctx, tx)
 		if err != nil {
 			return err
 		}
@@ -134,7 +134,7 @@ func tokenDelete(state state.State, r *http.Request) response.Response {
 	}
 
 	err = state.Database().Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		return cluster.DeleteInternalTokenRecord(ctx, tx, name)
+		return cluster.DeleteCoreTokenRecord(ctx, tx, name)
 	})
 	if err != nil {
 		return response.SmartError(err)

--- a/internal/rest/resources/truststore.go
+++ b/internal/rest/resources/truststore.go
@@ -13,10 +13,10 @@ import (
 
 	"github.com/canonical/microcluster/client"
 	internalClient "github.com/canonical/microcluster/internal/rest/client"
-	internalTypes "github.com/canonical/microcluster/internal/rest/types"
 	"github.com/canonical/microcluster/internal/trust"
 	"github.com/canonical/microcluster/rest"
 	"github.com/canonical/microcluster/rest/access"
+	"github.com/canonical/microcluster/rest/types"
 	"github.com/canonical/microcluster/state"
 )
 
@@ -35,7 +35,7 @@ var trustEntryCmd = rest.Endpoint{
 }
 
 func trustPost(s state.State, r *http.Request) response.Response {
-	req := internalTypes.ClusterMemberLocal{}
+	req := types.ClusterMemberLocal{}
 
 	// Parse the request.
 	err := json.NewDecoder(r.Body).Decode(&req)
@@ -121,10 +121,10 @@ func trustDelete(s state.State, r *http.Request) response.Response {
 	remotesMap = remotes.RemotesByName()
 	delete(remotesMap, name)
 
-	newRemotes := make([]internalTypes.ClusterMember, 0, len(remotesMap))
+	newRemotes := make([]types.ClusterMember, 0, len(remotesMap))
 	for _, remote := range remotesMap {
-		newRemote := internalTypes.ClusterMember{
-			ClusterMemberLocal: internalTypes.ClusterMemberLocal{
+		newRemote := types.ClusterMember{
+			ClusterMemberLocal: types.ClusterMemberLocal{
 				Name:        remote.Name,
 				Address:     remote.Address,
 				Certificate: remote.Certificate,

--- a/internal/rest/rest.go
+++ b/internal/rest/rest.go
@@ -88,7 +88,7 @@ func proxyTarget(action rest.EndpointAction, s state.State, r *http.Request) res
 
 	var targetURL *api.URL
 	err = s.Database().Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		clusterMember, err := cluster.GetInternalClusterMember(ctx, tx, target)
+		clusterMember, err := cluster.GetCoreClusterMember(ctx, tx, target)
 		if err != nil {
 			return fmt.Errorf("Failed to get cluster member for request target name %q: %w", target, err)
 		}

--- a/internal/rest/types/heartbeat.go
+++ b/internal/rest/types/heartbeat.go
@@ -1,10 +1,12 @@
 package types
 
+import "github.com/canonical/microcluster/rest/types"
+
 // HeartbeatInfo represents information about the cluster sent out by the leader of the cluster to other members.
 // If BeginRound is set, a new heartbeat will initiate.
 type HeartbeatInfo struct {
-	BeginRound        bool                     `json:"begin_round" yaml:"begin_round"`
-	MaxSchemaInternal uint64                   `json:"max_schema_internal" yaml:"max_schema_internal"`
-	MaxSchemaExternal uint64                   `json:"max_schema_external" yaml:"max_schema_external"`
-	ClusterMembers    map[string]ClusterMember `json:"cluster_members" yaml:"cluster_members"`
+	BeginRound        bool                           `json:"begin_round" yaml:"begin_round"`
+	MaxSchemaInternal uint64                         `json:"max_schema_internal" yaml:"max_schema_internal"`
+	MaxSchemaExternal uint64                         `json:"max_schema_external" yaml:"max_schema_external"`
+	ClusterMembers    map[string]types.ClusterMember `json:"cluster_members" yaml:"cluster_members"`
 }

--- a/internal/rest/types/hooks.go
+++ b/internal/rest/types/hooks.go
@@ -1,5 +1,7 @@
 package types
 
+import "github.com/canonical/microcluster/rest/types"
+
 // HookType represents the various types of hooks available to microcluster.
 type HookType string
 
@@ -46,5 +48,5 @@ type HookRemoveMemberOptions struct {
 // HookNewMemberOptions holds configuration pertaining to the OnNewMember hook.
 type HookNewMemberOptions struct {
 	// Name is the name of the new cluster member that joined the cluster, triggering this hook.
-	Name string `json:"name" yaml:"name"`
+	NewMember types.ClusterMemberLocal `json:"new_member" yaml:"new_member"`
 }

--- a/internal/rest/types/tokens.go
+++ b/internal/rest/types/tokens.go
@@ -23,7 +23,7 @@ type TokenResponse struct {
 
 	// ClusterMembers is the full list of cluster members that are currently present and available in the cluster.
 	// The joiner supplies this list to dqlite so that it can start its database.
-	ClusterMembers []ClusterMemberLocal `json:"cluster_members" yaml:"cluster_members"`
+	ClusterMembers []types.ClusterMemberLocal `json:"cluster_members" yaml:"cluster_members"`
 
 	// ClusterAdditionalCerts is the full list of certificates added for additional listeners.
 	ClusterAdditionalCerts map[string]types.KeyPair
@@ -33,7 +33,7 @@ type TokenResponse struct {
 	//
 	// The trusted member will have already recorded the joiner's information in
 	// its local truststore, and thus will trust requests from the joiner prior to fully joining.
-	TrustedMember ClusterMemberLocal `json:"trusted_member" yaml:"trusted_member"`
+	TrustedMember types.ClusterMemberLocal `json:"trusted_member" yaml:"trusted_member"`
 }
 
 // Token holds the information that is presented to the joining node when requesting a token.

--- a/internal/state/hooks.go
+++ b/internal/state/hooks.go
@@ -34,7 +34,7 @@ type Hooks struct {
 	OnHeartbeat func(s State) error
 
 	// OnNewMember is run on each peer after a new cluster member has joined and executed their 'PreJoin' hook.
-	OnNewMember func(s State) error
+	OnNewMember func(s State, newMember types.ClusterMemberLocal) error
 
 	// OnDaemonConfigUpdate is a post-action hook that is run on all cluster members when any cluster member receives a local configuration update.
 	OnDaemonConfigUpdate func(s State, config types.DaemonConfig) error

--- a/internal/trust/remotes.go
+++ b/internal/trust/remotes.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/canonical/microcluster/client"
 	internalClient "github.com/canonical/microcluster/internal/rest/client"
-	internalTypes "github.com/canonical/microcluster/internal/rest/types"
 	"github.com/canonical/microcluster/rest/types"
 )
 
@@ -131,7 +130,7 @@ func (r *Remotes) Add(dir string, remotes ...Remote) error {
 }
 
 // Replace replaces the in-memory and locally stored remotes with the given list from the database.
-func (r *Remotes) Replace(dir string, newRemotes ...internalTypes.ClusterMember) error {
+func (r *Remotes) Replace(dir string, newRemotes ...types.ClusterMember) error {
 	r.updateMu.Lock()
 	defer r.updateMu.Unlock()
 

--- a/rest/types/cluster.go
+++ b/rest/types/cluster.go
@@ -4,7 +4,6 @@ import (
 	"time"
 
 	"github.com/canonical/microcluster/internal/extensions"
-	"github.com/canonical/microcluster/rest/types"
 )
 
 // ClusterMember represents information about a dqlite cluster member.
@@ -21,9 +20,9 @@ type ClusterMember struct {
 
 // ClusterMemberLocal represents local information about a new cluster member.
 type ClusterMemberLocal struct {
-	Name        string                `json:"name" yaml:"name"`
-	Address     types.AddrPort        `json:"address" yaml:"address"`
-	Certificate types.X509Certificate `json:"certificate" yaml:"certificate"`
+	Name        string          `json:"name" yaml:"name"`
+	Address     AddrPort        `json:"address" yaml:"address"`
+	Certificate X509Certificate `json:"certificate" yaml:"certificate"`
 }
 
 // MemberStatus represents the online status of a cluster member.


### PR DESCRIPTION
Closes #108 

* Adds a new schema update that renames the tables `internal_cluster_members` and `internal_token_records` to `core_cluster_members` and `core_token_records`. This is so that it is clear that these tables should be accessed by downstream projects and are not an internal implementation detail.

* Updates all DB functions appropriately

* Since there is a cyclical issue with the schema update applying to the table that we use to check schema updates, we need to dynamically grab the table name in case it hasn't been renamed yet, so there is a new helper `getClusterTableName` to fetch it from `sqlite_master`.

* Renames the `/cluster` endpoints to `/core`. This has the added effect of fixing the `/cluster/1.0/cluster` stammering, now it's `/core/1.0/cluster`. 

* Moves `types.ClusterMember` and `types.ClusterMemberLocal` out of the `internal` package so that they are accessible by downstream projects.

* Since `types.ClusterMemberLocal` is exported, we can include it as an argument to the `OnNewMember` hook so that when that hook triggers, it is immediately available which cluster member got added without needing another transaction.
