### PR TITLE
Fix eager schema update (temporary table version)

### DIFF
--- a/cluster/cluster_members.go
+++ b/cluster/cluster_members.go
@@ -157,6 +157,22 @@ CREATE TABLE internal_cluster_members_new (
 );
 
 INSERT INTO internal_cluster_members_new SELECT id,name,address,certificate,1,(schema-1),heartbeat,role FROM internal_cluster_members;
+
+CREATE TRIGGER internal_cluster_member_added
+	AFTER INSERT ON internal_cluster_members
+FOR EACH ROW
+BEGIN
+	INSERT INTO internal_cluster_members_new (id,name,address,certificate,schema_internal,schema_external,heartbeat,role)
+	VALUES (NEW.id,NEW.name,NEW.address,NEW.certificate,1,(NEW.schema-1),heartbeat,role);
+END;
+
+	CREATE TRIGGER internal_cluster_member_removed
+	AFTER DELETE ON internal_cluster_members
+FOR EACH ROW
+BEGIN
+	DELETE FROM internal_cluster_members_new
+	WHERE id = OLD.id;
+END;
 `
 
 	_, err = tx.Exec(stmt)

--- a/cluster/cluster_members.go
+++ b/cluster/cluster_members.go
@@ -86,10 +86,96 @@ func (c InternalClusterMember) ToAPI() (*internalTypes.ClusterMember, error) {
 	}, nil
 }
 
+// getClusterSchemaTable returns the name of the table that holds an accurate picture of the current schema version.
+// Prior to updateFromV1, the schema version was not properly stored in the cluster members table, and so we need to store it somewhere else.
+func getClusterSchemaTable(tx *sql.Tx) (tableName string, err error) {
+	stmt := "SELECT name FROM sqlite_master WHERE name = 'internal_cluster_members_new'"
+	err = tx.QueryRow(stmt).Scan(&tableName)
+	if err != nil && err != sql.ErrNoRows {
+		return "", err
+	}
+
+	if tableName != "" {
+		return tableName, nil
+	}
+
+	// TODO: Dynamically rename to "core_"
+	return "internal_cluster_members", nil
+}
+
+// createClusterSchemaTable creates a temporary table to store an accurate representation of the internal and external schema version.
+// This table will get dropped by `updateFromV1`, and should only be created prior to that update, if no other cluster member has done it yet.
+func createClusterSchemaTable(tx *sql.Tx) (tableName string, err error) {
+	// Check if we need a temporary table, if no `type` field exists in the schemas table.
+	stmt := `
+SELECT count(name)
+FROM pragma_table_info('schemas')
+WHERE name IN ('type');
+`
+
+	var count int
+	err = tx.QueryRow(stmt).Scan(&count)
+	if err != nil {
+		return "", err
+	}
+
+	// If we have a `type` field, then the default database is valid, so we can just use that.
+	// TODO: Dynamically rename to "core_"
+	if count == 1 {
+		return "internal_cluster_members", nil
+	}
+
+	// Check if another cluster member has already created the temporary table.
+	stmt = `
+SELECT name
+FROM sqlite_master
+WHERE name = 'internal_cluster_members_new';
+`
+
+	err = tx.QueryRow(stmt).Scan(&tableName)
+	if err != nil && err != sql.ErrNoRows {
+		return "", err
+	}
+
+	if tableName != "" {
+		return tableName, nil
+	}
+
+	// If no cluster member has created the temporary table, create it and return its name.
+	stmt = `
+CREATE TABLE internal_cluster_members_new (
+  id                   INTEGER   PRIMARY  KEY    AUTOINCREMENT  NOT  NULL,
+  name                 TEXT      NOT      NULL,
+  address              TEXT      NOT      NULL,
+  certificate          TEXT      NOT      NULL,
+  schema_internal      INTEGER   NOT      NULL,
+  schema_external      INTEGER   NOT      NULL,
+  heartbeat            DATETIME  NOT      NULL,
+  role                 TEXT      NOT      NULL,
+  UNIQUE(name),
+  UNIQUE(certificate)
+);
+
+INSERT INTO internal_cluster_members_new SELECT id,name,address,certificate,1,(schema-1),heartbeat,role FROM internal_cluster_members;
+`
+
+	_, err = tx.Exec(stmt)
+	if err != nil {
+		return "", err
+	}
+
+	return "internal_cluster_members_new", nil
+}
+
 // UpdateClusterMemberSchemaVersion sets the schema version for the cluster member with the given address.
 // This helper is non-generated to work before generated statements are loaded, as we update the schema.
 func UpdateClusterMemberSchemaVersion(tx *sql.Tx, internalVersion uint64, externalVersion uint64, address string) error {
-	stmt := "UPDATE internal_cluster_members SET schema_internal=?,schema_external=? WHERE address=?"
+	tableName, err := createClusterSchemaTable(tx)
+	if err != nil {
+		return err
+	}
+
+	stmt := fmt.Sprintf("UPDATE %s SET schema_internal=?,schema_external=? WHERE address=?", tableName)
 	result, err := tx.Exec(stmt, internalVersion, externalVersion, address)
 	if err != nil {
 		return err
@@ -109,7 +195,12 @@ func UpdateClusterMemberSchemaVersion(tx *sql.Tx, internalVersion uint64, extern
 // GetClusterMemberSchemaVersions returns the schema versions from all cluster members that are not pending.
 // This helper is non-generated to work before generated statements are loaded, as we update the schema.
 func GetClusterMemberSchemaVersions(ctx context.Context, tx *sql.Tx) (internalSchema []uint64, externalSchema []uint64, err error) {
-	sql := "SELECT schema_internal,schema_external FROM internal_cluster_members WHERE NOT role='pending'"
+	tableName, err := getClusterSchemaTable(tx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sql := fmt.Sprintf("SELECT schema_internal,schema_external FROM %s WHERE NOT role='pending'", tableName)
 
 	internalSchema = []uint64{}
 	externalSchema = []uint64{}

--- a/internal/db/update/update.go
+++ b/internal/db/update/update.go
@@ -146,7 +146,7 @@ INSERT INTO schemas_new SELECT id,(version-1),1,updated_at FROM schemas WHERE ve
 DROP TABLE schemas;
 ALTER TABLE schemas_new RENAME TO schemas;
 
-CREATE TABLE internal_cluster_members_new (
+CREATE TABLE IF NOT EXISTS internal_cluster_members_new (
   id                   INTEGER   PRIMARY  KEY    AUTOINCREMENT  NOT  NULL,
   name                 TEXT      NOT      NULL,
   address              TEXT      NOT      NULL,
@@ -158,12 +158,29 @@ CREATE TABLE internal_cluster_members_new (
   UNIQUE(name),
   UNIQUE(certificate)
 );
+`
+		_, err = tx.ExecContext(ctx, stmt)
+		if err != nil {
+			return err
+		}
 
