### PR TITLE
internal/daemon: Don't error out if upgrade notification fails

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -623,7 +623,7 @@ func (d *Daemon) sendUpgradeNotification(ctx context.Context, c *client.Client) 
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return fmt.Errorf("Database upgrade notification failed: %s", resp.Status)
+		logger.Errorf("Database upgrade notification failed: %s", resp.Status)
 	}
 
 	return nil


### PR DESCRIPTION
If the upgrade notification fails, that does not mean that we have to stop starting the local node, rather it is informing us of an issue on a remote cluster member, so we can ignore it during set up.