### PR TITLE
Add upgrade progress to cluster member status.

### DIFF
--- a/example/cmd/microctl/cluster_members.go
+++ b/example/cmd/microctl/cluster_members.go
@@ -3,6 +3,7 @@ package main
 import (
 	"sort"
 
+	"github.com/canonical/lxd/shared"
 	cli "github.com/canonical/lxd/shared/cmd"
 	"github.com/spf13/cobra"
 
@@ -81,10 +82,10 @@ func (c *cmdClusterMembersList) run(cmd *cobra.Command, args []string) error {
 
 	data := make([][]string, len(clusterMembers))
 	for i, clusterMember := range clusterMembers {
-		data[i] = []string{clusterMember.Name, clusterMember.Address.String(), clusterMember.Role, clusterMember.Certificate.String(), string(clusterMember.Status)}
+		data[i] = []string{clusterMember.Name, clusterMember.Address.String(), clusterMember.Role, shared.CertFingerprint(clusterMember.Certificate.Certificate), string(clusterMember.Status)}
 	}
 
-	header := []string{"NAME", "ADDRESS", "ROLE", "CERTIFICATE", "STATUS"}
+	header := []string{"NAME", "ADDRESS", "ROLE", "FINGERPRINT", "STATUS"}
 	sort.Sort(cli.SortColumnsNaturally(data))
 
 	return cli.RenderTable(cli.TableFormatTable, header, data, clusterMembers)

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/canonical/microcluster/client"
 	"github.com/canonical/microcluster/cluster"
+	"github.com/canonical/microcluster/internal/db"
 	internalClient "github.com/canonical/microcluster/internal/rest/client"
 	internalTypes "github.com/canonical/microcluster/internal/rest/types"
 	"github.com/canonical/microcluster/internal/state"

--- a/internal/rest/types/cluster.go
+++ b/internal/rest/types/cluster.go
@@ -41,4 +41,10 @@ const (
 
 	// MemberNotFound should be the MemberStatus when the node was not found in dqlite.
 	MemberNotFound MemberStatus = "NOT FOUND"
+
+	// MemberUpgrading should be the MemberStatus if the system is awaiting or performing a schema upgrade.
+	MemberUpgrading MemberStatus = "UPGRADING"
+
+	// MemberNeedsUpgrade should be the MemberStatus if the system needs to receive a schema upgrade to be compatible with other cluster members.
+	MemberNeedsUpgrade MemberStatus = "NEEDS UPGRADE"
 )


### PR DESCRIPTION
Adds `MemberUpgrading` and `MemberNeedsUpgrade` to the list of possible cluster member statuses.

Consequentially, this means we need to set `AllowedBeforeInit=true` to the `/cluster` API. In the POST case, we still enforce that the database must be fully ready. 

But for listing cluster members, as long as the cluster is at least in a waiting state, we can try to grab the current list of members. In such a case, we will compare those cluster members' schema versions to our own local version, and set `UPGRADING` as the status if they match our's, or `NEEDS UPGRADE` if they do not.