### PR TITLE
github: added .jira_sync_config.yaml for the synchronization with Jira

### DIFF
--- a/.github/.jira_sync_config.yaml
+++ b/.github/.jira_sync_config.yaml
@@ -1,0 +1,39 @@
+settings:
+    # Jira project key to create the issue in
+  jira_project_key: "LXD"
+  
+  # Dictionary mapping GitHub issue status to Jira issue status
+  status_mapping:
+    opened: Untriaged
+    closed: done 
+    
+  # (Optional) Jira project components that should be attached to the created issue
+  # Component names are case-sensitive
+  # components:
+  #  - LXD
+  #  - Microcloud
+      
+  # (Optional) GitHub labels. Only issues with one of those labels will be synchronized.
+  # If not specified, all issues will be synchronized
+  labels:
+     - Jira
+      
+  # (Optional) (Default: false) Add a new comment in GitHub with a link to Jira created issue
+  add_gh_comment: false
+  
+  # (Optional) (Default: true) Synchronize issue description from GitHub to Jira
+  sync_description: true
+  
+  # (Optional) (Default: true) Synchronize comments from GitHub to Jira
+  sync_comments: false
+  
+  # (Optional) (Default: None) Parent Epic key to link the issue to
+  epic_key: "LXD-1251"
+      
+  # (Optional) Dictionary mapping GitHub issue labels to Jira issue types. 
+  # If label on the issue is not in specified list, this issue will be created as a Bug
+  label_mapping:
+    improvement: Story
+    feature: Story
+    investigation: Spike
+    bug: Bug


### PR DESCRIPTION
`.jira_sync_config.yaml` is a configuration file to allow the creation of Jira issues when a particular tag (`Jira`) is assigned to the GitHub issue. It uses [gh-jira-sync-bot](https://github.com/canonical/gh-jira-sync-bot). The issues in Jira are grouped in a specific epic defined in the config file, but the parent epic can be changed without affecting the synchronization. The default issue type assigned in Jira is "Bug" but it can be changed assigning a different label (`feature`,`improvement`, `investigation`) to the GitHub issue.  