### PR TITLE
internal: Prevent Daemon startup if control socket is present

### DIFF
--- a/example/test/main.sh
+++ b/example/test/main.sh
@@ -27,6 +27,9 @@ for member in "${members[@]}"; do
   microctl --state-dir "${state_dir}" waitready
 done
 
+# Ensure two daemons cannot start in the same state dir
+! microd --state-dir "${test_dir}/c1" "${cluster_flags[@]}"
+
 # Ensure only valid member names are used
 ! microctl --state-dir "${test_dir}/c1" init "c/1" 127.0.0.1:9001 --bootstrap
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -114,10 +114,18 @@ func (d *Daemon) Run(ctx context.Context, listenPort string, stateDir string, so
 		return fmt.Errorf("Failed to find state directory: %w", err)
 	}
 
-	// TODO: Check if already running.
 	d.os, err = sys.DefaultOS(stateDir, socketGroup, true)
 	if err != nil {
 		return fmt.Errorf("Failed to initialize directory structure: %w", err)
+	}
+
+	isAlreadyRunning, err := d.os.IsControlSocketPresent()
+	if err != nil {
+		return err
+	}
+
+	if isAlreadyRunning {
+		return fmt.Errorf("Control socket already present (%q); is another daemon already running?", d.os.ControlSocketPath())
 	}
 
 	d.extensionServers = extensionServers


### PR DESCRIPTION
I'm having a hard time coming up with any situation where it's safe to start the daemon if a control socket still exists in the state dir.

I'm doing this check anyway as a part of cluster recovery.