### PR TITLE
Move EndpointType to `types` package.

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -8,6 +8,7 @@ import (
 	"github.com/canonical/lxd/shared/api"
 
 	"github.com/canonical/microcluster/internal/rest/client"
+	"github.com/canonical/microcluster/rest/types"
 )
 
 // Client is a rest client for the MicroCluster daemon.
@@ -20,13 +21,13 @@ func IsNotification(r *http.Request) bool {
 	return r.Header.Get("User-Agent") == clusterRequest.UserAgentNotifier
 }
 
-// Query is a helper for initiating a request on the /1.0 endpoint. This function should be used for all client
+// Query is a helper for initiating a request to the microcluster API. This function should be used for all client
 // methods defined externally from MicroCluster.
-func (c *Client) Query(ctx context.Context, method string, path *api.URL, in any, out any) error {
+func (c *Client) Query(ctx context.Context, method string, prefix types.EndpointPrefix, path *api.URL, in any, out any) error {
 	queryCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, method, client.ExtendedEndpoint, path, in, &out)
+	return c.QueryStruct(queryCtx, method, prefix, path, in, &out)
 }
 
 // UseTarget returns a new client with the query "?target=name" set.

--- a/example/client/client.go
+++ b/example/client/client.go
@@ -20,7 +20,7 @@ func ExtendedPostCmd(ctx context.Context, c *client.Client, data *types.Extended
 	defer cancel()
 
 	var outStr string
-	err := c.Query(queryCtx, "POST", api.NewURL().Path("extended"), data, &outStr)
+	err := c.Query(queryCtx, "POST", "1.0", api.NewURL().Path("extended"), data, &outStr)
 	if err != nil {
 		clientURL := c.URL()
 		return "", fmt.Errorf("Failed performing action on %q: %w", clientURL.String(), err)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -599,7 +599,7 @@ func (d *Daemon) addExtensionServers() error {
 
 func (d *Daemon) sendUpgradeNotification(ctx context.Context, c *client.Client) error {
 	path := c.URL()
-	parts := strings.Split(string(internalClient.InternalEndpoint), "/")
+	parts := strings.Split(string(internalTypes.InternalEndpoint), "/")
 	parts = append(parts, "database")
 	path = *path.Path(parts...)
 	upgradeRequest, err := http.NewRequest("PATCH", path.String(), nil)

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -272,7 +272,7 @@ func dqliteNetworkDial(ctx context.Context, addr string, db *DB) (net.Conn, erro
 		Host:       addr,
 	}
 
-	path := fmt.Sprintf("https://%s/%s/%s", addr, client.InternalEndpoint, "database")
+	path := fmt.Sprintf("https://%s/%s/%s", addr, internalTypes.InternalEndpoint, "database")
 	request.URL, err = url.Parse(path)
 	if err != nil {
 		return nil, err

--- a/internal/rest/client/client.go
+++ b/internal/rest/client/client.go
@@ -22,6 +22,7 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/tcp"
+
 	"github.com/canonical/microcluster/rest/types"
 )
 
@@ -271,7 +272,7 @@ func (c *Client) MakeRequest(r *http.Request) (*api.Response, error) {
 // The response gets unpacked into the target struct. POST requests can optionally provide raw data to be sent through.
 //
 // The final URL is that provided as the endpoint combined with the applicable prefix for the endpointType and the scheme and host from the client.
-func (c *Client) QueryStruct(ctx context.Context, method string, endpointType EndpointType, endpoint *api.URL, data any, target any) error {
+func (c *Client) QueryStruct(ctx context.Context, method string, endpointType types.EndpointPrefix, endpoint *api.URL, data any, target any) error {
 	// Merge the provided URL with the one we have for the client.
 	localURL := api.NewURL()
 	if endpoint != nil {

--- a/internal/rest/client/client.go
+++ b/internal/rest/client/client.go
@@ -22,23 +22,7 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/tcp"
-)
-
-// EndpointType is a type specifying the endpoint on with the resource exists.
-type EndpointType string
-
-const (
-	// ExtendedEndpoint - All endpoints added managed by external usage of MicroCluster.
-	ExtendedEndpoint EndpointType = "1.0"
-
-	// PublicEndpoint - Internally managed APIs available without authentication.
-	PublicEndpoint EndpointType = "cluster/1.0"
-
-	// InternalEndpoint - all endpoints restricted to trusted servers.
-	InternalEndpoint EndpointType = "cluster/internal"
-
-	// ControlEndpoint - all endpoints available on the local unix socket.
-	ControlEndpoint EndpointType = "cluster/control"
+	"github.com/canonical/microcluster/rest/types"
 )
 
 // Client is a rest client for the daemon.

--- a/internal/rest/client/cluster.go
+++ b/internal/rest/client/cluster.go
@@ -16,7 +16,7 @@ func (c *Client) AddClusterMember(ctx context.Context, args types.ClusterMember)
 	defer cancel()
 
 	tokenResponse := types.TokenResponse{}
-	err := c.QueryStruct(queryCtx, "POST", PublicEndpoint, api.NewURL().Path("cluster"), args, &tokenResponse)
+	err := c.QueryStruct(queryCtx, "POST", types.PublicEndpoint, api.NewURL().Path("cluster"), args, &tokenResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +30,7 @@ func (c *Client) GetClusterMembers(ctx context.Context) ([]types.ClusterMember, 
 	defer cancel()
 
 	clusterMembers := []types.ClusterMember{}
-	err := c.QueryStruct(queryCtx, "GET", PublicEndpoint, api.NewURL().Path("cluster"), nil, &clusterMembers)
+	err := c.QueryStruct(queryCtx, "GET", types.PublicEndpoint, api.NewURL().Path("cluster"), nil, &clusterMembers)
 
 	return clusterMembers, err
 }
@@ -45,7 +45,7 @@ func (c *Client) DeleteClusterMember(ctx context.Context, name string, force boo
 		endpoint = endpoint.WithQuery("force", "1")
 	}
 
-	return c.QueryStruct(queryCtx, "DELETE", PublicEndpoint, endpoint, nil, nil)
+	return c.QueryStruct(queryCtx, "DELETE", types.PublicEndpoint, endpoint, nil, nil)
 }
 
 // ResetClusterMember clears the state directory of the cluster member, and re-execs its daemon.
@@ -58,7 +58,7 @@ func (c *Client) ResetClusterMember(ctx context.Context, name string, force bool
 		endpoint = endpoint.WithQuery("force", "1")
 	}
 
-	return c.QueryStruct(queryCtx, "PUT", PublicEndpoint, endpoint, nil, nil)
+	return c.QueryStruct(queryCtx, "PUT", types.PublicEndpoint, endpoint, nil, nil)
 }
 
 // UpdateClusterCertificate sets a new cluster keypair and CA.
@@ -67,5 +67,5 @@ func (c *Client) UpdateClusterCertificate(ctx context.Context, args apiTypes.Clu
 	defer cancel()
 
 	endpoint := api.NewURL().Path("cluster", "certificates")
-	return c.QueryStruct(queryCtx, "PUT", InternalEndpoint, endpoint, args, nil)
+	return c.QueryStruct(queryCtx, "PUT", types.InternalEndpoint, endpoint, args, nil)
 }

--- a/internal/rest/client/control.go
+++ b/internal/rest/client/control.go
@@ -8,5 +8,5 @@ import (
 
 // ControlDaemon posts control data to the daemon.
 func (c *Client) ControlDaemon(ctx context.Context, args types.Control) error {
-	return c.QueryStruct(ctx, "POST", ControlEndpoint, nil, args, nil)
+	return c.QueryStruct(ctx, "POST", types.ControlEndpoint, nil, args, nil)
 }

--- a/internal/rest/client/heartbeat.go
+++ b/internal/rest/client/heartbeat.go
@@ -17,5 +17,5 @@ func (c *Client) Heartbeat(ctx context.Context, hbInfo types.HeartbeatInfo) erro
 	queryCtx, cancel := context.WithTimeout(ctx, HeartbeatTimeout*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "POST", InternalEndpoint, api.NewURL().Path("heartbeat"), hbInfo, nil)
+	return c.QueryStruct(queryCtx, "POST", types.InternalEndpoint, api.NewURL().Path("heartbeat"), hbInfo, nil)
 }

--- a/internal/rest/client/hooks.go
+++ b/internal/rest/client/hooks.go
@@ -14,7 +14,7 @@ func RunPreRemoveHook(ctx context.Context, c *Client, config types.HookRemoveMem
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "POST", InternalEndpoint, api.NewURL().Path("hooks", string(types.PreRemove)), config, nil)
+	return c.QueryStruct(queryCtx, "POST", types.InternalEndpoint, api.NewURL().Path("hooks", string(types.PreRemove)), config, nil)
 }
 
 // RunPostRemoveHook executes the PostRemove hook with the given configuration on the cluster member targeted by this client.
@@ -22,7 +22,7 @@ func RunPostRemoveHook(ctx context.Context, c *Client, config types.HookRemoveMe
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "POST", InternalEndpoint, api.NewURL().Path("hooks", string(types.PostRemove)), config, nil)
+	return c.QueryStruct(queryCtx, "POST", types.InternalEndpoint, api.NewURL().Path("hooks", string(types.PostRemove)), config, nil)
 }
 
 // RunNewMemberHook executes the OnNewMember hook with the given configuration on the cluster member targeted by this client.
@@ -30,5 +30,5 @@ func RunNewMemberHook(ctx context.Context, c *Client, config types.HookNewMember
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "POST", InternalEndpoint, api.NewURL().Path("hooks", string(types.OnNewMember)), config, nil)
+	return c.QueryStruct(queryCtx, "POST", types.InternalEndpoint, api.NewURL().Path("hooks", string(types.OnNewMember)), config, nil)
 }

--- a/internal/rest/client/ready.go
+++ b/internal/rest/client/ready.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/canonical/lxd/shared/api"
+
+	"github.com/canonical/microcluster/internal/rest/types"
 )
 
 // CheckReady returns once the daemon has signalled to the ready channel that it is done setting up.
@@ -12,7 +14,7 @@ func (c *Client) CheckReady(ctx context.Context) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	err := c.QueryStruct(queryCtx, "GET", PublicEndpoint, api.NewURL().Path("ready"), nil, nil)
+	err := c.QueryStruct(queryCtx, "GET", types.PublicEndpoint, api.NewURL().Path("ready"), nil, nil)
 
 	return err
 }

--- a/internal/rest/client/shutdown.go
+++ b/internal/rest/client/shutdown.go
@@ -5,6 +5,8 @@ import (
 	"time"
 
 	"github.com/canonical/lxd/shared/api"
+
+	"github.com/canonical/microcluster/internal/rest/types"
 )
 
 // ShutdownDaemon begins the daemon shutdown sequence.
@@ -12,5 +14,5 @@ func (c *Client) ShutdownDaemon(ctx context.Context) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "POST", ControlEndpoint, api.NewURL().Path("shutdown"), nil, nil)
+	return c.QueryStruct(queryCtx, "POST", types.ControlEndpoint, api.NewURL().Path("shutdown"), nil, nil)
 }

