### PR TITLE
Client: remove "/" from path prefix if `endpointType` has empty value

### DIFF
--- a/internal/rest/client/client.go
+++ b/internal/rest/client/client.go
@@ -283,8 +283,8 @@ func (c *Client) QueryStruct(ctx context.Context, method string, endpointType ty
 
 	localURL.URL.Host = c.url.URL.Host
 	localURL.URL.Scheme = c.url.URL.Scheme
-	localURL.URL.Path = "/" + string(endpointType) + localURL.URL.Path
-	localURL.URL.RawPath = "/" + string(endpointType) + localURL.URL.RawPath
+	localURL.URL.Path = filepath.Join("/", string(endpointType), localURL.URL.Path)
+	localURL.URL.RawPath = filepath.Join("/", string(endpointType), localURL.URL.RawPath)
 
 	localQuery := localURL.URL.Query()
 	clientQuery := c.url.URL.Query()


### PR DESCRIPTION
Recently we merged #142 which allows the user to define their own path prefix for a client query. However, if the prefix is `""`, then we may end up with a path like `//some-path` in [QueryStruct](https://github.com/canonical/microcluster/blob/db6075a4cf00db01687e26e61a08fe679a6f567b/internal/rest/client/client.go#L275). This PR should resolve the issue.