### PR TITLE
Use an interface for `State`

### DIFF
--- a/example/api/extended.go
+++ b/example/api/extended.go
@@ -24,7 +24,7 @@ var extendedCmd = rest.Endpoint{
 
 // This is the POST handler for the /1.0/extended endpoint.
 // This example shows how to forward a request to other cluster members.
-func cmdPost(state *state.State, r *http.Request) response.Response {
+func cmdPost(state state.State, r *http.Request) response.Response {
 	// Check the user agent header to check if we are the notifying cluster member.
 	if !client.IsNotification(r) {
 		// Get a collection of clients every other cluster member, with the notification user-agent set.
@@ -34,7 +34,7 @@ func cmdPost(state *state.State, r *http.Request) response.Response {
 		}
 
 		messages := make([]string, 0, len(cluster))
-		err = cluster.Query(state.Context, true, func(ctx context.Context, c *client.Client) error {
+		err = cluster.Query(r.Context(), true, func(ctx context.Context, c *client.Client) error {
 			addrPort, err := types.ParseAddrPort(state.Address().URL.Host)
 			if err != nil {
 				return fmt.Errorf("Failed to parse addr:port of listen address %q: %w", state.Address().URL.Host, err)

--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -75,34 +75,24 @@ func (c *cmdDaemon) run(cmd *cobra.Command, args []string) error {
 	// exampleHooks are some example post-action hooks that can be run by MicroCluster.
 	exampleHooks := &state.Hooks{
 		// PostBootstrap is run after the daemon is initialized and bootstrapped.
-		PostBootstrap: func(s *state.State, initConfig map[string]string) error {
+		PostBootstrap: func(s state.State, initConfig map[string]string) error {
 			logCtx := logger.Ctx{}
 			for k, v := range initConfig {
 				logCtx[k] = v
 			}
 
-			// You can check your app extensions using the *state.State object.
-			hasMissingExt := s.Extensions.HasExtension("missing_extension")
+			// You can check your app extensions using the state.State object.
+			hasMissingExt := s.HasExtension("missing_extension")
 			if !hasMissingExt {
 				logger.Warn("The 'missing_extension' is not registered")
 			}
 
 			// You can also check the internal extensions. (starting with "internal:" prefix)
 			// These are read-only and defined at the MicroCluster level and cannot be added at runtime
-			hasInternalExt := s.Extensions.HasExtension("internal:runtime_extension_v1")
+			hasInternalExt := s.HasExtension("internal:runtime_extension_v1")
 			if !hasInternalExt {
 				logger.Warn("Every system should have the 'internal:runtime_extension_v1' extension")
 			}
-
-			// You can also register new extensions at runtime.
-			err := s.Extensions.Register([]string{"new_extension_at_runtime_1", "new_extension_at_runtime_2"})
-			if err != nil {
-				return err
-			}
-
-			// This shows the number of extensions that are registered (internal and external).
-			numberOfExtensions := s.Extensions.Version()
-			logger.Infof("The number of extensions is %d", numberOfExtensions)
 
 			logger.Info("This is a hook that runs after the daemon is initialized and bootstrapped")
 			logger.Info("Here are the extra configuration keys that were passed into the init --bootstrap command", logCtx)
@@ -110,7 +100,7 @@ func (c *cmdDaemon) run(cmd *cobra.Command, args []string) error {
 			return nil
 		},
 
-		PreBootstrap: func(s *state.State, initConfig map[string]string) error {
+		PreBootstrap: func(s state.State, initConfig map[string]string) error {
 			logCtx := logger.Ctx{}
 			for k, v := range initConfig {
 				logCtx[k] = v
@@ -123,14 +113,14 @@ func (c *cmdDaemon) run(cmd *cobra.Command, args []string) error {
 		},
 
 		// OnStart is run after the daemon is started.
-		OnStart: func(s *state.State) error {
+		OnStart: func(s state.State) error {
 			logger.Info("This is a hook that runs after the daemon first starts")
 
 			return nil
 		},
 
 		// PostJoin is run after the daemon is initialized and joins a cluster.
-		PostJoin: func(s *state.State, initConfig map[string]string) error {
+		PostJoin: func(s state.State, initConfig map[string]string) error {
 			logCtx := logger.Ctx{}
 			for k, v := range initConfig {
 				logCtx[k] = v
@@ -143,7 +133,7 @@ func (c *cmdDaemon) run(cmd *cobra.Command, args []string) error {
 		},
 
 		// PreJoin is run after the daemon is initialized and joins a cluster.
-		PreJoin: func(s *state.State, initConfig map[string]string) error {
+		PreJoin: func(s state.State, initConfig map[string]string) error {
 			logCtx := logger.Ctx{}
 			for k, v := range initConfig {
 				logCtx[k] = v
@@ -156,35 +146,35 @@ func (c *cmdDaemon) run(cmd *cobra.Command, args []string) error {
 		},
 
 		// PostRemove is run after the daemon is removed from a cluster.
-		PostRemove: func(s *state.State, force bool) error {
+		PostRemove: func(s state.State, force bool) error {
 			logger.Infof("This is a hook that is run on peer %q after a cluster member is removed, with the force flag set to %v", s.Name(), force)
 
 			return nil
 		},
 
 		// PreRemove is run before the daemon is removed from the cluster.
-		PreRemove: func(s *state.State, force bool) error {
+		PreRemove: func(s state.State, force bool) error {
 			logger.Infof("This is a hook that is run on peer %q just before it is removed, with the force flag set to %v", s.Name(), force)
 
 			return nil
 		},
 
 		// OnHeartbeat is run after a successful heartbeat round.
-		OnHeartbeat: func(s *state.State) error {
+		OnHeartbeat: func(s state.State) error {
 			logger.Info("This is a hook that is run on the dqlite leader after a successful heartbeat")
 
 			return nil
 		},
 
 		// OnNewMember is run after a new member has joined.
-		OnNewMember: func(s *state.State) error {
+		OnNewMember: func(s state.State) error {
 			logger.Infof("This is a hook that is run on peer %q when a new cluster member has joined", s.Name())
 
 			return nil
 		},
 
 		// OnDaemonConfigUpdate is run after the local daemon config of a cluster member got modified.
-		OnDaemonConfigUpdate: func(s *state.State, config types.DaemonConfig) error {
+		OnDaemonConfigUpdate: func(s state.State, config types.DaemonConfig) error {
 			logger.Infof("Running OnDaemonConfigUpdate triggered by %q", config.Name)
 
 			return nil

--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -7,7 +7,6 @@ import (
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/spf13/cobra"
 
-	"github.com/canonical/microcluster/config"
 	"github.com/canonical/microcluster/example/api"
 	"github.com/canonical/microcluster/example/database"
 	"github.com/canonical/microcluster/example/version"
@@ -74,7 +73,7 @@ func (c *cmdDaemon) run(cmd *cobra.Command, args []string) error {
 	m.AddServers(api.Servers)
 
 	// exampleHooks are some example post-action hooks that can be run by MicroCluster.
-	exampleHooks := &config.Hooks{
+	exampleHooks := &state.Hooks{
 		// PostBootstrap is run after the daemon is initialized and bootstrapped.
 		PostBootstrap: func(s *state.State, initConfig map[string]string) error {
 			logCtx := logger.Ctx{}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -294,10 +294,10 @@ func (d *Daemon) init(listenAddress string, schemaExtensions []schema.Update, ap
 
 func (d *Daemon) applyHooks(hooks *state.Hooks) {
 	// Apply a no-op hooks for any missing hooks.
-	noOpHook := func(s *state.State) error { return nil }
-	noOpRemoveHook := func(s *state.State, force bool) error { return nil }
-	noOpInitHook := func(s *state.State, initConfig map[string]string) error { return nil }
-	noOpConfigHook := func(s *state.State, config types.DaemonConfig) error { return nil }
+	noOpHook := func(s state.State) error { return nil }
+	noOpRemoveHook := func(s state.State, force bool) error { return nil }
+	noOpInitHook := func(s state.State, initConfig map[string]string) error { return nil }
+	noOpConfigHook := func(s state.State, config types.DaemonConfig) error { return nil }
 
 	if hooks == nil {
 		d.hooks = state.Hooks{}
@@ -998,13 +998,8 @@ func (d *Daemon) FileSystem() *sys.OS {
 
 // State creates a State instance with the daemon's stateful components.
 func (d *Daemon) State() state.State {
-	state.PreRemoveHook = d.hooks.PreRemove
-	state.PostRemoveHook = d.hooks.PostRemove
-	state.OnHeartbeatHook = d.hooks.OnHeartbeat
-	state.OnNewMemberHook = d.hooks.OnNewMember
-	state.OnDaemonConfigUpdate = d.hooks.OnDaemonConfigUpdate
-
 	state := &internalState.InternalState{
+		Hooks:                    &d.hooks,
 		Context:                  d.shutdownCtx,
 		ReadyCh:                  d.ReadyChan,
 		StartAPI:                 d.StartAPI,

--- a/internal/rest/resources/database.go
+++ b/internal/rest/resources/database.go
@@ -19,7 +19,7 @@ var databaseCmd = rest.Endpoint{
 	Patch: rest.EndpointAction{Handler: databasePatch},
 }
 
-func databasePost(state *state.State, r *http.Request) response.Response {
+func databasePost(state state.State, r *http.Request) response.Response {
 	// Compare the dqlite version of the connecting client with our own.
 	versionHeader := r.Header.Get("X-Dqlite-Version")
 	if versionHeader == "" {
@@ -40,7 +40,7 @@ func databasePost(state *state.State, r *http.Request) response.Response {
 	return response.EmptySyncResponse
 }
 
-func databasePatch(state *state.State, r *http.Request) response.Response {
+func databasePatch(state state.State, r *http.Request) response.Response {
 	// Compare the dqlite version of the connecting client with our own.
 	versionHeader := r.Header.Get("X-Dqlite-Version")
 	if versionHeader == "" {
@@ -54,7 +54,7 @@ func databasePatch(state *state.State, r *http.Request) response.Response {
 	}
 
 	// Notify this node that a schema upgrade has occurred, in case we are waiting on one.
-	state.Database.NotifyUpgraded()
+	state.Database().NotifyUpgraded()
 
 	return response.EmptySyncResponse
 }

--- a/internal/rest/resources/hooks.go
+++ b/internal/rest/resources/hooks.go
@@ -10,10 +10,11 @@ import (
 	"github.com/gorilla/mux"
 
 	internalTypes "github.com/canonical/microcluster/internal/rest/types"
-	"github.com/canonical/microcluster/internal/state"
+	internalState "github.com/canonical/microcluster/internal/state"
 	"github.com/canonical/microcluster/rest"
 	"github.com/canonical/microcluster/rest/access"
 	"github.com/canonical/microcluster/rest/types"
+	"github.com/canonical/microcluster/state"
 )
 
 var hooksCmd = rest.Endpoint{
@@ -22,8 +23,13 @@ var hooksCmd = rest.Endpoint{
 	Post: rest.EndpointAction{Handler: hooksPost, AccessHandler: access.AllowAuthenticated, ProxyTarget: true},
 }
 
-func hooksPost(s *state.State, r *http.Request) response.Response {
+func hooksPost(s state.State, r *http.Request) response.Response {
 	hookTypeStr, err := url.PathUnescape(mux.Vars(r)["hookType"])
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	intState, err := internalState.ToInternal(s)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -36,7 +42,7 @@ func hooksPost(s *state.State, r *http.Request) response.Response {
 			return response.BadRequest(err)
 		}
 
-		err = state.PreRemoveHook(s, req.Force)
+		err = intState.Hooks.PreRemove(s, req.Force)
 		if err != nil {
 			return response.SmartError(fmt.Errorf("Failed to execute pre-remove hook on cluster member %q: %w", s.Name(), err))
 		}
@@ -47,7 +53,7 @@ func hooksPost(s *state.State, r *http.Request) response.Response {
 			return response.BadRequest(err)
 		}
 
-		err = state.PostRemoveHook(s, req.Force)
+		err = intState.Hooks.PostRemove(s, req.Force)
 		if err != nil {
 			return response.SmartError(fmt.Errorf("Failed to execute post-remove hook on cluster member %q: %w", s.Name(), err))
 		}
@@ -63,7 +69,7 @@ func hooksPost(s *state.State, r *http.Request) response.Response {
 			return response.SmartError(fmt.Errorf("No new member name given for NewMember hook execution"))
 		}
 
-		err = state.OnNewMemberHook(s)
+		err = intState.Hooks.OnNewMember(s)
 		if err != nil {
 			return response.SmartError(fmt.Errorf("Failed to run hook after system %q has joined the cluster: %w", req.Name, err))
 		}
@@ -74,7 +80,7 @@ func hooksPost(s *state.State, r *http.Request) response.Response {
 			return response.BadRequest(err)
 		}
 
-		err = state.OnDaemonConfigUpdate(s, req)
+		err = intState.Hooks.OnDaemonConfigUpdate(s, req)
 		if err != nil {
 			return response.SmartError(fmt.Errorf("Failed to run hook on %q after daemon received local config update: %w", s.Name(), err))
 		}

--- a/internal/rest/resources/hooks_test.go
+++ b/internal/rest/resources/hooks_test.go
@@ -28,28 +28,29 @@ func TestHooksSuite(t *testing.T) {
 }
 
 func (t *hooksSuite) Test_hooks() {
-	s := &state.State{
-		Context: context.TODO(),
-		Name:    func() string { return "n0" },
-	}
-
 	var ranHook types.HookType
 	var isForce bool
-	state.PostRemoveHook = func(state *state.State, force bool) error {
-		ranHook = types.PostRemove
-		isForce = force
-		return nil
-	}
+	s := &state.InternalState{
+		Context:      context.TODO(),
+		InternalName: func() string { return "n0" },
+		Hooks: &state.Hooks{
+			PostRemove: func(state state.State, force bool) error {
+				ranHook = types.PostRemove
+				isForce = force
+				return nil
+			},
 
-	state.PreRemoveHook = func(state *state.State, force bool) error {
-		ranHook = types.PreRemove
-		isForce = force
-		return nil
-	}
+			PreRemove: func(state state.State, force bool) error {
+				ranHook = types.PreRemove
+				isForce = force
+				return nil
+			},
 
-	state.OnNewMemberHook = func(state *state.State) error {
-		ranHook = types.OnNewMember
-		return nil
+			OnNewMember: func(state state.State) error {
+				ranHook = types.OnNewMember
+				return nil
+			},
+		},
 	}
 
 	tests := []struct {

--- a/internal/rest/resources/shutdown.go
+++ b/internal/rest/resources/shutdown.go
@@ -7,9 +7,10 @@ import (
 	"github.com/canonical/lxd/lxd/response"
 
 	"github.com/canonical/microcluster/internal/db"
-	"github.com/canonical/microcluster/internal/state"
+	internalState "github.com/canonical/microcluster/internal/state"
 	"github.com/canonical/microcluster/rest"
 	"github.com/canonical/microcluster/rest/access"
+	"github.com/canonical/microcluster/state"
 )
 
 var shutdownCmd = rest.Endpoint{
@@ -19,19 +20,24 @@ var shutdownCmd = rest.Endpoint{
 	Post: rest.EndpointAction{Handler: shutdownPost, AccessHandler: access.AllowAuthenticated},
 }
 
-func shutdownPost(state *state.State, r *http.Request) response.Response {
-	if state.Context.Err() != nil {
+func shutdownPost(state state.State, r *http.Request) response.Response {
+	intState, err := internalState.ToInternal(state)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	if intState.Context.Err() != nil {
 		return response.SmartError(fmt.Errorf("Shutdown already in progress"))
 	}
 
 	return response.ManualResponse(func(w http.ResponseWriter) error {
 		// If the database is waiting for an upgrade, we may never become ready, so go ahead and shut down the database anyway.
-		if state.Database.Status() != db.StatusWaiting {
-			<-state.ReadyCh // Wait for daemon to start.
+		if state.Database().Status() != db.StatusWaiting {
+			<-intState.ReadyCh // Wait for daemon to start.
 		}
 
 		// Run shutdown sequence synchronously.
-		exit, stopErr := state.Stop()
+		exit, stopErr := intState.Stop()
 		err := response.SmartError(stopErr).Render(w)
 		if err != nil {
 			return err

--- a/internal/rest/resources/sql.go
+++ b/internal/rest/resources/sql.go
@@ -28,7 +28,7 @@ var sqlCmd = rest.Endpoint{
 }
 
 // Perform a database dump.
-func sqlGet(state *state.State, r *http.Request) response.Response {
+func sqlGet(state state.State, r *http.Request) response.Response {
 	parentCtx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
 
@@ -38,7 +38,7 @@ func sqlGet(state *state.State, r *http.Request) response.Response {
 	}
 
 	var dump string
-	err = state.Database.Transaction(parentCtx, func(ctx context.Context, tx *sql.Tx) error {
+	err = state.Database().Transaction(parentCtx, func(ctx context.Context, tx *sql.Tx) error {
 		dump, err = query.Dump(ctx, tx, schemaOnly == 1)
 		if err != nil {
 			return fmt.Errorf("Failed dump database: %w", err)
@@ -54,7 +54,7 @@ func sqlGet(state *state.State, r *http.Request) response.Response {
 }
 
 // Execute queries.
-func sqlPost(state *state.State, r *http.Request) response.Response {
+func sqlPost(state state.State, r *http.Request) response.Response {
 	parentCtx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
 	req := &types.SQLQuery{}
@@ -78,7 +78,7 @@ func sqlPost(state *state.State, r *http.Request) response.Response {
 		}
 
 		result := types.SQLResult{}
-		err = state.Database.Transaction(parentCtx, func(ctx context.Context, tx *sql.Tx) error {
+		err = state.Database().Transaction(parentCtx, func(ctx context.Context, tx *sql.Tx) error {
 			if strings.HasPrefix(strings.ToUpper(query), "SELECT") {
 				err = sqlSelect(ctx, tx, query, &result)
 			} else {

--- a/internal/rest/resources/truststore.go
+++ b/internal/rest/resources/truststore.go
@@ -14,10 +14,10 @@ import (
 	"github.com/canonical/microcluster/client"
 	internalClient "github.com/canonical/microcluster/internal/rest/client"
 	internalTypes "github.com/canonical/microcluster/internal/rest/types"
-	"github.com/canonical/microcluster/internal/state"
 	"github.com/canonical/microcluster/internal/trust"
 	"github.com/canonical/microcluster/rest"
 	"github.com/canonical/microcluster/rest/access"
+	"github.com/canonical/microcluster/state"
 )
 
 var trustCmd = rest.Endpoint{
@@ -34,7 +34,7 @@ var trustEntryCmd = rest.Endpoint{
 	Delete: rest.EndpointAction{Handler: trustDelete, AccessHandler: access.AllowAuthenticated},
 }
 
-func trustPost(s *state.State, r *http.Request) response.Response {
+func trustPost(s state.State, r *http.Request) response.Response {
 	req := internalTypes.ClusterMemberLocal{}
 
 	// Parse the request.
@@ -48,7 +48,7 @@ func trustPost(s *state.State, r *http.Request) response.Response {
 		Certificate: req.Certificate,
 	}
 
-	ctx, cancel := context.WithTimeout(s.Context, 30*time.Second)
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
 
 	if !client.IsNotification(r) {
@@ -74,7 +74,7 @@ func trustPost(s *state.State, r *http.Request) response.Response {
 	remotes := s.Remotes()
 	_, ok := remotes.RemotesByName()[newRemote.Name]
 	if !ok {
-		err = remotes.Add(s.OS.TrustDir, newRemote)
+		err = remotes.Add(s.FileSystem().TrustDir, newRemote)
 		if err != nil {
 			return response.SmartError(fmt.Errorf("Failed adding local record of newly joined node %q: %w", req.Name, err))
 		}
@@ -83,13 +83,13 @@ func trustPost(s *state.State, r *http.Request) response.Response {
 	return response.EmptySyncResponse
 }
 
-func trustDelete(s *state.State, r *http.Request) response.Response {
+func trustDelete(s state.State, r *http.Request) response.Response {
 	name, err := url.PathUnescape(mux.Vars(r)["name"])
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	ctx, cancel := context.WithTimeout(s.Context, 30*time.Second)
+	ctx, cancel := context.WithTimeout(r.Context(), 30*time.Second)
 	defer cancel()
 
 	remotesMap := s.Remotes().RemotesByName()
@@ -134,7 +134,7 @@ func trustDelete(s *state.State, r *http.Request) response.Response {
 		newRemotes = append(newRemotes, newRemote)
 	}
 
-	err = remotes.Replace(s.OS.TrustDir, newRemotes...)
+	err = remotes.Replace(s.FileSystem().TrustDir, newRemotes...)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed to remove truststore entry for node with name %q: %w", name, err))
 	}

--- a/internal/rest/rest.go
+++ b/internal/rest/rest.go
@@ -18,12 +18,13 @@ import (
 	"github.com/canonical/microcluster/cluster"
 	internalAccess "github.com/canonical/microcluster/internal/rest/access"
 	"github.com/canonical/microcluster/internal/rest/client"
-	"github.com/canonical/microcluster/internal/state"
+	internalState "github.com/canonical/microcluster/internal/state"
 	"github.com/canonical/microcluster/rest"
 	"github.com/canonical/microcluster/rest/access"
+	"github.com/canonical/microcluster/state"
 )
 
-func handleAPIRequest(action rest.EndpointAction, state *state.State, w http.ResponseWriter, r *http.Request) response.Response {
+func handleAPIRequest(action rest.EndpointAction, state state.State, w http.ResponseWriter, r *http.Request) response.Response {
 	if action.Handler == nil {
 		return response.NotImplemented(nil)
 	}
@@ -66,7 +67,7 @@ func handleAPIRequest(action rest.EndpointAction, state *state.State, w http.Res
 	return action.Handler(state, r)
 }
 
-func proxyTarget(action rest.EndpointAction, s *state.State, r *http.Request) response.Response {
+func proxyTarget(action rest.EndpointAction, s state.State, r *http.Request) response.Response {
 	if r.URL == nil {
 		return action.Handler(s, r)
 	}
@@ -86,7 +87,7 @@ func proxyTarget(action rest.EndpointAction, s *state.State, r *http.Request) re
 	}
 
 	var targetURL *api.URL
-	err = s.Database.Transaction(s.Context, func(ctx context.Context, tx *sql.Tx) error {
+	err = s.Database().Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		clusterMember, err := cluster.GetInternalClusterMember(ctx, tx, target)
 		if err != nil {
 			return fmt.Errorf("Failed to get cluster member for request target name %q: %w", target, err)
@@ -125,7 +126,7 @@ func proxyTarget(action rest.EndpointAction, s *state.State, r *http.Request) re
 	return response.SyncResponse(true, resp.Metadata)
 }
 
-func handleDatabaseRequest(action rest.EndpointAction, state *state.State, w http.ResponseWriter, r *http.Request) response.Response {
+func handleDatabaseRequest(action rest.EndpointAction, state state.State, w http.ResponseWriter, r *http.Request) response.Response {
 	trusted := r.Context().Value(request.CtxAccess)
 	if trusted == nil {
 		return response.Forbidden(nil)
@@ -156,7 +157,7 @@ func handleDatabaseRequest(action rest.EndpointAction, state *state.State, w htt
 			return response.InternalError(fmt.Errorf("Failed to hijack connection: %w", err))
 		}
 
-		state.Database.Accept(conn)
+		state.Database().Accept(conn)
 	}
 
 	return action.Handler(state, r)
@@ -164,7 +165,7 @@ func handleDatabaseRequest(action rest.EndpointAction, state *state.State, w htt
 
 // HandleEndpoint adds the endpoint to the mux router. A function variable is used to implement common logic
 // before calling the endpoint action handler associated with the request method, if it exists.
-func HandleEndpoint(state *state.State, mux *mux.Router, version string, e rest.Endpoint) {
+func HandleEndpoint(state state.State, mux *mux.Router, version string, e rest.Endpoint) {
 	url := "/" + version
 	if e.Path != "" {
 		url = filepath.Join(url, e.Path)
@@ -176,8 +177,18 @@ func HandleEndpoint(state *state.State, mux *mux.Router, version string, e rest.
 		// Actually process the request.
 		var resp response.Response
 
+		intState, err := internalState.ToInternal(state)
+		if err != nil {
+			err := response.BadRequest(err).Render(w)
+			if err != nil {
+				logger.Error("Failed to write HTTP response", logger.Ctx{"url": r.URL, "err": err})
+			}
+
+			return
+		}
+
 		// Return Unavailable Error (503) if daemon is shutting down, except for endpoints with AllowedDuringShutdown.
-		if state.Context.Err() == context.Canceled && !e.AllowedDuringShutdown {
+		if intState.Context.Err() == context.Canceled && !e.AllowedDuringShutdown {
 			err := response.Unavailable(fmt.Errorf("Daemon is shutting down")).Render(w)
 			if err != nil {
 				logger.Error("Failed to write HTTP response", logger.Ctx{"url": r.URL, "err": err})
@@ -187,7 +198,7 @@ func HandleEndpoint(state *state.State, mux *mux.Router, version string, e rest.
 		}
 
 		if !e.AllowedBeforeInit {
-			err := state.Database.IsOpen(r.Context())
+			err := state.Database().IsOpen(r.Context())
 			if err != nil {
 				err := response.SmartError(err).Render(w)
 				if err != nil {

--- a/internal/state/hooks.go
+++ b/internal/state/hooks.go
@@ -1,7 +1,6 @@
-package config
+package state
 
 import (
-	"github.com/canonical/microcluster/internal/state"
 	"github.com/canonical/microcluster/rest/types"
 )
 
@@ -9,34 +8,34 @@ import (
 // integrate with other tools.
 type Hooks struct {
 	// PreBootstrap is run before the daemon is initialized and bootstrapped.
-	PreBootstrap func(s *state.State, initConfig map[string]string) error
+	PreBootstrap func(s State, initConfig map[string]string) error
 
 	// PostBootstrap is run after the daemon is initialized and bootstrapped.
-	PostBootstrap func(s *state.State, initConfig map[string]string) error
+	PostBootstrap func(s State, initConfig map[string]string) error
 
 	// OnStart is run after the daemon is started.
-	OnStart func(s *state.State) error
+	OnStart func(s State) error
 
 	// PostJoin is run after the daemon is initialized, joined the cluster and existing members triggered
 	// their 'OnNewMember' hooks.
-	PostJoin func(s *state.State, initConfig map[string]string) error
+	PostJoin func(s State, initConfig map[string]string) error
 
 	// PreJoin is run after the daemon is initialized and joined the cluster but before existing members triggered
 	// their 'OnNewMember' hooks.
-	PreJoin func(s *state.State, initConfig map[string]string) error
+	PreJoin func(s State, initConfig map[string]string) error
 
 	// PreRemove is run on a cluster member just before it is removed from the cluster.
-	PreRemove func(s *state.State, force bool) error
+	PreRemove func(s State, force bool) error
 
 	// PostRemove is run on all other peers after one is removed from the cluster.
-	PostRemove func(s *state.State, force bool) error
+	PostRemove func(s State, force bool) error
 
 	// OnHeartbeat is run after a successful heartbeat round.
-	OnHeartbeat func(s *state.State) error
+	OnHeartbeat func(s State) error
 
 	// OnNewMember is run on each peer after a new cluster member has joined and executed their 'PreJoin' hook.
-	OnNewMember func(s *state.State) error
+	OnNewMember func(s State) error
 
-	// OnDaemonConfigUpdate
-	OnDaemonConfigUpdate func(s *state.State, config types.DaemonConfig) error
+	// OnDaemonConfigUpdate is a post-action hook that is run on all cluster members when any cluster member receives a local configuration update.
+	OnDaemonConfigUpdate func(s State, config types.DaemonConfig) error
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -2,6 +2,7 @@ package state
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/canonical/lxd/shared"
@@ -18,8 +19,44 @@ import (
 	"github.com/canonical/microcluster/rest/types"
 )
 
-// State is a gateway to the stateful components of the microcluster daemon.
-type State struct {
+// State exposes the internal daemon state for use with extended API handlers.
+type State interface {
+	// FileSystem structure.
+	FileSystem() *sys.OS
+
+	// Listen Address.
+	Address() *api.URL
+
+	// Name of the cluster member.
+	Name() string
+
+	// Server certificate is used for server-to-server connection.
+	ServerCert() *shared.CertInfo
+
+	// Cluster certificate is used for downstream connections within a cluster.
+	ClusterCert() *shared.CertInfo
+
+	// Database.
+	Database() *db.DB
+
+	// Local truststore access.
+	Remotes() *trust.Remotes
+
+	// Cluster returns a client to every cluster member according to dqlite.
+	Cluster(isNotification bool) (client.Cluster, error)
+
+	// Leader returns a client to the dqlite cluster leader.
+	Leader() (*client.Client, error)
+
+	// HasExtension returns whether the given API extension is supported.
+	HasExtension(ext string) bool
+
+	// ExtensionServers returns an immutable list of the daemon's additional listeners.
+	ExtensionServers() []string
+}
+
+// InternalState is a gateway to the stateful components of the microcluster daemon.
+type InternalState struct {
 	// Context.
 	Context context.Context
 
@@ -29,32 +66,11 @@ type State struct {
 	// ShutdownDoneCh receives the result of the d.Stop() function and tells the daemon to end.
 	ShutdownDoneCh chan error
 
-	// File structure.
-	OS *sys.OS
-
-	// Listen Address.
-	Address func() *api.URL
-
-	// Name of the cluster member.
-	Name func() string
-
-	// Server.
+	// Endpoints manages the network and unix socket listeners.
 	Endpoints *endpoints.Endpoints
-
-	// Server certificate is used for server-to-server connection.
-	ServerCert func() *shared.CertInfo
-
-	// Cluster certificate is used for downstream connections within a cluster.
-	ClusterCert func() *shared.CertInfo
 
 	// Local daemon's config.
 	LocalConfig func() *internalConfig.DaemonConfig
-
-	// Database.
-	Database *db.DB
-
-	// Remotes.
-	Remotes func() *trust.Remotes
 
 	// Initialize APIs and bootstrap/join database.
 	StartAPI func(bootstrap bool, initConfig map[string]string, newConfig *trust.Location, joinAddresses ...string) error
@@ -62,42 +78,81 @@ type State struct {
 	// Update the additional listeners.
 	UpdateServers func() error
 
+	// ReloadCert reloads the given keypair from the state directory.
+	ReloadCert func(name types.CertificateName) error
+
+	// StopListeners stops the network listeners and the fsnotify listener.
+	StopListeners func() error
+
 	// Stop fully stops the daemon, its database, and all listeners.
 	Stop func() (exit func(), stopErr error)
 
 	// Runtime extensions.
 	Extensions extensions.Extensions
 
-	// Returns an immutable list of the daemon's additional listeners.
-	ExtensionServers func() []string
+	// Hooks contain external implementations that are triggered by specific cluster actions.
+	Hooks *Hooks
+
+	InternalFileSystem       func() *sys.OS
+	InternalAddress          func() *api.URL
+	InternalName             func() string
+	InternalServerCert       func() *shared.CertInfo
+	InternalClusterCert      func() *shared.CertInfo
+	InternalDatabase         *db.DB
+	InternalRemotes          func() *trust.Remotes
+	InternalExtensionServers func() []string
 }
 
-// StopListeners stops the network listeners and the fsnotify listener.
-var StopListeners func() error
+// FileSystem can be used to inspect the microcluster filesystem.
+func (s *InternalState) FileSystem() *sys.OS {
+	return s.InternalFileSystem()
+}
 
-// PostRemoveHook is a post-action hook that is run on all cluster members when a cluster member is removed.
-var PostRemoveHook func(state *State, force bool) error
+// Address returns the core microcluster listen address.
+func (s *InternalState) Address() *api.URL {
+	return s.InternalAddress()
+}
 
-// PreRemoveHook is a post-action hook that is run on a cluster member just before it is is removed.
-var PreRemoveHook func(state *State, force bool) error
+// Name returns the cluster name for the local system.
+func (s *InternalState) Name() string {
+	return s.InternalName()
+}
 
-// OnHeartbeatHook is a post-action hook that is run on the leader after a successful heartbeat round.
-var OnHeartbeatHook func(state *State) error
+// ServerCert returns the keypair identifying the local system.
+func (s *InternalState) ServerCert() *shared.CertInfo {
+	return s.InternalServerCert()
+}
 
-// OnNewMemberHook is a post-action hook that is run on all cluster members when a new cluster member joins the cluster.
-var OnNewMemberHook func(state *State) error
+// ClusterCert returns the keypair identifying the cluster.
+func (s *InternalState) ClusterCert() *shared.CertInfo {
+	return s.InternalClusterCert()
+}
 
-// OnDaemonConfigUpdate is a post-action hook that is run on all cluster members when any cluster member receives a local configuration update.
-var OnDaemonConfigUpdate func(state *State, config types.DaemonConfig) error
+// Database allows access to the dqlite database.
+func (s *InternalState) Database() *db.DB {
+	return s.InternalDatabase
+}
 
-// ReloadCert reloads the given keypair from the state directory.
-var ReloadCert func(name types.CertificateName) error
+// Remotes returns the local record of cluster members in the truststore.
+func (s *InternalState) Remotes() *trust.Remotes {
+	return s.InternalRemotes()
+}
+
+// ExtensionServers returns an immutable list of the daemon's additional listeners.
+func (s *InternalState) ExtensionServers() []string {
+	return s.InternalExtensionServers()
+}
+
+// HasExtension returns whether the given API extension is supported.
+func (s *InternalState) HasExtension(ext string) bool {
+	return s.Extensions.HasExtension(ext)
+}
 
 // Cluster returns a client for every member of a cluster, except
 // this one.
 // All requests made by the client will have the UserAgentNotifier header set
 // if isNotification is true.
-func (s *State) Cluster(isNotification bool) (client.Cluster, error) {
+func (s *InternalState) Cluster(isNotification bool) (client.Cluster, error) {
 	c, err := s.Leader()
 	if err != nil {
 		return nil, err
@@ -132,11 +187,11 @@ func (s *State) Cluster(isNotification bool) (client.Cluster, error) {
 }
 
 // Leader returns a client connected to the dqlite leader.
-func (s *State) Leader() (*client.Client, error) {
+func (s *InternalState) Leader() (*client.Client, error) {
 	ctx, cancel := context.WithTimeout(s.Context, time.Second*30)
 	defer cancel()
 
-	leaderClient, err := s.Database.Leader(ctx)
+	leaderClient, err := s.Database().Leader(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -158,4 +213,14 @@ func (s *State) Leader() (*client.Client, error) {
 	}
 
 	return &client.Client{Client: *c}, nil
+}
+
+// ToInternal returns the underlying InternalState from the exposed State interface.
+func ToInternal(s State) (*InternalState, error) {
+	internal, ok := s.(*InternalState)
+	if ok {
+		return internal, nil
+	}
+
+	return nil, fmt.Errorf("Underlying State is not an InternalState")
 }

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -20,7 +20,6 @@ import (
 
 	"github.com/canonical/microcluster/client"
 	"github.com/canonical/microcluster/cluster"
-	"github.com/canonical/microcluster/config"
 	"github.com/canonical/microcluster/internal/daemon"
 	"github.com/canonical/microcluster/internal/recover"
 	internalClient "github.com/canonical/microcluster/internal/rest/client"
@@ -28,6 +27,7 @@ import (
 	"github.com/canonical/microcluster/internal/sys"
 	"github.com/canonical/microcluster/rest"
 	"github.com/canonical/microcluster/rest/types"
+	"github.com/canonical/microcluster/state"
 )
 
 // MicroCluster contains some basic filesystem information for interacting with the MicroCluster daemon.
@@ -75,7 +75,7 @@ func App(args Args) (*MicroCluster, error) {
 // database exists yet. Any api or schema extensions can be applied here.
 // - `extensionsSchema` is a list of schema updates in the order that they should be applied.
 // - `hooks` are a set of functions that trigger at certain points during cluster communication.
-func (m *MicroCluster) Start(ctx context.Context, extensionsSchema []schema.Update, apiExtensions []string, hooks *config.Hooks) error {
+func (m *MicroCluster) Start(ctx context.Context, extensionsSchema []schema.Update, apiExtensions []string, hooks *state.Hooks) error {
 	// Initialize the logger.
 	err := logger.InitLogger(m.FileSystem.LogFile, "", m.args.Verbose, m.args.Debug, nil)
 	if err != nil {

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -17,8 +17,8 @@ type EndpointAlias struct {
 
 // EndpointAction represents an action on an API endpoint.
 type EndpointAction struct {
-	Handler        func(state *state.State, r *http.Request) response.Response
-	AccessHandler  func(state *state.State, r *http.Request) (trusted bool, resp response.Response)
+	Handler        func(state state.State, r *http.Request) response.Response
+	AccessHandler  func(state state.State, r *http.Request) (trusted bool, resp response.Response)
 	AllowUntrusted bool
 	ProxyTarget    bool // Allow forwarding of the request to a target if ?target=name is specified.
 }

--- a/state/state.go
+++ b/state/state.go
@@ -4,3 +4,6 @@ import "github.com/canonical/microcluster/internal/state"
 
 // State exposes the internal daemon state for use with extended API handlers.
 type State = state.State
+
+// Hooks exposes the Hooks struct to be imported by the upstream project.
+type Hooks = state.Hooks


### PR DESCRIPTION
Closes #133 

* Replaces `state.State` with a new `state.InternalState` struct which implements a `state.State` interface. This means that the fields of `State` are not overwrite-able by the upstream project, and internal functions are not exposed externally.

* To avoid import cycles, `config.Hooks` is moved into the `state` package as well. This is actually not too bad since the `config` package was a confusing place for it. It also means we don't need to define functions and can just provide the whole type to `InternalState`

