### PR TITLE
Minimal cluster recovery

### DIFF
--- a/cluster/recover.go
+++ b/cluster/recover.go
@@ -1,0 +1,40 @@
+package cluster
+
+import (
+	"fmt"
+
+	"github.com/canonical/go-dqlite"
+	dqliteClient "github.com/canonical/go-dqlite/client"
+)
+
+// DqliteMember is the information that can be derived locally about a cluster
+// member without access to the dqlite database.
+type DqliteMember struct {
+	// dqlite.NodeInfo fields
+	DqliteID uint64 `json:"id" yaml:"id"`
+	Address  string `json:"address" yaml:"address"`
+	Role     string `json:"role" yaml:"role"`
+
+	Name string `json:"name" yaml:"name"`
+}
+
+// NodeInfo is used for interop with go-dqlite.
+func (m DqliteMember) NodeInfo() (*dqlite.NodeInfo, error) {
+	var role dqliteClient.NodeRole
+	switch m.Role {
+	case "voter":
+		role = dqliteClient.Voter
+	case "stand-by":
+		role = dqliteClient.StandBy
+	case "spare":
+		role = dqliteClient.Spare
+	default:
+		return nil, fmt.Errorf("invalid dqlite role %q", m.Role)
+	}
+
+	return &dqlite.NodeInfo{
+		ID:      m.DqliteID,
+		Role:    role,
+		Address: m.Address,
+	}, nil
+}

--- a/example/cmd/microctl/cluster_members.go
+++ b/example/cmd/microctl/cluster_members.go
@@ -1,14 +1,45 @@
 package main
 
 import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
 	"sort"
+	"strings"
 
+	"github.com/canonical/lxd/shared"
 	cli "github.com/canonical/lxd/shared/cmd"
+	"github.com/canonical/lxd/shared/termios"
 	"github.com/spf13/cobra"
+	"golang.org/x/sys/unix"
+	"gopkg.in/yaml.v2"
 
 	"github.com/canonical/microcluster/client"
+	"github.com/canonical/microcluster/cluster"
 	"github.com/canonical/microcluster/microcluster"
 )
+
+const recoveryConfirmation = `You should only run this command if:
+ - A quorum of cluster members is permanently lost
+ - You are *absolutely* sure all microd instances are stopped
+ - This instance has the most up to date database
+
+Do you want to proceed? (yes/no): `
+
+const recoveryYamlComment = `# Member roles can be modified. Unrecoverable nodes should be given the role "spare".
+#
+# "voter" - Voting member of the database. A majority of voters is a quorum.
+# "stand-by" - Non-voting member of the database; can be promoted to voter.
+# "spare" - Not a member of the database.
+#
+# The edit is aborted if:
+# - the number of members changes
+# - the name of any member changes
+# - the ID of any member changes
+# - the address of any member changes
+# - no changes are made
+`
 
 type cmdClusterMembers struct {
 	common *CmdControl
@@ -26,6 +57,9 @@ func (c *cmdClusterMembers) command() *cobra.Command {
 
 	var cmdList = cmdClusterMembersList{common: c.common}
 	cmd.AddCommand(cmdList.command())
+
+	var cmdRestore = cmdClusterEdit{common: c.common}
+	cmd.AddCommand(cmdRestore.command())
 
 	return cmd
 }
@@ -127,6 +161,76 @@ func (c *cmdClusterMemberRemove) run(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+
+	return nil
+}
+
+type cmdClusterEdit struct {
+	common *CmdControl
+}
+
+func (c *cmdClusterEdit) command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "edit",
+		Short: "Recover the cluster from this node if quorum is lost",
+		RunE:  c.run,
+	}
+
+	return cmd
+}
+
+func (c *cmdClusterEdit) run(cmd *cobra.Command, args []string) error {
+	m, err := microcluster.App(microcluster.Args{StateDir: c.common.FlagStateDir, Verbose: c.common.FlagLogVerbose, Debug: c.common.FlagLogDebug})
+	if err != nil {
+		return err
+	}
+
+	members, err := m.GetDqliteClusterMembers()
+	if err != nil {
+		return err
+	}
+
+	membersYaml, err := yaml.Marshal(members)
+	if err != nil {
+		return err
+	}
+
+	var content []byte
+	if !termios.IsTerminal(unix.Stdin) {
+		content, err = io.ReadAll(os.Stdin)
+		if err != nil {
+			return err
+		}
+	} else {
+		reader := bufio.NewReader(os.Stdin)
+		fmt.Print(recoveryConfirmation)
+
+		input, _ := reader.ReadString('\n')
+		input = strings.TrimSuffix(input, "\n")
+
+		if strings.ToLower(input) != "yes" {
+			fmt.Println("Cluster edit aborted; no changes made")
+			return nil
+		}
+
+		content, err = shared.TextEditor("", append([]byte(recoveryYamlComment), membersYaml...))
+		if err != nil {
+			return err
+		}
+	}
+
+	newMembers := []cluster.DqliteMember{}
+	err = yaml.Unmarshal(content, &newMembers)
+	if err != nil {
+		return err
+	}
+
+	err = m.RecoverFromQuorumLoss(newMembers)
+	if err != nil {
+		return fmt.Errorf("cluster edit: %w", err)
+	}
+
+	fmt.Println("Cluster reconfigured successfully")
 
 	return nil
 }

