### PR TITLE
allow modification of response if access handler returns a callback

### DIFF
--- a/rest/access/handlers.go
+++ b/rest/access/handlers.go
@@ -27,22 +27,22 @@ func (e ErrInvalidHost) Unwrap() error {
 
 // AllowAuthenticated checks if the request is trusted by extracting access.TrustedRequest from the request context.
 // This handler is used as an access handler by default if AllowUntrusted is false on a rest.EndpointAction.
-func AllowAuthenticated(state *state.State, r *http.Request) response.Response {
+func AllowAuthenticated(state *state.State, r *http.Request) (bool, response.Response) {
 	trusted := r.Context().Value(request.CtxAccess)
 	if trusted == nil {
-		return response.Forbidden(nil)
+		return false, response.Forbidden(nil)
 	}
 
 	trustedReq, ok := trusted.(access.TrustedRequest)
 	if !ok {
-		return response.Forbidden(nil)
+		return false, response.Forbidden(nil)
 	}
 
 	if !trustedReq.Trusted {
-		return response.Forbidden(nil)
+		return false, response.Forbidden(nil)
 	}
 
-	return response.EmptySyncResponse
+	return true, nil
 }
 
 // Authenticate ensures the request certificates are trusted against the given set of trusted certificates.

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -19,7 +19,7 @@ type EndpointAlias struct {
 // EndpointAction represents an action on an API endpoint.
 type EndpointAction struct {
 	Handler        func(state *state.State, r *http.Request) response.Response
-	AccessHandler  func(state *state.State, r *http.Request) response.Response
+	AccessHandler  func(state *state.State, r *http.Request) (trusted bool, resp response.Response)
 	AllowUntrusted bool
 	ProxyTarget    bool // Allow forwarding of the request to a target if ?target=name is specified.
 }


### PR DESCRIPTION
## Done
 - Allow `AccessHandler` to return a callback that can modify the `http.ResponseWriter` object.

## Context
 - In an upstream project, endpoints authentication applied by using the custom `AccessHandler` may need to write to the response regardless of success or failure. Currently in microcluster if an `AccessHandler` returns `EmptySyncResponse`, then we will not be able to access the response object even if we need to write to it.
 - The upstream project can get around this issue by writing auth data to the request context and handle it in the actual endpoint handler. However, this approach tend to require the authentication logic to be split up which makes the code difficult to understand.