### PR TITLE
internal/daemon: Attempt to re-use control.socket if present

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -118,15 +118,6 @@ func (d *Daemon) Run(ctx context.Context, listenPort string, stateDir string, so
 		return fmt.Errorf("Failed to initialize directory structure: %w", err)
 	}
 
-	isAlreadyRunning, err := d.os.IsControlSocketPresent()
-	if err != nil {
-		return err
-	}
-
-	if isAlreadyRunning {
-		return fmt.Errorf("Control socket already present (%q); is another daemon already running?", d.os.ControlSocketPath())
-	}
-
 	d.extensionServers = extensionServers
 
 	err = d.init(listenPort, extensionsSchema, apiExtensions, hooks)

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -167,11 +167,7 @@ func (db *DB) Join(extensions extensions.Extensions, project string, addr api.UR
 
 		// If this is a graceful abort, then we should loop back and try to start the database again.
 		if errors.Is(err, schema.ErrGracefulAbort) {
-			logger.Debug("Closing database after upgrade notification", logger.Ctx{"address": db.listenAddr.String()})
-			err = db.db.Close()
-			if err != nil {
-				logger.Error("Failed to close database", logger.Ctx{"address": db.listenAddr.String(), "error": err})
-			}
+			logger.Debug("Re-attempting schema upgrade and API extension checks", logger.Ctx{"address": db.listenAddr.String()})
 
 			continue
 		}

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -148,19 +148,19 @@ func (db *DB) Bootstrap(extensions extensions.Extensions, project string, addr a
 
 // Join a dqlite cluster with the address of a member.
 func (db *DB) Join(extensions extensions.Extensions, project string, addr api.URL, joinAddresses ...string) error {
-	for {
-		var err error
-		db.listenAddr = addr
-		db.dqlite, err = dqlite.New(db.os.DatabaseDir,
-			dqlite.WithCluster(joinAddresses),
-			dqlite.WithAddress(db.listenAddr.URL.Host),
-			dqlite.WithExternalConn(db.dialFunc(), db.acceptCh),
-			dqlite.WithUnixSocket(os.Getenv(sys.DqliteSocket)))
-		if err != nil {
-			return fmt.Errorf("Failed to join dqlite cluster %w", err)
-		}
+	var err error
+	db.listenAddr = addr
+	db.dqlite, err = dqlite.New(db.os.DatabaseDir,
+		dqlite.WithCluster(joinAddresses),
+		dqlite.WithAddress(db.listenAddr.URL.Host),
+		dqlite.WithExternalConn(db.dialFunc(), db.acceptCh),
+		dqlite.WithUnixSocket(os.Getenv(sys.DqliteSocket)))
+	if err != nil {
+		return fmt.Errorf("Failed to join dqlite cluster %w", err)
+	}
 
-		err = db.Open(extensions, false, project)
+	for {
+		err := db.Open(extensions, false, project)
 		if err == nil {
 			break
 		}


### PR DESCRIPTION
If the daemon crashed or stopped uncleanly due to an error, then the control socket file might still be present in the state directory. This means the daemon will enter a restart loop until the control socket is manually removed.

Instead, we can just attempt to re-connect to the control socket. If it's already in use then that will error out the daemon anyway.