--- a/example/cmd/microctl/cluster_members.go
+++ b/example/cmd/microctl/cluster_members.go
@@ -258,12 +258,14 @@ func (c *cmdClusterEdit) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = m.RecoverFromQuorumLoss(newMembers)
+	tarballPath, err := m.RecoverFromQuorumLoss(newMembers)
 	if err != nil {
 		return fmt.Errorf("cluster edit: %w", err)
 	}
 
-	fmt.Println("Cluster reconfigured successfully")
+	fmt.Printf("Cluster changes applied; new database state saved to %s\n\n", tarballPath)
+	fmt.Printf("*Before* starting any cluster member, copy %s to %s on all remaining cluster members.\n\n", tarballPath, tarballPath)
+	fmt.Printf("microd will load this file during startup.\n")
 
 	return nil
 }

--- a/example/test/main.sh
+++ b/example/test/main.sh
@@ -18,7 +18,7 @@ if [ -d "${test_dir}" ]; then
   rm -r "${test_dir}"
 fi
 
-members=("c1" "c2" "c3")
+members=("c1" "c2" "c3" "c4" "c5")
 
 for member in "${members[@]}"; do
   state_dir="${test_dir}/${member}"
@@ -30,20 +30,23 @@ done
 # Ensure two daemons cannot start in the same state dir
 ! microd --state-dir "${test_dir}/c1" "${cluster_flags[@]}"
 
-# Ensure only valid member names are used
+# Ensure only valid member names are used for bootstrap
 ! microctl --state-dir "${test_dir}/c1" init "c/1" 127.0.0.1:9001 --bootstrap
 
 microctl --state-dir "${test_dir}/c1" init "c1" 127.0.0.1:9001 --bootstrap
 
-# Ensure only valid member names are used
+# Ensure only valid member names are used for join
 token_node2=$(microctl --state-dir "${test_dir}/c1" tokens add "c/2")
-! microctl --state-dir "${test_dir}/c1" init "c/2" 127.0.0.1:9003 --token "${token_node2}"
+! microctl --state-dir "${test_dir}/c1" init "c/2" 127.0.0.1:9002 --token "${token_node2}"
 
-token_node2=$(microctl --state-dir "${test_dir}/c1" tokens add "c2")
-token_node3=$(microctl --state-dir "${test_dir}/c1" tokens add "c3")
+indx=2
+for member in "${members[@]:1}"; do
+  token=$(microctl --state-dir "${test_dir}/c1" tokens add "${member}")
 
-microctl --state-dir "${test_dir}/c2" init "c2" 127.0.0.1:9002 --token "${token_node2}"
-microctl --state-dir "${test_dir}/c3" init "c3" 127.0.0.1:9003 --token "${token_node3}"
+  microctl --state-dir "${test_dir}/${member}" init "${member}" "127.0.0.1:900${indx}" --token "${token}"
+
+  indx=$((indx + 1))
+done
 
 # Clean up
 if [ -n "${CLUSTER_INSPECT:-}" ]; then
