### PR TITLE
Project version

### DIFF
--- a/example/Makefile
+++ b/example/Makefile
@@ -1,11 +1,18 @@
+VERSION=$(shell git describe --always --dirty --abbrev=10)
+LDFLAGS="-X github.com/canonical/microcluster/example/version.version=$(VERSION)"
+
 .PHONY: default
 default: build
 
 # Build targets.
 .PHONY: build
 build:
-	go install -v ./cmd/microctl
-	go install -v ./cmd/microd
+	go install -v \
+		-ldflags $(LDFLAGS) \
+		./cmd/microctl
+	go install -v \
+		-ldflags $(LDFLAGS) \
+		./cmd/microd
 
 # Testing targets.
 .PHONY: check

--- a/example/cmd/microctl/main.go
+++ b/example/cmd/microctl/main.go
@@ -28,7 +28,7 @@ func main() {
 	app := &cobra.Command{
 		Use:               "microctl",
 		Short:             "Command for managing the MicroCluster daemon",
-		Version:           version.Version,
+		Version:           version.Version(),
 		SilenceUsage:      true,
 		CompletionOptions: cobra.CompletionOptions{DisableDefaultCmd: true},
 	}

--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -49,7 +49,7 @@ func (c *cmdDaemon) command() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "microd",
 		Short:   "Example daemon for MicroCluster - This will start a daemon with a running control socket and no database",
-		Version: version.Version,
+		Version: version.Version(),
 	}
 
 	cmd.RunE = c.run
@@ -64,6 +64,7 @@ func (c *cmdDaemon) run(cmd *cobra.Command, args []string) error {
 		SocketGroup: c.flagSocketGroup,
 		Verbose:     c.global.flagLogVerbose,
 		Debug:       c.global.flagLogDebug,
+		Version:     version.Version(),
 	})
 
 	if err != nil {

--- a/example/version/version.go
+++ b/example/version/version.go
@@ -1,5 +1,9 @@
 // Package version provides shared version information.
 package version
 
-// Version is the current API version.
-const Version = "0.1"
+var version string
+
+// Version is set by the build system.
+func Version() string {
+	return version
+}

--- a/internal/rest/resources/api_1.0.go
+++ b/internal/rest/resources/api_1.0.go
@@ -32,6 +32,7 @@ func api10Get(s state.State, r *http.Request) response.Response {
 	return response.SyncResponse(true, internalTypes.Server{
 		Name:       s.Name(),
 		Address:    addrPort,
+		Version:    s.Version(),
 		Ready:      s.Database().IsOpen(r.Context()) == nil,
 		Extensions: intState.Extensions,
 	})

--- a/internal/rest/types/server.go
+++ b/internal/rest/types/server.go
@@ -9,6 +9,7 @@ import (
 type Server struct {
 	Name       string                `json:"name"    yaml:"name"`
 	Address    types.AddrPort        `json:"address" yaml:"address"`
+	Version    string                `json:"version" yaml:"version"`
 	Ready      bool                  `json:"ready"   yaml:"ready"`
 	Extensions extensions.Extensions `json:"extensions" yaml:"extensions"`
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -30,6 +30,9 @@ type State interface {
 	// Name of the cluster member.
 	Name() string
 
+	// Version is provided by the MicroCluster consumer.
+	Version() string
+
 	// Server certificate is used for server-to-server connection.
 	ServerCert() *shared.CertInfo
 
@@ -96,6 +99,7 @@ type InternalState struct {
 	InternalFileSystem       func() *sys.OS
 	InternalAddress          func() *api.URL
 	InternalName             func() string
+	InternalVersion          func() string
 	InternalServerCert       func() *shared.CertInfo
 	InternalClusterCert      func() *shared.CertInfo
 	InternalDatabase         *db.DB
@@ -116,6 +120,12 @@ func (s *InternalState) Address() *api.URL {
 // Name returns the cluster name for the local system.
 func (s *InternalState) Name() string {
 	return s.InternalName()
+}
+
+// Version is provided by the MicroCluster consumer. The daemon includes it in
+// its /cluster/1.0 response.
+func (s *InternalState) Version() string {
+	return s.InternalVersion()
 }
 
 // ServerCert returns the keypair identifying the local system.

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -44,6 +44,10 @@ type Args struct {
 	StateDir    string
 	SocketGroup string
 
+	// Consumers of MicroCluster should provide a version to serve at /cluster/1.0
+	// This is required at daemon start.
+	Version string
+
 	PreInitListenAddress string
 	Client               *client.Client
 	Proxy                func(*http.Request) (*url.URL, error)
@@ -82,9 +86,13 @@ func (m *MicroCluster) Start(ctx context.Context, extensionsSchema []schema.Upda
 		return err
 	}
 
+	if m.args.Version == "" {
+		return fmt.Errorf("Version was missing at MicroCluster daemon start")
+	}
+
 	// Start up a daemon with a basic control socket.
 	defer logger.Info("Daemon stopped")
-	d := daemon.NewDaemon(cluster.GetCallerProject())
+	d := daemon.NewDaemon(cluster.GetCallerProject(), m.args.Version)
 
 	chIgnore := make(chan os.Signal, 1)
 	signal.Notify(chIgnore, unix.SIGHUP)


### PR DESCRIPTION
Take a (required) project version via the microcluster app args and include it in the response from `GET /cluster/1.0`. This will allow MicroCloud to enforce version requirements on its sub-snaps.

This also adds a build-time constant version (`git describe`) to the example.

LXD-1279