### PR TITLE
Add descriptive errors for database status checks

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -452,7 +452,7 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 			Role:        cluster.Pending,
 		}
 
-		clusterMember.SchemaInternal, clusterMember.SchemaExternal = d.db.Schema().Version()
+		clusterMember.SchemaInternal, clusterMember.SchemaExternal, _ = d.db.Schema().Version()
 
 		err = d.db.Bootstrap(d.Extensions, d.project, d.address, clusterMember)
 		if err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -576,7 +576,7 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 
 			// Run the OnNewMember hook, and skip errors on any nodes that are still in the process of joining.
 			err = internalClient.RunNewMemberHook(ctx, c.Client.UseTarget(remote.Name), internalTypes.HookNewMemberOptions{Name: localMemberInfo.Name})
-			if err != nil && err.Error() != "Daemon not yet initialized" {
+			if err != nil && !api.StatusErrorCheck(err, http.StatusServiceUnavailable) {
 				return err
 			}
 		}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -247,8 +247,9 @@ func (db *DB) retry(ctx context.Context, f func(context.Context) error) error {
 
 // Update attempts to update the database with the executable at the path specified by the SCHEMA_UPDATE variable.
 func (db *DB) Update() error {
-	if !db.IsOpen() {
-		return fmt.Errorf("Failed to update, database is not yet open")
+	err := db.IsOpen(context.Background())
+	if err != nil {
+		return fmt.Errorf("Failed to update, database is not yet open: %w", err)
 	}
 
 	updateExec := os.Getenv(sys.SchemaUpdate)
@@ -263,7 +264,7 @@ func (db *DB) Update() error {
 	time.Sleep(wait)
 
 	logger.Info("Triggering cluster auto-update now")
-	_, err := shared.RunCommand(updateExec)
+	_, err = shared.RunCommand(updateExec)
 	if err != nil {
 		logger.Error("Triggering cluster update failed", logger.Ctx{"err": err})
 		return err

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -130,7 +130,7 @@ func (db *DB) waitUpgrade(bootstrap bool, ext extensions.Extensions) error {
 	newSchema := db.Schema()
 	if !bootstrap {
 		checkVersions := func(ctx context.Context, current int, tx *sql.Tx) error {
-			schemaVersionInternal, schemaVersionExternal := newSchema.Version()
+			schemaVersionInternal, schemaVersionExternal, _ := newSchema.Version()
 			err := cluster.UpdateClusterMemberSchemaVersion(tx, schemaVersionInternal, schemaVersionExternal, db.listenAddr.URL.Host)
 			if err != nil {
 				return fmt.Errorf("Failed to update schema version when joining cluster: %w", err)

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -13,6 +13,7 @@ import (
 	"github.com/canonical/lxd/lxd/db/schema"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/logger"
+	"github.com/canonical/lxd/shared/revert"
 
 	"github.com/canonical/microcluster/cluster"
 	"github.com/canonical/microcluster/internal/extensions"
@@ -24,6 +25,19 @@ import (
 func (db *DB) Open(ext extensions.Extensions, bootstrap bool, project string) error {
 	ctx, cancel := context.WithTimeout(db.ctx, 30*time.Second)
 	defer cancel()
+
+	db.statusLock.Lock()
+	db.status = StatusStarting
+	db.statusLock.Unlock()
+
+	reverter := revert.New()
+	defer reverter.Fail()
+
+	reverter.Add(func() {
+		db.statusLock.Lock()
+		db.status = StatusOffline
+		db.statusLock.Unlock()
+	})
 
 	err := db.dqlite.Ready(ctx)
 	if err != nil {
@@ -45,7 +59,11 @@ func (db *DB) Open(ext extensions.Extensions, bootstrap bool, project string) er
 		return err
 	}
 
-	db.openCanceller.Cancel()
+	db.statusLock.Lock()
+	db.status = StatusReady
+	db.statusLock.Unlock()
+
+	reverter.Success()
 
 	return nil
 }
@@ -189,6 +207,10 @@ func (db *DB) waitUpgrade(bootstrap bool, ext extensions.Extensions) error {
 
 	// If we are not bootstrapping, wait for an upgrade notification, or wait a minute before checking again.
 	if otherNodesBehind && !bootstrap {
+		db.statusLock.Lock()
+		db.status = StatusWaiting
+		db.statusLock.Unlock()
+
 		logger.Warn("Waiting for other cluster members to upgrade their versions", logger.Ctx{"address": db.listenAddr.String()})
 		select {
 		case <-db.upgradeCh:

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -209,6 +209,19 @@ func (db *DB) Cluster(ctx context.Context, client *dqliteClient.Client) ([]dqlit
 	return members, nil
 }
 
+// Status returns the current status of the database.
+func (db *DB) Status() Status {
+	if db == nil {
+		return StatusNotReady
+	}
+
+	db.statusLock.RLock()
+	status := db.status
+	db.statusLock.RUnlock()
+
+	return status
+}
+
 // IsOpen returns nil  only if the DB has been opened and the schema loaded.
 // Otherwise, it returns an error describing why the database is offline.
 // The returned error may have the http status 503, indicating that the database is in a valid but unavailable state.

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -292,7 +292,7 @@ func (db *DB) loopHeartbeat() {
 }
 
 func (db *DB) heartbeat(ctx context.Context) {
-	if !db.IsOpen() {
+	if db.IsOpen(ctx) != nil {
 		logger.Debug("Database is not yet open, aborting heartbeat", logger.Ctx{"address": db.listenAddr.String()})
 		return
 	}
@@ -419,7 +419,7 @@ func (db *DB) Stop() error {
 	db.status = StatusOffline
 	db.statusLock.Unlock()
 
-	if db.IsOpen() {
+	if db.IsOpen(context.TODO()) == nil {
 		// The database might refuse to close if many nodes are stopping at the same time,
 		// because the dqlite connection will have been lost.
 		_ = db.db.Close()

--- a/internal/db/update/schema.go
+++ b/internal/db/update/schema.go
@@ -9,6 +9,8 @@ import (
 	"github.com/canonical/lxd/lxd/db/query"
 	"github.com/canonical/lxd/lxd/db/schema"
 	"github.com/canonical/lxd/shared"
+
+	"github.com/canonical/microcluster/internal/extensions"
 )
 
 // updateType represents whether the update is an internal or external schema update.
@@ -24,11 +26,12 @@ const (
 
 // SchemaUpdate holds the configuration for executing schema updates.
 type SchemaUpdate struct {
-	updates map[updateType][]schema.Update // Ordered series of internal and external updates making up the schema
-	hook    schema.Hook                    // Optional hook to execute whenever a update gets applied
-	fresh   string                         // Optional SQL statement used to create schema from scratch
-	check   schema.Check                   // Optional callback invoked before doing any update
-	path    string                         // Optional path to a file containing extra queries to run
+	updates       map[updateType][]schema.Update // Ordered series of internal and external updates making up the schema
+	apiExtensions extensions.Extensions
+	hook          schema.Hook  // Optional hook to execute whenever a update gets applied
+	fresh         string       // Optional SQL statement used to create schema from scratch
+	check         schema.Check // Optional callback invoked before doing any update
+	path          string       // Optional path to a file containing extra queries to run
 }
 
 // Fresh sets a statement that will be used to create the schema from scratch
@@ -47,8 +50,8 @@ func (s *SchemaUpdate) Check(check schema.Check) {
 }
 
 // Version returns the internal and external schema update versions, corresponding to the number of updates that have occurred.
-func (s *SchemaUpdate) Version() (internalVersion uint64, externalVersion uint64) {
-	return uint64(len(s.updates[updateInternal])), uint64(len(s.updates[updateExternal]))
+func (s *SchemaUpdate) Version() (internalVersion uint64, externalVersion uint64, apiExtensions extensions.Extensions) {
+	return uint64(len(s.updates[updateInternal])), uint64(len(s.updates[updateExternal])), s.apiExtensions
 }
 
 // Ensure makes sure that the actual schema in the given database matches the

--- a/internal/db/update/update.go
+++ b/internal/db/update/update.go
@@ -62,7 +62,7 @@ func (s *SchemaUpdateManager) SetExternalUpdates(updates []schema.Update) {
 
 // Schema returns a SchemaUpdate from the SchemaUpdateManager config.
 func (s *SchemaUpdateManager) Schema() *SchemaUpdate {
-	schema := &SchemaUpdate{updates: s.updates}
+	schema := &SchemaUpdate{updates: s.updates, apiExtensions: s.apiExtensions}
 	schema.Fresh("")
 	return schema
 }

--- a/internal/rest/resources/api_1.0.go
+++ b/internal/rest/resources/api_1.0.go
@@ -26,6 +26,6 @@ func api10Get(s *state.State, r *http.Request) response.Response {
 	return response.SyncResponse(true, internalTypes.Server{
 		Name:    s.Name(),
 		Address: addrPort,
-		Ready:   s.Database.IsOpen(),
+		Ready:   s.Database.IsOpen(r.Context()) == nil,
 	})
 }

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -97,7 +97,7 @@ func joinWithToken(state *state.State, r *http.Request, req *internalTypes.Contr
 	}
 
 	// Prepare the cluster for the incoming dqlite request by creating a database entry.
-	internalVersion, externalVersion := state.Database.Schema().Version()
+	internalVersion, externalVersion, _ := state.Database.Schema().Version()
 	newClusterMember := internalTypes.ClusterMember{
 		ClusterMemberLocal: internalTypes.ClusterMemberLocal{
 			Name:        localClusterMember.Name,

--- a/internal/rest/resources/heartbeat.go
+++ b/internal/rest/resources/heartbeat.go
@@ -40,8 +40,9 @@ func heartbeatPost(s *state.State, r *http.Request) response.Response {
 	// If we are not beginning a heartbeat, we are receiving one sent by the leader,
 	// so we should update our local store of cluster members with the data from the heartbeat.
 
-	if !s.Database.IsOpen() {
-		return response.SmartError(fmt.Errorf("Failed to respond to heartbeat, database is not yet open"))
+	err = s.Database.IsOpen(r.Context())
+	if err != nil {
+		return response.SmartError(fmt.Errorf("Failed to respond to heartbeat, database is not yet open: %w", err))
 	}
 
 	clusterMemberList := []types.ClusterMember{}

--- a/internal/rest/rest.go
+++ b/internal/rest/rest.go
@@ -172,8 +172,9 @@ func HandleEndpoint(state *state.State, mux *mux.Router, version string, e rest.
 		}
 
 		if !e.AllowedBeforeInit {
-			if !state.Database.IsOpen() {
-				err := response.Unavailable(fmt.Errorf("Daemon not yet initialized")).Render(w)
+			err := state.Database.IsOpen(r.Context())
+			if err != nil {
+				err := response.SmartError(err).Render(w)
 				if err != nil {
 					logger.Error("Failed to write HTTP response", logger.Ctx{"url": r.URL, "err": err})
 				}


### PR DESCRIPTION
Closes #66

Rather than just returning `Daemon not yet initialized` when the database is offline, there are now more nuanced errors:

* `Database is not yet initialized` will be reported if the database is offline (prior to starting dqlite, or when the database is stopped)
* `Database is still starting` will be reported after dqlite has begun starting up, but before it has finished.
* `Database upgrade is in progress: %d cluster members have not yet received the update` will be reported for as long as a system is blocking, waiting for a schema upgrade or API extension to be committed. 

The number returned by the latter error will be fetched from the cluster members table as a count of all systems whose schema versions are smaller than the local schema version. Additionally, `sqlite_master` is checked to see if the current schema supports api extensions. If so, then we ensure that API extensions must also match what the local system expects.