### PR TITLE
Recover from join failures

### DIFF
--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -480,7 +480,7 @@ func clusterMemberDelete(s *state.State, r *http.Request) response.Response {
 
 	// Tell the cluster member to run its PreRemove hook and return.
 	err = internalClient.RunPreRemoveHook(ctx, c.UseTarget(name), internalTypes.HookRemoveMemberOptions{Force: force})
-	if err != nil {
+	if err != nil && !force {
 		return response.SmartError(err)
 	}
 
@@ -506,7 +506,7 @@ func clusterMemberDelete(s *state.State, r *http.Request) response.Response {
 	}
 
 	err = internalClient.DeleteTrustStoreEntry(ctx, localClient, name)
-	if err != nil {
+	if err != nil && !force {
 		return response.SmartError(err)
 	}
 
@@ -516,7 +516,7 @@ func clusterMemberDelete(s *state.State, r *http.Request) response.Response {
 	}
 
 	err = c.ResetClusterMember(s.Context, name, force)
-	if err != nil {
+	if err != nil && !force {
 		return response.SmartError(err)
 	}
 

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -145,10 +145,12 @@ func clusterPost(s *state.State, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	localRemote := remotes.RemotesByName()[s.Name()]
 	tokenResponse := internalTypes.TokenResponse{
 		ClusterCert: types.X509Certificate{Certificate: clusterCert},
 		ClusterKey:  string(s.ClusterCert().PrivateKey()),
 
+		TrustedMember:  internalTypes.ClusterMemberLocal{Name: s.Name(), Address: localRemote.Address, Certificate: localRemote.Certificate},
 		ClusterMembers: clusterMembers,
 	}
 

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -385,7 +385,7 @@ func clusterMemberDelete(s *state.State, r *http.Request) response.Response {
 		}
 	}
 
-	if len(clusterMembers)-numPending < 2 {
+	if len(clusterMembers)-numPending < 1 {
 		return response.SmartError(fmt.Errorf("Cannot remove cluster members, there are no remaining non-pending members"))
 	}
 

--- a/internal/rest/types/tokens.go
+++ b/internal/rest/types/tokens.go
@@ -15,15 +15,35 @@ type TokenRecord struct {
 
 // TokenResponse holds the information for connecting to a cluster by a node with a valid join token.
 type TokenResponse struct {
-	ClusterCert    types.X509Certificate `json:"cluster_cert" yaml:"cluster_cert"`
-	ClusterKey     string                `json:"cluster_key" yaml:"cluster_key"`
-	ClusterMembers []ClusterMemberLocal  `json:"cluster_members" yaml:"cluster_members"`
+	// ClusterCert is the public key used across the cluster.
+	ClusterCert types.X509Certificate `json:"cluster_cert" yaml:"cluster_cert"`
+
+	// ClusterKey is the private key used across the cluster.
+	ClusterKey string `json:"cluster_key" yaml:"cluster_key"`
+
+	// ClusterMembers is the full list of cluster members that are currently present and available in the cluster.
+	// The joiner supplies this list to dqlite so that it can start its database.
+	ClusterMembers []ClusterMemberLocal `json:"cluster_members" yaml:"cluster_members"`
+
+	// TrustedMember contains the address of the existing cluster member
+	// who was dqlite leader at the time that the joiner supplied its join token.
+	//
+	// The trusted member will have already recorded the joiner's information in
+	// its local truststore, and thus will trust requests from the joiner prior to fully joining.
+	TrustedMember ClusterMemberLocal `json:"trusted_member" yaml:"trusted_member"`
 }
 
 // Token holds the information that is presented to the joining node when requesting a token.
 type Token struct {
-	Secret        string           `json:"secret" yaml:"secret"`
-	Fingerprint   string           `json:"fingerprint" yaml:"fingerprint"`
+	// Secret is the underlying secret string used to authenticate the token.
+	Secret string `json:"secret" yaml:"secret"`
+
+	// Fingerprint is the fingerprint of the cluster certificate,
+	// so that the joiner can verify that the public key of the cluster matches this request.
+	Fingerprint string `json:"fingerprint" yaml:"fingerprint"`
+
+	// JoinAddresses is the list of addresses of the existing cluster members that the joiner may supply the token to.
+	// Internally, the first system to accept the token will forward it to the dqlite leader.
 	JoinAddresses []types.AddrPort `json:"join_addresses" yaml:"join_addresses"`
 }
 


### PR DESCRIPTION
Reverts the joiner and cluster if there is an error during the join process.


* Instead of iterating over every join address to find which system initially consumed our join token, the address of this system is now included in the response returned by validating the join token.
* Allows reducing a 2 system cluster to a 1 system cluster, as there is no issue with quorum since the roles are turned over first.
* If deleting a node with `?force=true`, then errors related to reaching the node will be ignored as we are forcibly removing it and it may be unreachable.
* If the joiner fails to join the cluster, a revert block is executed which resets the state of the joiner back to pre-initialization, and additionally attempts to send a request to the existing cluster to clear out any remaining state that may persist on the cluster side.