### PR TITLE
microcluster: Add the apiExtensions to the MicroCluster app args

### DIFF
--- a/internal/rest/resources/api_1.0.go
+++ b/internal/rest/resources/api_1.0.go
@@ -24,8 +24,9 @@ func api10Get(s *state.State, r *http.Request) response.Response {
 	}
 
 	return response.SyncResponse(true, internalTypes.Server{
-		Name:    s.Name(),
-		Address: addrPort,
-		Ready:   s.Database.IsOpen(r.Context()) == nil,
+		Name:       s.Name(),
+		Address:    addrPort,
+		Ready:      s.Database.IsOpen(r.Context()) == nil,
+		Extensions: s.Extensions,
 	})
 }

--- a/internal/rest/types/server.go
+++ b/internal/rest/types/server.go
@@ -1,14 +1,16 @@
 package types
 
 import (
+	"github.com/canonical/microcluster/internal/extensions"
 	"github.com/canonical/microcluster/rest/types"
 )
 
 // Server represents server status information.
 type Server struct {
-	Name    string         `json:"name"    yaml:"name"`
-	Address types.AddrPort `json:"address" yaml:"address"`
-	Ready   bool           `json:"ready"   yaml:"ready"`
+	Name       string                `json:"name"    yaml:"name"`
+	Address    types.AddrPort        `json:"address" yaml:"address"`
+	Ready      bool                  `json:"ready"   yaml:"ready"`
+	Extensions extensions.Extensions `json:"extensions" yaml:"extensions"`
 }
 
 const (


### PR DESCRIPTION
needed by: https://github.com/canonical/microcloud/pull/245/commits/e6eadc1981614ae9d1a909239243dde93a901841

___

This way, a MicroCluster app started in an particular snap application (like `microovn`), when its recovered as a MicroCluster app in `microcloud`, can expose its API extensions.
