### PR TITLE
Streamline extension servers with core API

### DIFF
--- a/example/api/servers.go
+++ b/example/api/servers.go
@@ -11,7 +11,8 @@ import (
 // If the Server is marked as CoreAPI, its endpoints will be added to the core listener of Microcluster.
 var Servers = []rest.Server{
 	{
-		CoreAPI: true,
+		CoreAPI:   true,
+		ServeUnix: true,
 		Resources: []rest.Resources{
 			{
 				PathPrefix: types.ExtendedPathPrefix,

--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -60,16 +60,17 @@ func (c *cmdDaemon) command() *cobra.Command {
 
 func (c *cmdDaemon) run(cmd *cobra.Command, args []string) error {
 	m, err := microcluster.App(microcluster.Args{
-		StateDir:         c.flagStateDir,
-		SocketGroup:      c.flagSocketGroup,
-		Verbose:          c.global.flagLogVerbose,
-		Debug:            c.global.flagLogDebug,
-		ExtensionServers: api.Servers,
+		StateDir:    c.flagStateDir,
+		SocketGroup: c.flagSocketGroup,
+		Verbose:     c.global.flagLogVerbose,
+		Debug:       c.global.flagLogDebug,
 	})
 
 	if err != nil {
 		return err
 	}
+
+	m.AddServers(api.Servers)
 
 	// exampleHooks are some example post-action hooks that can be run by MicroCluster.
 	exampleHooks := &config.Hooks{

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -201,7 +201,9 @@ func (d *Daemon) init(listenPort string, schemaExtensions []schema.Update, apiEx
 	}
 
 	for _, server := range d.extensionServers {
-		serverEndpoints = append(serverEndpoints, server.Resources...)
+		if server.ServeUnix {
+			serverEndpoints = append(serverEndpoints, server.Resources...)
+		}
 	}
 
 	ctlServer := d.initServer(serverEndpoints...)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -184,8 +184,12 @@ func (d *Daemon) init(listenPort string, schemaExtensions []schema.Update, apiEx
 
 	d.db = db.NewDB(d.shutdownCtx, d.serverCert, d.ClusterCert, d.os)
 
-	// Extract user defined endpoints for core listener.
-	coreEndpoints, err := resources.GetAndValidateCoreEndpoints(d.extensionServers)
+	listenAddr := api.NewURL()
+	if listenPort != "" {
+		listenAddr = listenAddr.Host(fmt.Sprintf(":%s", listenPort))
+	}
+
+	err = resources.ValidateEndpoints(d.extensionServers, listenAddr.URL.Host)
 	if err != nil {
 		return err
 	}
@@ -195,7 +199,11 @@ func (d *Daemon) init(listenPort string, schemaExtensions []schema.Update, apiEx
 		resources.InternalEndpoints,
 		resources.PublicEndpoints,
 	}
-	serverEndpoints = append(serverEndpoints, coreEndpoints...)
+
+	for _, server := range d.extensionServers {
+		serverEndpoints = append(serverEndpoints, server.Resources...)
+	}
+
 	ctlServer := d.initServer(serverEndpoints...)
 	ctl := endpoints.NewSocket(d.shutdownCtx, ctlServer, d.os.ControlSocket(), d.os.SocketGroup)
 	d.endpoints = endpoints.NewEndpoints(d.shutdownCtx, ctl)
@@ -206,14 +214,16 @@ func (d *Daemon) init(listenPort string, schemaExtensions []schema.Update, apiEx
 
 	if listenPort != "" {
 		serverEndpoints = []rest.Resources{resources.PublicEndpoints}
-		serverEndpoints = append(serverEndpoints, coreEndpoints...)
-		server := d.initServer(serverEndpoints...)
-		url := api.NewURL().Host(fmt.Sprintf(":%s", listenPort))
-		network := endpoints.NewNetwork(d.shutdownCtx, endpoints.EndpointNetwork, server, *url, d.serverCert)
-		err = d.endpoints.Add(network)
+		err = d.addCoreServers(true, *listenAddr, d.ServerCert(), serverEndpoints)
 		if err != nil {
 			return err
 		}
+	}
+
+	// Add extension servers before post-join hook.
+	err = d.addExtensionServers(true, d.ServerCert(), listenAddr.URL.Host)
+	if err != nil {
+		return err
 	}
 
 	d.db.SetSchema(schemaExtensions, d.Extensions)
@@ -422,22 +432,25 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 		return err
 	}
 
-	// Extract user defined endpoints for core listener.
-	coreEndpoints, err := resources.GetAndValidateCoreEndpoints(d.extensionServers)
+	// Validate the extension servers again now that we have applied addresses.
+	err = resources.ValidateEndpoints(d.extensionServers, d.address.URL.Host)
 	if err != nil {
 		return err
 	}
 
-	serverEndpoints := []rest.Resources{resources.InternalEndpoints, resources.PublicEndpoints}
-	serverEndpoints = append(serverEndpoints, coreEndpoints...)
-	server := d.initServer(serverEndpoints...)
-	network := endpoints.NewNetwork(d.shutdownCtx, endpoints.EndpointNetwork, server, d.address, d.ClusterCert())
 	err = d.endpoints.Down(endpoints.EndpointNetwork)
 	if err != nil {
 		return err
 	}
 
-	err = d.endpoints.Add(network)
+	serverEndpoints := []rest.Resources{resources.InternalEndpoints, resources.PublicEndpoints}
+	err = d.addCoreServers(false, d.address, d.ClusterCert(), serverEndpoints)
+	if err != nil {
+		return err
+	}
+
+	// Add extension servers before post-join hook.
+	err = d.addExtensionServers(false, d.ClusterCert(), d.address.URL.Host)
 	if err != nil {
 		return err
 	}
@@ -460,12 +473,6 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 		}
 
 		err = d.trustStore.Refresh()
-		if err != nil {
-			return err
-		}
-
-		// Add extension servers before post-bootstrap hook.
-		err = d.addExtensionServers()
 		if err != nil {
 			return err
 		}
@@ -587,12 +594,6 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 		return err
 	}
 
-	// Add extension servers before post-join hook.
-	err = d.addExtensionServers()
-	if err != nil {
-		return err
-	}
-
 	if len(joinAddresses) > 0 {
 		return d.hooks.PostJoin(d.State(), initConfig)
 	}
@@ -600,17 +601,63 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 	return nil
 }
 
+// addCoreServers initializes the default resources with the default address and certificate.
+// If the default address and certificate may be applied to any extension servers, those will be started as well.
+func (d *Daemon) addCoreServers(preInit bool, defaultURL api.URL, defaultCert *shared.CertInfo, defaultResources []rest.Resources) error {
+	serverEndpoints := []rest.Resources{}
+	serverEndpoints = append(serverEndpoints, defaultResources...)
+
+	// Append all extension servers whose address is empty or matches the default URL.
+	for _, s := range d.extensionServers {
+		// If the server is not available prior to initialization, then skip it if we are before initialization.
+		if !s.PreInit && preInit {
+			continue
+		}
+
+		// If the Server resources are not part of the core API, then skip it.
+		if !s.CoreAPI {
+			continue
+		}
+
+		serverEndpoints = append(serverEndpoints, s.Resources...)
+	}
+
+	server := d.initServer(serverEndpoints...)
+	network := endpoints.NewNetwork(d.shutdownCtx, endpoints.EndpointNetwork, server, defaultURL, defaultCert)
+
+	return d.endpoints.Add(network)
+}
+
 // addExtensionServers initialises a new *endpoints.Network for each extension server and adds it to the Daemon endpoints.
-func (d *Daemon) addExtensionServers() error {
+// Only servers with a defined address will be started.
+// If a server lacks a certificate, the fallbackCert will be used instead.
+func (d *Daemon) addExtensionServers(preInit bool, fallbackCert *shared.CertInfo, coreAddress string) error {
 	var networks []endpoints.Endpoint
 	for _, extensionServer := range d.extensionServers {
+		// Skip any core API servers.
 		if extensionServer.CoreAPI {
 			continue
 		}
 
+		// If we are before initialization, only start the servers who have `PreInit` set.
+		if !extensionServer.PreInit && preInit {
+			continue
+		}
+
+		// If the server has no defined address, then do not start it as it should have already started with the core servers.
+		if extensionServer.Address == (types.AddrPort{}) {
+			continue
+		}
+
+		// If the server address matches the core address, then it should have already started.
+		if extensionServer.Address.String() == coreAddress {
+			continue
+		}
+
+		// If there is no certificate defined, apply the default certificate for the core server.
 		cert := extensionServer.Certificate
 		if cert == nil {
-			cert = d.ClusterCert()
+			cert = fallbackCert
 		}
 
 		server := d.initServer(extensionServer.Resources...)
@@ -619,9 +666,11 @@ func (d *Daemon) addExtensionServers() error {
 		networks = append(networks, network)
 	}
 
-	err := d.endpoints.Add(networks...)
-	if err != nil {
-		return err
+	if len(networks) > 0 {
+		err := d.endpoints.Add(networks...)
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -206,10 +206,7 @@ func (d *Daemon) init(listenPort string, schemaExtensions []schema.Update, apiEx
 		}
 	}
 
-	ctlServer := d.initServer(serverEndpoints...)
-	ctl := endpoints.NewSocket(d.shutdownCtx, ctlServer, d.os.ControlSocket(), d.os.SocketGroup)
-	d.endpoints = endpoints.NewEndpoints(d.shutdownCtx, ctl)
-	err = d.endpoints.Up()
+	err = d.startUnixServer(serverEndpoints)
 	if err != nil {
 		return err
 	}
@@ -601,6 +598,15 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 	}
 
 	return nil
+}
+
+// startUnixServer starts up the core unix listener with the given resources.
+func (d *Daemon) startUnixServer(serverEndpoints []rest.Resources) error {
+	ctlServer := d.initServer(serverEndpoints...)
+	ctl := endpoints.NewSocket(d.shutdownCtx, ctlServer, d.os.ControlSocket(), d.os.SocketGroup)
+	d.endpoints = endpoints.NewEndpoints(d.shutdownCtx, ctl)
+
+	return d.endpoints.Up()
 }
 
 // addCoreServers initializes the default resources with the default address and certificate.

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -70,6 +70,10 @@ func ValidateEndpoints(extensionServers []rest.Server, coreAddress string) error
 			return fmt.Errorf("Server must have defined resources")
 		}
 
+		if server.ServeUnix && !server.CoreAPI {
+			return fmt.Errorf("Cannot serve non-core API resources over the core unix socket")
+		}
+
 		if server.CoreAPI && server.Certificate != nil {
 			return fmt.Errorf("Core API server cannot have a pre-defined certificate")
 		}

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -46,7 +46,7 @@ type Args struct {
 	Client     *client.Client
 	Proxy      func(*http.Request) (*url.URL, error)
 
-	ExtensionServers []rest.Server
+	extensionServers []rest.Server
 }
 
 // App returns an instance of MicroCluster with a newly initialized filesystem if one does not exist.
@@ -90,12 +90,17 @@ func (m *MicroCluster) Start(ctx context.Context, extensionsSchema []schema.Upda
 	ctx, cancel := signal.NotifyContext(ctx, unix.SIGPWR, unix.SIGTERM, unix.SIGINT, unix.SIGQUIT)
 	defer cancel()
 
-	err = d.Run(ctx, m.args.ListenPort, m.FileSystem.StateDir, m.FileSystem.SocketGroup, extensionsSchema, apiExtensions, m.args.ExtensionServers, hooks)
+	err = d.Run(ctx, m.args.ListenPort, m.FileSystem.StateDir, m.FileSystem.SocketGroup, extensionsSchema, apiExtensions, m.args.extensionServers, hooks)
 	if err != nil {
 		return fmt.Errorf("Daemon stopped with error: %w", err)
 	}
 
 	return nil
+}
+
+// AddServers adds additional server configurations to microcluster.
+func (m *MicroCluster) AddServers(servers []rest.Server) {
+	m.args.extensionServers = servers
 }
 
 // Status returns basic status information about the cluster.

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -53,6 +53,9 @@ type Server struct {
 	// PreInit determines whether the Server should be available prior to initializing the daemon.
 	PreInit bool
 
+	// ServeUnix sets whether the resources of this endpoint should also be served over the unix socket.
+	ServeUnix bool
+
 	// Protocol is the server protocol.
 	// Example: https
 	Protocol string

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -1,7 +1,6 @@
 package rest
 
 import (
-	"fmt"
 	"net/http"
 
 	"github.com/canonical/lxd/lxd/response"
@@ -48,20 +47,24 @@ type Resources struct {
 
 // Server contains configuration and handlers for additional listeners to be instantiated after app startup.
 type Server struct {
-	CoreAPI     bool
-	Protocol    string
-	Address     types.AddrPort
+	// CoreAPI determines whether the the resources of the server should be served over the default cluster API.
+	CoreAPI bool
+
+	// PreInit determines whether the Server should be available prior to initializing the daemon.
+	PreInit bool
+
+	// Protocol is the server protocol.
+	// Example: https
+	Protocol string
+
+	// Address is the server listen address.
+	// Example: 127.0.0.1:9000
+	Address types.AddrPort
+
+	// Certificate is used for setting up TLS on the server.
+	// x509 PEM Certificate
 	Certificate *shared.CertInfo
-	Resources   []Resources
-}
 
-// ValidateServerConfigs checks that the server configuration is valid.
-func (s Server) ValidateServerConfigs() error {
-	if s.CoreAPI {
-		if s.Address != (types.AddrPort{}) || s.Protocol != "" || s.Certificate != nil {
-			return fmt.Errorf("Core API server cannot have Address, Protocol or Certificate")
-		}
-	}
-
-	return nil
+	// Resources is the list of resources offered by this server.
+	Resources []Resources
 }


### PR DESCRIPTION
This changes the structure of the extension servers a bit to make them play more nicely with the core API.

* Removes `CoreAPI` flag, instead any `Server` without an address/certificate will be set up with the core listener. 
* Adds `PreInit` flag. This signifies whether the `Server` should start prior to initialization if `ListenPort` is defined on the daemon.

* Adds 2 functions: `addCoreServers` and `addExtensionServers`. The former captures all entries in the `Servers` list that either do not have an address & certificate, or whose fields match the core values, and offers all of their resources over the same server. The latter starts up a new server for any remaining `Server`s whose address is defined.

* Adds a helper `AddServers` for applying the extension server config to microcluster, rather than directly in `microcluster.Args`. This is because at the time we define `microcluster.Args`, we have not yet created the state directory, which means there may not be a place for the project to store the certificates defined for the `Server`. Now, the project must call `microcluster.App` first, and then `AddServer`. 

* Adds global validation of `Servers`:
  * A server's resource path must not conflict with any other defined resource path.
  * A server's address must not conflict with any other defined server.
  * A server must define an address if it defines a protocol.