--- a/internal/rest/client/sql.go
+++ b/internal/rest/client/sql.go
@@ -21,7 +21,7 @@ func (c *Client) GetSQL(ctx context.Context, schema bool) (*types.SQLDump, error
 		endpoint.WithQuery("schema", "1")
 	}
 
-	err := c.QueryStruct(reqCtx, "GET", InternalEndpoint, endpoint, nil, dump)
+	err := c.QueryStruct(reqCtx, "GET", types.InternalEndpoint, endpoint, nil, dump)
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +35,7 @@ func (c *Client) PostSQL(ctx context.Context, query types.SQLQuery) (*types.SQLB
 	defer cancel()
 
 	batch := &types.SQLBatch{}
-	err := c.QueryStruct(reqCtx, "POST", InternalEndpoint, api.NewURL().Path("sql"), query, batch)
+	err := c.QueryStruct(reqCtx, "POST", types.InternalEndpoint, api.NewURL().Path("sql"), query, batch)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/rest/client/tokens.go
+++ b/internal/rest/client/tokens.go
@@ -16,7 +16,7 @@ func (c *Client) RequestToken(ctx context.Context, name string) (string, error) 
 
 	var token string
 	tokenRecord := types.TokenRecord{Name: name}
-	err := c.QueryStruct(queryCtx, "POST", PublicEndpoint, api.NewURL().Path("tokens"), tokenRecord, &token)
+	err := c.QueryStruct(queryCtx, "POST", types.PublicEndpoint, api.NewURL().Path("tokens"), tokenRecord, &token)
 
 	return token, err
 }
