### PR TITLE
Allow downstream app to adjust addresses for multiple network listeners [WD-11977]

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -578,9 +578,13 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 func (d *Daemon) addExtensionServers() error {
 	var networks []endpoints.Endpoint
 	for _, extensionServer := range d.extensionServers {
+		cert := extensionServer.Certificate
+		if cert == nil {
+			cert = d.ClusterCert()
+		}
 		server := d.initServer(extensionServer.Resources...)
 		url := api.NewURL().Scheme(extensionServer.Protocol).Host(extensionServer.Address.String())
-		network := endpoints.NewNetwork(d.shutdownCtx, endpoints.EndpointNetwork, server, *url, extensionServer.Certificate)
+		network := endpoints.NewNetwork(d.shutdownCtx, endpoints.EndpointNetwork, server, *url, cert)
 		networks = append(networks, network)
 	}
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -69,7 +69,7 @@ type Daemon struct {
 	// stop is a sync.Once which wraps the daemon's stop sequence. Each call will block until the first one completes.
 	stop func() error
 
-	extensionServers []rest.Server
+	extensionServers []*rest.Server
 }
 
 // NewDaemon initializes the Daemon context and channels.
@@ -99,7 +99,7 @@ func NewDaemon(project string) *Daemon {
 // - `extensionsSchema` is a list of schema updates in the order that they should be applied.
 // - `extensionServers` is a list of rest.Server that will be initialized and managed by microcluster.
 // - `hooks` are a set of functions that trigger at certain points during cluster communication.
-func (d *Daemon) Run(ctx context.Context, listenPort string, stateDir string, socketGroup string, extensionsAPI []rest.Endpoint, extensionsSchema []schema.Update, apiExtensions []string, extensionServers []rest.Server, hooks *config.Hooks) error {
+func (d *Daemon) Run(ctx context.Context, listenPort string, stateDir string, socketGroup string, extensionsAPI []rest.Endpoint, extensionsSchema []schema.Update, apiExtensions []string, extensionServers []*rest.Server, hooks *config.Hooks) error {
 	d.shutdownCtx, d.shutdownCancel = context.WithCancel(ctx)
 	if stateDir == "" {
 		stateDir = os.Getenv(sys.StateDir)

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -46,7 +46,7 @@ type Args struct {
 	Client     *client.Client
 	Proxy      func(*http.Request) (*url.URL, error)
 
-	ExtensionServers []rest.Server
+	ExtensionServers []*rest.Server
 }
 
 // App returns an instance of MicroCluster with a newly initialized filesystem if one does not exist.

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -51,6 +51,7 @@ type EndpointType client.EndpointType
 
 // Server contains configuration and handlers for additional listeners to be instantiated after app startup.
 type Server struct {
+	Name        string
 	Protocol    string
 	Address     types.AddrPort
 	Certificate *shared.CertInfo


### PR DESCRIPTION
## Done
 - update `microcluster.Arg.ExtensionServers` to be a slice of pointers `*rest.Server`
 - use cluster certificate if new server certificate isn't provided

## Context
 - This is a potential solution for #139 
 - A downstream app may adjust the listener address in the `PreBootstrap` and `PreJoin` hooks (see example implementation in this [lxd-site-manager PR](https://github.com/canonical/lxd-site-manager/pull/15)).