### PR TITLE
internal/db: Pass dial context through to dialer.Dial

### DIFF
--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -361,7 +361,8 @@ func dqliteNetworkDial(ctx context.Context, addr string, db *DB) (net.Conn, erro
 
 	deadline, _ := ctx.Deadline()
 	dialer := &net.Dialer{Timeout: time.Until(deadline)}
-	conn, err := tls.DialWithDialer(dialer, "tcp", addr, config)
+	tlsDialer := tls.Dialer{NetDialer: dialer, Config: config}
+	conn, err := tlsDialer.DialContext(ctx, "tcp", addr)
 	if err != nil {
 		return nil, fmt.Errorf("Failed connecting to HTTP endpoint %q: %w", addr, err)
 	}


### PR DESCRIPTION
`go-dqlite` sets a context on calls to the `DialFunc` specified by us that may have already been cancelled. In such cases we shouldn't need to continue to execute `Dial`, so this passes the context down to `dial.DialContext`. 