@@ -26,7 +26,7 @@ func (c *Client) DeleteTokenRecord(ctx context.Context, name string) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	err := c.QueryStruct(queryCtx, "DELETE", InternalEndpoint, api.NewURL().Path("tokens", name), nil, nil)
+	err := c.QueryStruct(queryCtx, "DELETE", types.InternalEndpoint, api.NewURL().Path("tokens", name), nil, nil)
 
 	return err
 }
@@ -37,7 +37,7 @@ func (c *Client) GetTokenRecords(ctx context.Context) ([]types.TokenRecord, erro
 	defer cancel()
 
 	tokenRecords := []types.TokenRecord{}
-	err := c.QueryStruct(queryCtx, "GET", PublicEndpoint, api.NewURL().Path("tokens"), nil, &tokenRecords)
+	err := c.QueryStruct(queryCtx, "GET", types.PublicEndpoint, api.NewURL().Path("tokens"), nil, &tokenRecords)
 
 	return tokenRecords, err
 }

--- a/internal/rest/client/truststore.go
+++ b/internal/rest/client/truststore.go
@@ -14,7 +14,7 @@ func AddTrustStoreEntry(ctx context.Context, c *Client, args types.ClusterMember
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "POST", InternalEndpoint, api.NewURL().Path("truststore"), args, nil)
+	return c.QueryStruct(queryCtx, "POST", types.InternalEndpoint, api.NewURL().Path("truststore"), args, nil)
 }
 
 // DeleteTrustStoreEntry deletes the record corresponding to the given cluster member from the trust store.