@@ -51,6 +54,11 @@ if [ -n "${CLUSTER_INSPECT:-}" ]; then
   read -r
 fi
 
-kill %1
-kill %2
-kill %3
+for member in "${members[@]}"; do
+  microctl --state-dir "${test_dir}/${member}" shutdown
+done
+
+kill 0
+
+sleep 1
+

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -27,6 +27,7 @@ import (
 	"github.com/canonical/microcluster/internal/db"
 	"github.com/canonical/microcluster/internal/endpoints"
 	"github.com/canonical/microcluster/internal/extensions"
+	"github.com/canonical/microcluster/internal/recover"
 	internalREST "github.com/canonical/microcluster/internal/rest"
 	internalClient "github.com/canonical/microcluster/internal/rest/client"
 	"github.com/canonical/microcluster/internal/rest/resources"
@@ -125,6 +126,11 @@ func (d *Daemon) Run(ctx context.Context, listenPort string, stateDir string, so
 
 	if isAlreadyRunning {
 		return fmt.Errorf("Control socket already present (%q); is another daemon already running?", d.os.ControlSocketPath())
+	}
+
+	err = recover.MaybeUnpackRecoveryTarball(d.os)
+	if err != nil {
+		return fmt.Errorf("Database recovery failed: %w", err)
 	}
 
 	d.extensionServers = extensionServers

--- a/internal/recover/recover.go
+++ b/internal/recover/recover.go
@@ -1,0 +1,332 @@
+package recover
+
+import (
+	"archive/tar"
+	"compress/gzip"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+	"path"
+	"strings"
+
+	dqlite "github.com/canonical/go-dqlite/client"
+	"github.com/canonical/lxd/shared/logger"
+	"gopkg.in/yaml.v2"
+
+	"github.com/canonical/microcluster/cluster"
+	"github.com/canonical/microcluster/internal/sys"
+	"github.com/canonical/microcluster/internal/trust"
+)
+
+// GetDqliteClusterMembers parses the trust store and
+// path.Join(filesystem.DatabaseDir, "cluster.yaml").
+func GetDqliteClusterMembers(filesystem *sys.OS) ([]cluster.DqliteMember, error) {
+	storePath := path.Join(filesystem.DatabaseDir, "cluster.yaml")
+	nodeInfo, err := dumpYamlNodeStore(storePath)
+	if err != nil {
+		return nil, err
+	}
+
+	remotes, err := ReadTrustStore(filesystem.TrustDir)
+	if err != nil {
+		return nil, err
+	}
+
+	remotesByName := remotes.RemotesByName()
+
+	var members []cluster.DqliteMember
+	for _, remote := range remotesByName {
+		for _, info := range nodeInfo {
+			if remote.Address.String() == info.Address {
+				members = append(members, cluster.DqliteMember{
+					DqliteID: info.ID,
+					Address:  info.Address,
+					Role:     info.Role.String(),
+					Name:     remote.Name,
+				})
+			}
+		}
+	}
+
+	return members, nil
+}
+
+func dumpYamlNodeStore(path string) ([]dqlite.NodeInfo, error) {
+	store, err := dqlite.NewYamlNodeStore(path)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read %q: %w", path, err)
+	}
+
+	nodeInfo, err := store.Get(context.Background())
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read from node store: %w", err)
+	}
+
+	return nodeInfo, nil
+}
+
+// ReadTrustStore parses the trust store. This is not thread safe!
+func ReadTrustStore(dir string) (*trust.Remotes, error) {
+	remotes := &trust.Remotes{}
+	err := remotes.Load(dir)
+
+	return remotes, err
+}
+
+// ValidateMemberChanges compares two arrays of members to ensure:
+// - Their lengths are the same.
+// - Members with the same name also use the same ID and address.
+func ValidateMemberChanges(oldMembers []cluster.DqliteMember, newMembers []cluster.DqliteMember) error {
+	if len(newMembers) != len(oldMembers) {
+		return fmt.Errorf("members cannot be added or removed")
+	}
+
+	for _, newMember := range newMembers {
+		memberValid := false
+		for _, oldMember := range oldMembers {
+			// FIXME: Allow changing member addresses as part of cluster recovery
+			membersMatch := newMember.DqliteID == oldMember.DqliteID &&
+				newMember.Name == oldMember.Name &&
+				newMember.Address == oldMember.Address
+
+			if membersMatch {
+				memberValid = true
+				break
+			}
+		}
+
+		if !memberValid {
+			return fmt.Errorf("ID or address changed for member %s", newMember.Name)
+		}
+	}
+
+	return nil
+}
+
+// CreateRecoveryTarball writes a tarball of filesystem.DatabaseDir to
+// filesystem.StateDir.
+// go-dqlite's info.yaml is excluded from the tarball.
+func CreateRecoveryTarball(filesystem *sys.OS) error {
+	dbFS := os.DirFS(filesystem.DatabaseDir)
+	dbFiles, err := fs.Glob(dbFS, "*")
+	if err != nil {
+		return fmt.Errorf("%w", err)
+	}
+
+	tarballPath := path.Join(filesystem.StateDir, "recovery_db.tar.gz")
+
+	// info.yaml is used by go-dqlite to keep track of the current cluster member's
+	// ID and address. We shouldn't replicate the recovery member's info.yaml
+	// to all other members, so exclude it from the tarball:
+	for indx, filename := range dbFiles {
+		if filename == "info.yaml" {
+			newlen := len(dbFiles) - 1
+			dbFiles[indx] = dbFiles[newlen]
+			dbFiles = dbFiles[:newlen]
+			break
+		}
+	}
+
+	return createTarball(tarballPath, filesystem.DatabaseDir, dbFiles)
+}
+
+// MaybeUnpackRecoveryTarball checks for the presence of a recovery tarball in
+// fiesystem.StateDir. If it exists, unpack it into a temporary directory,
+// ensure that it is a valid microcluster recovery tarball, and replace the
+// existing filesystem.DatabaseDir.
+func MaybeUnpackRecoveryTarball(filesystem *sys.OS) error {
+	tarballPath := path.Join(filesystem.StateDir, "recovery_db.tar.gz")
+	unpackDir := path.Join(filesystem.StateDir, "recovery_db")
+
+	// Determine if the recovery tarball exists
+	if _, err := os.Stat(tarballPath); errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+
+	logger.Warn("Recovery tarball located; attempting DB recovery", logger.Ctx{"tarball": tarballPath})
+
+	err := unpackTarball(tarballPath, unpackDir)
+	if err != nil {
+		return err
+	}
+
+	// sanity check: valid cluster.yaml in the incoming DB dir
+	clusterYamlPath := path.Join(unpackDir, "cluster.yaml")
+	incomingNodeInfo, err := dumpYamlNodeStore(clusterYamlPath)
+	if err != nil {
+		return err
+	}
+
+	// use the local info.yaml so that the dqlite ID is preserved on each
+	// cluster member
+	localInfoYamlPath := path.Join(filesystem.DatabaseDir, "info.yaml")
+	recoveryInfoYamlPath := path.Join(unpackDir, "info.yaml")
+
+	localInfoYaml, err := os.ReadFile(localInfoYamlPath)
+	if err != nil {
+		return err
+	}
+
+	var localInfo dqlite.NodeInfo
+	err = yaml.Unmarshal(localInfoYaml, &localInfo)
+	if err != nil {
+		return fmt.Errorf("invalid %q", localInfoYamlPath)
+	}
+
+	found := false
+	for _, incomingInfo := range incomingNodeInfo {
+		found = localInfo.ID == incomingInfo.ID
+
+		if found {
+			break
+		}
+	}
+
+	if !found {
+		return fmt.Errorf("missing local cluster member in incoming cluster.yaml")
+	}
+
+	err = os.WriteFile(recoveryInfoYamlPath, localInfoYaml, 0o664)
+	if err != nil {
+		return err
+	}
+
+	// FIXME: Take a DB backup
+
+	// Now that we're as sure as we can be that the recovery DB is valid, we can
+	// replace the existing DB
+	err = os.RemoveAll(filesystem.DatabaseDir)
+	if err != nil {
+		return err
+	}
+
+	err = os.Rename(unpackDir, filesystem.DatabaseDir)
+	if err != nil {
+		return err
+	}
+
+	// Prevent the database being restored again after subsequent restarts
+	err = os.Remove(tarballPath)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// create tarball at tarballPath with files path.Join(dir, file)
+// Note: does not handle subdirectories.
+func createTarball(tarballPath string, dir string, files []string) error {
+	tarball, err := os.Create(tarballPath)
+	if err != nil {
+		return err
+	}
+
+	gzWriter := gzip.NewWriter(tarball)
+	tarWriter := tar.NewWriter(gzWriter)
+
+	for _, filename := range files {
+		filepath := path.Join(dir, filename)
+
+		file, err := os.Open(filepath)
+		if err != nil {
+			return err
+		}
+
+		stat, err := file.Stat()
+		if err != nil {
+			return err
+		}
+
+		// Note: header.Name is set to the basename of stat. If dqlite starts
+		// using subdirs in the DB dir, this will need modification
+		header, err := tar.FileInfoHeader(stat, filename)
+		if err != nil {
+			return fmt.Errorf("create tar header for %q: %w", filepath, err)
+		}
+
+		err = tarWriter.WriteHeader(header)
+		if err != nil {
+			return err
+		}
+
+		_, err = io.Copy(tarWriter, file)
+		if err != nil {
+			return err
+		}
+
+		err = file.Close()
+		if err != nil {
+			return err
+		}
+	}
+
+	err = tarWriter.Close()
+	if err != nil {
+		return err
+	}
+
+	err = gzWriter.Close()
+	if err != nil {
+		return err
+	}
+
+	err = tarball.Close()
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Note: Does not handle subdirectories.
+func unpackTarball(tarballPath string, destRoot string) error {
+	tarball, err := os.Open(tarballPath)
+	if err != nil {
+		return err
+	}
+
+	gzReader, err := gzip.NewReader(tarball)
+	if err != nil {
+		return err
+	}
+
+	tarReader := tar.NewReader(gzReader)
+
+	err = os.MkdirAll(destRoot, 0o755)
+	if err != nil {
+		return err
+	}
+
+	for {
+		header, err := tarReader.Next()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		// CWE-22
+		if strings.Contains(header.Name, "..") {
+			return fmt.Errorf("Invalid sequence `..` in recovery tarball entry %q", header.Name)
+		}
+
+		filepath := path.Join(destRoot, header.Name)
+		file, err := os.Create(filepath)
+		if err != nil {
+			return err
+		}
+
+		countWritten, err := io.Copy(file, tarReader)
+		if countWritten != header.Size {
+			return fmt.Errorf("mismatched written (%d) and size (%d) for entry %q in %q", countWritten, header.Size, header.Name, tarballPath)
+		} else if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}

--- a/internal/recover/recover.go
+++ b/internal/recover/recover.go
@@ -109,11 +109,12 @@ func ValidateMemberChanges(oldMembers []cluster.DqliteMember, newMembers []clust
 // CreateRecoveryTarball writes a tarball of filesystem.DatabaseDir to
 // filesystem.StateDir.
 // go-dqlite's info.yaml is excluded from the tarball.
-func CreateRecoveryTarball(filesystem *sys.OS) error {
+// This function returns the path to the tarball.
+func CreateRecoveryTarball(filesystem *sys.OS) (string, error) {
 	dbFS := os.DirFS(filesystem.DatabaseDir)
 	dbFiles, err := fs.Glob(dbFS, "*")
 	if err != nil {
-		return fmt.Errorf("%w", err)
+		return "", fmt.Errorf("%w", err)
 	}
 
 	tarballPath := path.Join(filesystem.StateDir, "recovery_db.tar.gz")
@@ -130,7 +131,7 @@ func CreateRecoveryTarball(filesystem *sys.OS) error {
 		}
 	}
 
-	return createTarball(tarballPath, filesystem.DatabaseDir, dbFiles)
+	return tarballPath, createTarball(tarballPath, filesystem.DatabaseDir, dbFiles)
 }
 
 // MaybeUnpackRecoveryTarball checks for the presence of a recovery tarball in

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -233,16 +233,18 @@ func (m *MicroCluster) GetDqliteClusterMembers() ([]cluster.DqliteMember, error)
 //
 // On start, Microcluster will automatically check for & load the recovery
 // tarball. A database backup will be taken before the load.
-func (m *MicroCluster) RecoverFromQuorumLoss(members []cluster.DqliteMember) error {
+//
+// RecoverFromQuorumLoss returns the path to the recovery tarball.
+func (m *MicroCluster) RecoverFromQuorumLoss(members []cluster.DqliteMember) (string, error) {
 	// Double check to make sure the cluster configuration has actually changed
 	oldMembers, err := m.GetDqliteClusterMembers()
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	err = recover.ValidateMemberChanges(oldMembers, members)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// Set up our new cluster configuration
@@ -250,7 +252,7 @@ func (m *MicroCluster) RecoverFromQuorumLoss(members []cluster.DqliteMember) err
 	for _, member := range members {
 		info, err := member.NodeInfo()
 		if err != nil {
-			return err
+			return "", err
 		}
 		nodeInfo = append(nodeInfo, *info)
 	}
@@ -258,11 +260,11 @@ func (m *MicroCluster) RecoverFromQuorumLoss(members []cluster.DqliteMember) err
 	// Ensure that the daemon is not running
 	isSocketPresent, err := m.FileSystem.IsControlSocketPresent()
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	if isSocketPresent {
-		return fmt.Errorf("daemon is running (socket path exists: %q)", m.FileSystem.ControlSocketPath())
+		return "", fmt.Errorf("daemon is running (socket path exists: %q)", m.FileSystem.ControlSocketPath())
 	}
 
 	// Check each cluster member's /1.0 to ensure that they are unreachable.
@@ -270,27 +272,27 @@ func (m *MicroCluster) RecoverFromQuorumLoss(members []cluster.DqliteMember) err
 	// that's still partially up.
 	remotes, err := recover.ReadTrustStore(m.FileSystem.TrustDir)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	serverCert, err := m.FileSystem.ServerCert()
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	clusterCert, err := m.FileSystem.ClusterCert()
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	clusterKey, err := clusterCert.PublicKeyX509()
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	cluster, err := remotes.Cluster(false, serverCert, clusterKey)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	cancelCtx, cancel := context.WithTimeout(context.Background(), time.Second*10)
@@ -304,23 +306,23 @@ func (m *MicroCluster) RecoverFromQuorumLoss(members []cluster.DqliteMember) err
 	})
 	cancel()
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	// FIXME: Take a DB backup
 
 	err = dqlite.ReconfigureMembershipExt(m.FileSystem.DatabaseDir, nodeInfo)
 	if err != nil {
-		return fmt.Errorf("dqlite recovery: %w", err)
+		return "", fmt.Errorf("dqlite recovery: %w", err)
 	}
 
 	// Tar up the m.FileSystem.DatabaseDir and write to `dbExportPath`
-	err = recover.CreateRecoveryTarball(m.FileSystem)
+	recoveryTarballPath, err := recover.CreateRecoveryTarball(m.FileSystem)
 	if err != nil {
-		return err
+		return "", err
 	}
 
-	return nil
+	return recoveryTarballPath, nil
 }
 
 // NewJoinToken creates and records a new join token containing all the necessary credentials for joining a cluster.

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -309,7 +309,10 @@ func (m *MicroCluster) RecoverFromQuorumLoss(members []cluster.DqliteMember) (st
 		return "", err
 	}
 
-	// FIXME: Take a DB backup
+	err = recover.CreateDatabaseBackup(m.FileSystem)
+	if err != nil {
+		return "", err
+	}
 
 	err = dqlite.ReconfigureMembershipExt(m.FileSystem.DatabaseDir, nodeInfo)
 	if err != nil {

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/canonical/go-dqlite"
 	"github.com/canonical/lxd/lxd/db/schema"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
@@ -21,6 +22,7 @@ import (
 	"github.com/canonical/microcluster/cluster"
 	"github.com/canonical/microcluster/config"
 	"github.com/canonical/microcluster/internal/daemon"
+	"github.com/canonical/microcluster/internal/recover"
 	internalClient "github.com/canonical/microcluster/internal/rest/client"
 	internalTypes "github.com/canonical/microcluster/internal/rest/types"
 	"github.com/canonical/microcluster/internal/sys"
@@ -203,6 +205,87 @@ func (m *MicroCluster) JoinCluster(ctx context.Context, name string, address str
 	}
 
 	return c.ControlDaemon(ctx, internalTypes.Control{JoinToken: token, Address: addr, Name: name, InitConfig: initConfig})
+}
+
+// GetDqliteClusterMembers retrieves the current local cluster configuration
+// (derived from the trust store & dqlite metadata); it does not query the
+// database.
+// This is primarily intended for modifying the cluster configuration via
+// MicroCluster.RecoverFromQuorumLoss.
+func (m *MicroCluster) GetDqliteClusterMembers() ([]cluster.DqliteMember, error) {
+	return recover.GetDqliteClusterMembers(m.FileSystem)
+}
+
+// RecoverFromQuorumLoss can be used to recover database access when a quorum of
+// members is lost and cannot be recovered (e.g. hardware failure).
+// This function requires that:
+//   - All cluster members' databases are not running
+//   - The current member has the most up-to-date raft log (usually the member
+//     which was most recently the leader)
+//
+// RecoverFromQuorumLoss will take a database backup before attempting the
+// recovery operation.
+//
+// RecoverFromQuorumLoss should be invoked _exactly once_ for the entire cluster.
+// This function creates a gz-compressed tarball
+// path.Join(m.FileSystem.StateDir, "recovery_db.tar.gz"). This tarball should
+// be manually copied by the user to the state dir of all other cluster members.
+//
+// On start, Microcluster will automatically check for & load the recovery
+// tarball. A database backup will be taken before the load.
+func (m *MicroCluster) RecoverFromQuorumLoss(members []cluster.DqliteMember) error {
+	// Double check to make sure the cluster configuration has actually changed
+	oldMembers, err := m.GetDqliteClusterMembers()
+	if err != nil {
+		return err
+	}
+
+	err = recover.ValidateMemberChanges(oldMembers, members)
+	if err != nil {
+		return err
+	}
+
+	// Set up our new cluster configuration
+	nodeInfo := make([]dqlite.NodeInfo, 0, len(members))
+	for _, member := range members {
+		info, err := member.NodeInfo()
+		if err != nil {
+			return err
+		}
+		nodeInfo = append(nodeInfo, *info)
+	}
+
+	// Ensure that the daemon is not running
+	isSocketPresent, err := m.FileSystem.IsControlSocketPresent()
+	if err != nil {
+		return err
+	}
+
+	if isSocketPresent {
+		return fmt.Errorf("daemon is running (socket path exists: %q)", m.FileSystem.ControlSocketPath())
+	}
+
+	// Check each cluster member's /1.0 to ensure that they are unreachable.
+	// This is a sanity check to ensure that we're not reconfiguring a cluster
+	// that's still partially up.
+	// It may also be possible to check the raft term of each surviving member
+	// and redirect the user to call RecoverFromQuorumLoss on that member instead.
+	// TODO
+
+	// FIXME: Take a DB backup
+
+	err = dqlite.ReconfigureMembershipExt(m.FileSystem.DatabaseDir, nodeInfo)
+	if err != nil {
+		return fmt.Errorf("dqlite recovery: %w", err)
+	}
+
+	// Tar up the m.FileSystem.DatabaseDir and write to `dbExportPath`
+	err = recover.CreateRecoveryTarball(m.FileSystem)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // NewJoinToken creates and records a new join token containing all the necessary credentials for joining a cluster.


### PR DESCRIPTION
A few things:
- Updated [the spec](https://discourse.ubuntu.com/t/microcluster-microcloud-quorum-recovery/45560) to reflect what I've implemented here
- This works with microd; ~~tests in the works~~ see below.
- I've not implemented address changes as it requires an update to the database once it's up; @masnax mentioned that patches in LXD were relevant. I'll throw the code I do have pursuant to address changes in a branch soon.
- ~~Also still working on the `TODO` to reach out to the rest of the cluster~~
- Setting all the node roles except one voter to `stand-by` causes dqlite to fail; I'd like to find out why but it's not a high priority as the other configurations I've tried (including stand-by members) work. +1 on a fix for #66 .

~~This PR depends on #146~~ Merged

LXD-1118