-INSERT INTO internal_cluster_members_new SELECT id,name,address,certificate,1,(schema-1),heartbeat,role FROM internal_cluster_members;
+		// Check if we have pre-emptively created this table when checking for schema updates. If so, we won't need to insert any rows.
+		stmt = `SELECT count(id) from internal_cluster_members_new`
+		err := tx.QueryRow(stmt).Scan(&count)
+		if err != nil {
+			return err
+		}
+
+		stmt = ""
+		if count == 0 {
+			stmt = "INSERT INTO internal_cluster_members_new SELECT id,name,address,certificate,1,(schema-1),heartbeat,role FROM internal_cluster_members;"
+		}
+
+		stmt = fmt.Sprintf(`%s
 DROP TABLE internal_cluster_members;
 ALTER TABLE internal_cluster_members_new RENAME TO internal_cluster_members;
-`
-		_, err := tx.ExecContext(ctx, stmt)
+`, stmt)
+		_, err = tx.ExecContext(ctx, stmt)
 		return err
 	}
 

--- a/internal/db/update/update.go
+++ b/internal/db/update/update.go
@@ -179,6 +179,8 @@ CREATE TABLE IF NOT EXISTS internal_cluster_members_new (
 		stmt = fmt.Sprintf(`%s
 DROP TABLE internal_cluster_members;
 ALTER TABLE internal_cluster_members_new RENAME TO internal_cluster_members;
+DROP TRIGGER IF EXISTS internal_cluster_member_added;
+DROP TRIGGER IF EXISTS internal_cluster_member_removed;
 `, stmt)
 		_, err = tx.ExecContext(ctx, stmt)
 		return err


### PR DESCRIPTION
This PR is an alternate (but much messier) fix for the issue in #150 by maintaining a separate table. This method also covers the edge case mentioned at the bottom of that PR.

We create the temporary table `internal_cluster_members_new` so that old cluster members can continue to use the old table, and new schema updates will only apply to the new table.

Once a cluster member is refreshed to expect the update from `updateFromV1`, it attempts to create this temporary table. All refreshed cluster members will update their expected version in only this table. Once the final cluster member has applied the update, the old `internal_cluster_members` table is replaced with the new table.

This means existing cluster members can continue to function, and updated cluster members can use a different table in the meantime to check schema versions.

One caveat here is that this new table can get out of date, since it's only maintained for schema updates. We can get around this by having some sqlite `TRIGGER`s which fire on `INSERT/DELETE` executions, and update the temporary table, if for example a user removes or adds a cluster member in the middle of an update. 