@@ -22,5 +22,5 @@ func DeleteTrustStoreEntry(ctx context.Context, c *Client, name string) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "DELETE", InternalEndpoint, api.NewURL().Path("truststore", name), nil, nil)
+	return c.QueryStruct(queryCtx, "DELETE", types.InternalEndpoint, api.NewURL().Path("truststore", name), nil, nil)
 }

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -1,13 +1,13 @@
 package resources
 
 import (
-	"github.com/canonical/microcluster/internal/rest/client"
+	"github.com/canonical/microcluster/internal/rest/types"
 	"github.com/canonical/microcluster/rest"
 )
 
 // UnixEndpoints are the endpoints available over the unix socket.
 var UnixEndpoints = rest.Resources{
-	Path: rest.EndpointType(client.ControlEndpoint),
+	Path: types.ControlEndpoint,
 	Endpoints: []rest.Endpoint{
 		controlCmd,
 		shutdownCmd,
@@ -16,7 +16,7 @@ var UnixEndpoints = rest.Resources{
 
 // PublicEndpoints are the /cluster/1.0 API endpoints available without authentication.
 var PublicEndpoints = rest.Resources{
-	Path: rest.EndpointType(client.PublicEndpoint),
+	Path: types.PublicEndpoint,
 	Endpoints: []rest.Endpoint{
 		api10Cmd,
 		clusterCmd,
@@ -28,7 +28,7 @@ var PublicEndpoints = rest.Resources{
 
 // InternalEndpoints are the /cluster/internal API endpoints available at the listen address.
 var InternalEndpoints = rest.Resources{
-	Path: rest.EndpointType(client.InternalEndpoint),
+	Path: types.InternalEndpoint,
 	Endpoints: []rest.Endpoint{
 		databaseCmd,
 		clusterCertificatesCmd,
@@ -43,6 +43,6 @@ var InternalEndpoints = rest.Resources{
 
 // ExtendedEndpoints holds all the endpoints added by external usage of MicroCluster.
 var ExtendedEndpoints = rest.Resources{
-	Path:      rest.EndpointType(client.ExtendedEndpoint),
+	Path:      types.ExtendedEndpoint,
 	Endpoints: []rest.Endpoint{},
 }

--- a/internal/rest/types/server.go
+++ b/internal/rest/types/server.go
@@ -10,3 +10,17 @@ type Server struct {
 	Address types.AddrPort `json:"address" yaml:"address"`
 	Ready   bool           `json:"ready"   yaml:"ready"`
 }
+
+const (
+	// ExtendedEndpoint - All endpoints added managed by external usage of MicroCluster.
+	ExtendedEndpoint types.EndpointPrefix = "1.0"
+
+	// PublicEndpoint - Internally managed APIs available without authentication.
+	PublicEndpoint types.EndpointPrefix = "cluster/1.0"
+
+	// InternalEndpoint - all endpoints restricted to trusted servers.
+	InternalEndpoint types.EndpointPrefix = "cluster/internal"
+
+	// ControlEndpoint - all endpoints available on the local unix socket.
+	ControlEndpoint types.EndpointPrefix = "cluster/control"
+)

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -107,7 +107,7 @@ func (m *MicroCluster) Status(ctx context.Context) (*internalTypes.Server, error
 	}
 
 	server := internalTypes.Server{}
-	err = c.QueryStruct(ctx, "GET", internalClient.PublicEndpoint, nil, nil, &server)
+	err = c.QueryStruct(ctx, "GET", internalTypes.PublicEndpoint, nil, nil, &server)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to get cluster status: %w", err)
 	}

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -6,7 +6,6 @@ import (
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/shared"
 
-	"github.com/canonical/microcluster/internal/rest/client"
 	"github.com/canonical/microcluster/rest/types"
 	"github.com/canonical/microcluster/state"
 )
@@ -42,12 +41,9 @@ type Endpoint struct {
 
 // Resources represents all the resources served over the same path.
 type Resources struct {
-	Path      EndpointType
+	Path      types.EndpointPrefix
 	Endpoints []Endpoint
 }
-
-// EndpointType is a type specifying the endpoint on which the resource exists.
-type EndpointType client.EndpointType
 
 // Server contains configuration and handlers for additional listeners to be instantiated after app startup.
 type Server struct {

--- a/rest/types/endpoint.go
+++ b/rest/types/endpoint.go
@@ -1,0 +1,4 @@
+package types
+
+// EndpointPrefix is a type specifying the endpoint on which the resource exists.
+type EndpointPrefix string


### PR DESCRIPTION
The hardcoded `1.0` value for resources supplied by the project using microcluster will be removed by #142, which means we need a way to supply the endpoint prefix to client functions.

This PR moves the type definition for `EndpointType` into the API types package, and moves all internal implementations into the internal API types package. It is also renamed to `EndpointPrefix` for clarity.

Then, when #142 is merged, this value will be specified in the set of `Resources` supplied to microcluster, and can be passed into the `Query` method. 