### PR TITLE
Allow FQDN cluster member names

### DIFF
--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -17,7 +17,6 @@ import (
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
-	"github.com/canonical/lxd/shared/validate"
 	"github.com/gorilla/mux"
 	"golang.org/x/sys/unix"
 
@@ -68,7 +67,7 @@ func clusterPost(s *state.State, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	err = validate.IsHostname(req.Name)
+	err = validateFQDN(req.Name)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Invalid cluster member name %q: %w", req.Name, err))
 	}

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/util"
@@ -29,6 +30,24 @@ var controlCmd = rest.Endpoint{
 	Post: rest.EndpointAction{Handler: controlPost, AccessHandler: access.AllowAuthenticated},
 }
 
+// validateFQDN validates that the given name is a a valid fully qualified domain name.
+func validateFQDN(name string) error {
+	// Validate length
+	if len(name) < 1 || len(name) > 255 {
+		return fmt.Errorf("Name must be 1-255 characters long")
+	}
+
+	hostnames := strings.Split(name, ".")
+	for _, h := range hostnames {
+		err := validate.IsHostname(h)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func controlPost(state *state.State, r *http.Request) response.Response {
 	req := &internalTypes.Control{}
 	// Parse the request.
@@ -41,7 +60,7 @@ func controlPost(state *state.State, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Invalid options - received join token and bootstrap flag"))
 	}
 
-	err = validate.IsHostname(req.Name)
+	err = validateFQDN(req.Name)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Invalid cluster member name %q: %w", req.Name, err))
 	}


### PR DESCRIPTION
#106 validated that cluster member names must be a hostname. I don't see any reason not to also allow FQDN cluster member names. Currently, at least Sunbeam has been using FQDNs as cluster member names.