### PR TITLE
Extend additional network listener concept

### DIFF
--- a/config/hooks.go
+++ b/config/hooks.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"github.com/canonical/microcluster/internal/state"
+	"github.com/canonical/microcluster/rest/types"
 )
 
 // Hooks holds customizable functions that can be called at varying points by the daemon to.
@@ -35,4 +36,7 @@ type Hooks struct {
 
 	// OnNewMember is run on each peer after a new cluster member has joined and executed their 'PreJoin' hook.
 	OnNewMember func(s *state.State) error
+
+	// OnDaemonConfigUpdate
+	OnDaemonConfigUpdate func(s *state.State, config types.DaemonConfig) error
 }

--- a/example/api/servers.go
+++ b/example/api/servers.go
@@ -9,8 +9,8 @@ import (
 // Servers represents the list of listeners that the daemon will start
 // Each Server has pre-defined endpoints that will be added to the listener
 // If the Server is marked as CoreAPI, its endpoints will be added to the core listener of Microcluster.
-var Servers = []rest.Server{
-	{
+var Servers = map[string]rest.Server{
+	"extended": {
 		CoreAPI:   true,
 		ServeUnix: true,
 		Resources: []rest.Resources{

--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/canonical/microcluster/example/database"
 	"github.com/canonical/microcluster/example/version"
 	"github.com/canonical/microcluster/microcluster"
+	"github.com/canonical/microcluster/rest/types"
 	"github.com/canonical/microcluster/state"
 )
 
@@ -179,6 +180,13 @@ func (c *cmdDaemon) run(cmd *cobra.Command, args []string) error {
 		// OnNewMember is run after a new member has joined.
 		OnNewMember: func(s *state.State) error {
 			logger.Infof("This is a hook that is run on peer %q when a new cluster member has joined", s.Name())
+
+			return nil
+		},
+
+		// OnDaemonConfigUpdate is run after the local daemon config of a cluster member got modified.
+		OnDaemonConfigUpdate: func(s *state.State, config types.DaemonConfig) error {
+			logger.Infof("Running OnDaemonConfigUpdate triggered by %q", config.Name)
 
 			return nil
 		},

--- a/internal/config/daemon.go
+++ b/internal/config/daemon.go
@@ -1,0 +1,128 @@
+package config
+
+import (
+	"fmt"
+	"os"
+	"sync"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/canonical/microcluster/rest/types"
+)
+
+// DaemonConfig wraps the daemon's config with get, set and lock capabilities.
+type DaemonConfig struct {
+	// Path of the daemon.yaml file.
+	path string
+
+	// Lock the daemon config for read and write operations.
+	lock *sync.RWMutex
+
+	// The actual configuration.
+	config *types.DaemonConfig
+}
+
+// NewDaemonConfig returns an initialised version of the daemon's config.
+// The implementation is thread safe so the same in memory representation of the config
+// can be consumed both internally in the daemon and it's API endpoints.
+// The config has to be written to file proactively so when setting a config setting
+// it doesn't automatically get propagated to the underlying file.
+func NewDaemonConfig(path string) *DaemonConfig {
+	return &DaemonConfig{
+		path: path,
+		lock: &sync.RWMutex{},
+		config: &types.DaemonConfig{
+			Servers: make(map[string]types.ServerConfig),
+		},
+	}
+}
+
+// Load loads the daemon's config from its path.
+func (d *DaemonConfig) Load() error {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	data, err := os.ReadFile(d.path)
+	if err != nil {
+		return fmt.Errorf("Failed to load daemon config: %w", err)
+	}
+
+	err = yaml.Unmarshal(data, d.config)
+	if err != nil {
+		return fmt.Errorf("Failed to parse daemon config from yaml: %w", err)
+	}
+
+	return nil
+}
+
+// Write writes the daemon's config to its path.
+func (d *DaemonConfig) Write() error {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	bytes, err := yaml.Marshal(d.config)
+	if err != nil {
+		return fmt.Errorf("Failed to parse daemon config to yaml: %w", err)
+	}
+
+	err = os.WriteFile(d.path, bytes, 0644)
+	if err != nil {
+		return fmt.Errorf("Failed to write daemon configuration yaml: %w", err)
+	}
+
+	return nil
+}
+
+// GetName returns the daemon's name.
+func (d *DaemonConfig) GetName() string {
+	d.lock.RLock()
+	defer d.lock.RUnlock()
+
+	return d.config.Name
+}
+
+// GetAddress returns the daemon's address.
+func (d *DaemonConfig) GetAddress() types.AddrPort {
+	d.lock.RLock()
+	defer d.lock.RUnlock()
+
+	return d.config.Address
+}
+
+// GetServers returns the daemon's additional listener configs.
+func (d *DaemonConfig) GetServers() map[string]types.ServerConfig {
+	d.lock.RLock()
+	defer d.lock.RUnlock()
+
+	// Create a deep copy to not return the reference to the original map.
+	serverConfigCopy := make(map[string]types.ServerConfig, len(d.config.Servers))
+	for k, v := range d.config.Servers {
+		serverConfigCopy[k] = v
+	}
+
+	return serverConfigCopy
+}
+
+// SetName sets the daemon's name.
+func (d *DaemonConfig) SetName(name string) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	d.config.Name = name
+}
+
+// SetAddress sets the daemon's address.
+func (d *DaemonConfig) SetAddress(address types.AddrPort) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	d.config.Address = address
+}
+
+// SetServers sets the daemon's additional listener configs.
+func (d *DaemonConfig) SetServers(servers map[string]types.ServerConfig) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	d.config.Servers = servers
+}

--- a/internal/config/daemon.go
+++ b/internal/config/daemon.go
@@ -55,6 +55,11 @@ func (d *DaemonConfig) Load() error {
 	return nil
 }
 
+// Dump dumps the entire daemon's config.
+func (d *DaemonConfig) Dump() *types.DaemonConfig {
+	return d.config
+}
+
 // Write writes the daemon's config to its path.
 func (d *DaemonConfig) Write() error {
 	d.lock.Lock()

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -810,7 +810,7 @@ func (d *Daemon) addExtensionServers(preInit bool, fallbackCert *shared.CertInfo
 			continue
 		}
 
-		url := api.NewURL().Scheme(extensionServer.Protocol).Host(extensionServer.Address.String())
+		url := api.NewURL().Scheme("https").Host(extensionServer.Address.String())
 		alreadyRunning := false
 		for name := range d.endpoints.List(endpoints.EndpointNetwork) {
 			if name == serverName {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -72,7 +72,7 @@ type Daemon struct {
 	stop func() error
 
 	extensionServersMu sync.RWMutex
-	extensionServers   []rest.Server
+	extensionServers   map[string]rest.Server
 }
 
 // NewDaemon initializes the Daemon context and channels.
@@ -114,7 +114,7 @@ func NewDaemon(project string) *Daemon {
 // - `extensionsSchema` is a list of schema updates in the order that they should be applied.
 // - `extensionServers` is a list of rest.Server that will be initialized and managed by microcluster.
 // - `hooks` are a set of functions that trigger at certain points during cluster communication.
-func (d *Daemon) Run(ctx context.Context, listenPort string, stateDir string, socketGroup string, extensionsSchema []schema.Update, apiExtensions []string, extensionServers []rest.Server, hooks *config.Hooks) error {
+func (d *Daemon) Run(ctx context.Context, listenPort string, stateDir string, socketGroup string, extensionsSchema []schema.Update, apiExtensions []string, extensionServers map[string]rest.Server, hooks *config.Hooks) error {
 	d.shutdownCtx, d.shutdownCancel = context.WithCancel(ctx)
 	if stateDir == "" {
 		stateDir = os.Getenv(sys.StateDir)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -291,6 +291,7 @@ func (d *Daemon) applyHooks(hooks *config.Hooks) {
 	noOpHook := func(s *state.State) error { return nil }
 	noOpRemoveHook := func(s *state.State, force bool) error { return nil }
 	noOpInitHook := func(s *state.State, initConfig map[string]string) error { return nil }
+	noOpConfigHook := func(s *state.State, config types.DaemonConfig) error { return nil }
 
 	if hooks == nil {
 		d.hooks = config.Hooks{}
@@ -332,6 +333,10 @@ func (d *Daemon) applyHooks(hooks *config.Hooks) {
 
 	if d.hooks.PostRemove == nil {
 		d.hooks.PostRemove = noOpRemoveHook
+	}
+
+	if d.hooks.OnDaemonConfigUpdate == nil {
+		d.hooks.OnDaemonConfigUpdate = noOpConfigHook
 	}
 }
 
@@ -989,6 +994,7 @@ func (d *Daemon) State() *state.State {
 	state.PostRemoveHook = d.hooks.PostRemove
 	state.OnHeartbeatHook = d.hooks.OnHeartbeat
 	state.OnNewMemberHook = d.hooks.OnNewMember
+	state.OnDaemonConfigUpdate = d.hooks.OnDaemonConfigUpdate
 	state.ReloadCert = d.ReloadCert
 	state.StopListeners = func() error {
 		err := d.fsWatcher.Close()

--- a/internal/endpoints/endpoint.go
+++ b/internal/endpoints/endpoint.go
@@ -19,6 +19,14 @@ const (
 	EndpointNetwork
 )
 
+const (
+	// EndpointsUnix represents the name of the Unix endpoints.
+	EndpointsUnix string = "unix"
+
+	// EndpointsCore represents the name of the core API endpoints.
+	EndpointsCore string = "core"
+)
+
 // String labels EndpointTypes for logging purposes.
 func (et EndpointType) String() string {
 	switch et {

--- a/internal/endpoints/endpoints.go
+++ b/internal/endpoints/endpoints.go
@@ -13,17 +13,12 @@ type Endpoints struct {
 	mu          sync.RWMutex
 	shutdownCtx context.Context // Parent context for shutting down cleanly.
 
-	listeners map[EndpointType]Endpoint // Map of supported listeners.
+	listeners map[string]Endpoint // Map of supported listeners.
 }
 
 // NewEndpoints aggregates the given endpoints so we can manage them from one source.
-func NewEndpoints(shutdownCtx context.Context, endpoints ...Endpoint) *Endpoints {
-	listeners := map[EndpointType]Endpoint{}
-	for _, endpoint := range endpoints {
-		listeners[endpoint.Type()] = endpoint
-	}
-
-	return &Endpoints{listeners: listeners, shutdownCtx: shutdownCtx}
+func NewEndpoints(shutdownCtx context.Context, endpoints map[string]Endpoint) *Endpoints {
+	return &Endpoints{listeners: endpoints, shutdownCtx: shutdownCtx}
 }
 
 // Up calls Serve on each of the configured listeners.
@@ -39,34 +34,33 @@ func (e *Endpoints) Up() error {
 	return nil
 }
 
-// UpdateTLS updates the TLS configuration of the network listeners.
-func (e *Endpoints) UpdateTLS(cert *shared.CertInfo) {
+// UpdateTLSByName updates the TLS configuration of the network listeners.
+// In case the cluster certificate gets updated reload the core.
+func (e *Endpoints) UpdateTLSByName(name string, cert *shared.CertInfo) {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	for _, l := range e.listeners {
-		n, ok := l.(*Network)
+	endpoint, ok := e.listeners[name]
+	if ok {
+		network, ok := endpoint.(*Network)
 		if ok {
-			n.UpdateTLS(cert)
+			network.UpdateTLS(cert)
 		}
 	}
 }
 
 // Add calls Serve on the additional set of listeners, and adds them to Endpoints.
-func (e *Endpoints) Add(endpoints ...Endpoint) error {
-	newListeners := map[EndpointType]Endpoint{}
-	for _, endpoint := range endpoints {
-		newListeners[endpoint.Type()] = endpoint
-	}
-
-	for k, v := range newListeners {
+func (e *Endpoints) Add(endpoints map[string]Endpoint) error {
+	for k, v := range endpoints {
 		e.listeners[k] = v
 	}
 
-	err := e.up(newListeners)
+	err := e.up(endpoints)
 	if err != nil {
-		// Attempt to call Down() in case something actually got brought up.
-		_ = e.Down()
+		// Attempt to call DownByName() in case something actually got brought up.
+		for name := range endpoints {
+			_ = e.DownByName(name)
+		}
 
 		return err
 	}
@@ -74,27 +68,27 @@ func (e *Endpoints) Add(endpoints ...Endpoint) error {
 	return nil
 }
 
-func (e *Endpoints) up(listeners map[EndpointType]Endpoint) error {
+func (e *Endpoints) up(listeners map[string]Endpoint) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
 	// Startup listeners.
-	for key := range listeners {
-		err := listeners[key].Listen()
+	for _, listener := range listeners {
+		listenerCopy := listener
+
+		err := listenerCopy.Listen()
 		if err != nil {
 			return err
 		}
 
-		listener := listeners[key]
-
 		go func() {
 			select {
 			case <-e.shutdownCtx.Done():
-				logger.Infof("Received shutdown signal - aborting endpoint startup for %s", listener.Type().String())
+				logger.Infof("Received shutdown signal - aborting endpoint startup for %s", listenerCopy.Type().String())
 				return
 
 			default:
-				listener.Serve()
+				listenerCopy.Serve()
 			}
 		}()
 	}
@@ -107,37 +101,42 @@ func (e *Endpoints) Down(types ...EndpointType) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	for _, listener := range e.listeners {
+	for name, endpoint := range e.listeners {
 		remove := false
-		for _, endpoint := range types {
-			if listener.Type() == endpoint {
+		for _, endpointType := range types {
+			if endpoint.Type() == endpointType {
 				remove = true
 			}
 		}
 
 		if types == nil || remove {
-			err := listener.Close()
+			err := endpoint.Close()
 			if err != nil {
 				return err
 			}
+
+			// Delete the stopped endpoint from the slice.
+			delete(e.listeners, name)
 		}
 	}
 
 	return nil
 }
 
-// DownBy closes the configured listeners based on the decisionFunc.
-// If it returns true the respective listener gets closed.
-func (e *Endpoints) DownBy(decisionFunc func(endpoint Endpoint) bool) error {
+// DownByName closes the configured listeners based on its name.
+func (e *Endpoints) DownByName(name string) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	for _, listener := range e.listeners {
-		if decisionFunc(listener) {
-			err := listener.Close()
+	for endpointName, endpoint := range e.listeners {
+		if endpointName == name {
+			err := endpoint.Close()
 			if err != nil {
 				return err
 			}
+
+			// Delete the stopped endpoint from the slice.
+			delete(e.listeners, name)
 		}
 	}
 
@@ -145,14 +144,14 @@ func (e *Endpoints) DownBy(decisionFunc func(endpoint Endpoint) bool) error {
 }
 
 // List returns a list of already added endpoints.
-func (e *Endpoints) List(types ...EndpointType) []Endpoint {
+func (e *Endpoints) List(types ...EndpointType) map[string]Endpoint {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
-	var endpoints = make([]Endpoint, 0)
-	for _, listener := range e.listeners {
-		if shared.ValueInSlice(listener.Type(), types) {
-			endpoints = append(endpoints, listener)
+	var endpoints = make(map[string]Endpoint, 0)
+	for name, endpoint := range e.listeners {
+		if shared.ValueInSlice(endpoint.Type(), types) {
+			endpoints[name] = endpoint
 		}
 	}
 

--- a/internal/endpoints/endpoints.go
+++ b/internal/endpoints/endpoints.go
@@ -157,3 +157,11 @@ func (e *Endpoints) List(types ...EndpointType) map[string]Endpoint {
 
 	return endpoints
 }
+
+// Get returns a specific endpoint based on its name.
+func (e *Endpoints) Get(name string) Endpoint {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+
+	return e.listeners[name]
+}

--- a/internal/rest/client/cluster.go
+++ b/internal/rest/client/cluster.go
@@ -62,10 +62,10 @@ func (c *Client) ResetClusterMember(ctx context.Context, name string, force bool
 }
 
 // UpdateClusterCertificate sets a new cluster keypair and CA.
-func (c *Client) UpdateClusterCertificate(ctx context.Context, args apiTypes.ClusterCertificatePut) error {
+func (c *Client) UpdateClusterCertificate(ctx context.Context, name string, args apiTypes.ClusterCertificatePut) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	endpoint := api.NewURL().Path("cluster", "certificates")
+	endpoint := api.NewURL().Path("cluster", "certificates", name)
 	return c.QueryStruct(queryCtx, "PUT", types.InternalEndpoint, endpoint, args, nil)
 }

--- a/internal/rest/client/cluster.go
+++ b/internal/rest/client/cluster.go
@@ -62,7 +62,7 @@ func (c *Client) ResetClusterMember(ctx context.Context, name string, force bool
 }
 
 // UpdateClusterCertificate sets a new cluster keypair and CA.
-func (c *Client) UpdateClusterCertificate(ctx context.Context, name string, args apiTypes.ClusterCertificatePut) error {
+func (c *Client) UpdateClusterCertificate(ctx context.Context, name string, args apiTypes.KeyPair) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 

--- a/internal/rest/client/cluster.go
+++ b/internal/rest/client/cluster.go
@@ -61,11 +61,11 @@ func (c *Client) ResetClusterMember(ctx context.Context, name string, force bool
 	return c.QueryStruct(queryCtx, "PUT", types.PublicEndpoint, endpoint, nil, nil)
 }
 
-// UpdateClusterCertificate sets a new cluster keypair and CA.
-func (c *Client) UpdateClusterCertificate(ctx context.Context, name string, args apiTypes.KeyPair) error {
+// UpdateCertificate sets a new keypair and CA.
+func (c *Client) UpdateCertificate(ctx context.Context, name apiTypes.CertificateName, args apiTypes.KeyPair) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	endpoint := api.NewURL().Path("cluster", "certificates", name)
+	endpoint := api.NewURL().Path("cluster", "certificates", string(name))
 	return c.QueryStruct(queryCtx, "PUT", types.InternalEndpoint, endpoint, args, nil)
 }

--- a/internal/rest/client/daemon.go
+++ b/internal/rest/client/daemon.go
@@ -1,0 +1,20 @@
+package client
+
+import (
+	"context"
+	"time"
+
+	"github.com/canonical/lxd/shared/api"
+
+	"github.com/canonical/microcluster/internal/rest/types"
+	apiTypes "github.com/canonical/microcluster/rest/types"
+)
+
+// UpdateServers updates the additional servers config.
+func (c *Client) UpdateServers(ctx context.Context, config map[string]apiTypes.ServerConfig) error {
+	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	endpoint := api.NewURL().Path("daemon", "servers")
+	return c.QueryStruct(queryCtx, "PUT", types.InternalEndpoint, endpoint, config, nil)
+}

--- a/internal/rest/client/hooks.go
+++ b/internal/rest/client/hooks.go
@@ -7,6 +7,7 @@ import (
 	"github.com/canonical/lxd/shared/api"
 
 	"github.com/canonical/microcluster/internal/rest/types"
+	"github.com/canonical/microcluster/rest/types"
 )
 
 // RunPreRemoveHook executes the PreRemove hook with the given configuration on the cluster member targeted by this client.
@@ -31,4 +32,12 @@ func RunNewMemberHook(ctx context.Context, c *Client, config types.HookNewMember
 	defer cancel()
 
 	return c.QueryStruct(queryCtx, "POST", types.InternalEndpoint, api.NewURL().Path("hooks", string(types.OnNewMember)), config, nil)
+}
+
+// RunOnDaemonConfigUpdateHook executes the OnDaemonConfigUpdate hook with the given configuration on the cluster member targeted by this client.
+func RunOnDaemonConfigUpdateHook(ctx context.Context, c *Client, config *types.DaemonConfig) error {
+	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	return c.QueryStruct(queryCtx, "POST", types.InternalEndpoint, api.NewURL().Path("hooks", string(types.OnDaemonConfigUpdate)), config, nil)
 }

--- a/internal/rest/client/hooks.go
+++ b/internal/rest/client/hooks.go
@@ -6,32 +6,32 @@ import (
 
 	"github.com/canonical/lxd/shared/api"
 
-	"github.com/canonical/microcluster/internal/rest/types"
+	internalTypes "github.com/canonical/microcluster/internal/rest/types"
 	"github.com/canonical/microcluster/rest/types"
 )
 
 // RunPreRemoveHook executes the PreRemove hook with the given configuration on the cluster member targeted by this client.
-func RunPreRemoveHook(ctx context.Context, c *Client, config types.HookRemoveMemberOptions) error {
+func RunPreRemoveHook(ctx context.Context, c *Client, config internalTypes.HookRemoveMemberOptions) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "POST", types.InternalEndpoint, api.NewURL().Path("hooks", string(types.PreRemove)), config, nil)
+	return c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, api.NewURL().Path("hooks", string(internalTypes.PreRemove)), config, nil)
 }
 
 // RunPostRemoveHook executes the PostRemove hook with the given configuration on the cluster member targeted by this client.
-func RunPostRemoveHook(ctx context.Context, c *Client, config types.HookRemoveMemberOptions) error {
+func RunPostRemoveHook(ctx context.Context, c *Client, config internalTypes.HookRemoveMemberOptions) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "POST", types.InternalEndpoint, api.NewURL().Path("hooks", string(types.PostRemove)), config, nil)
+	return c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, api.NewURL().Path("hooks", string(internalTypes.PostRemove)), config, nil)
 }
 
 // RunNewMemberHook executes the OnNewMember hook with the given configuration on the cluster member targeted by this client.
-func RunNewMemberHook(ctx context.Context, c *Client, config types.HookNewMemberOptions) error {
+func RunNewMemberHook(ctx context.Context, c *Client, config internalTypes.HookNewMemberOptions) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "POST", types.InternalEndpoint, api.NewURL().Path("hooks", string(types.OnNewMember)), config, nil)
+	return c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, api.NewURL().Path("hooks", string(internalTypes.OnNewMember)), config, nil)
 }
 
 // RunOnDaemonConfigUpdateHook executes the OnDaemonConfigUpdate hook with the given configuration on the cluster member targeted by this client.
@@ -39,5 +39,5 @@ func RunOnDaemonConfigUpdateHook(ctx context.Context, c *Client, config *types.D
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "POST", types.InternalEndpoint, api.NewURL().Path("hooks", string(types.OnDaemonConfigUpdate)), config, nil)
+	return c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, api.NewURL().Path("hooks", string(internalTypes.OnDaemonConfigUpdate)), config, nil)
 }

--- a/internal/rest/resources/certificates.go
+++ b/internal/rest/resources/certificates.go
@@ -78,6 +78,13 @@ func clusterCertificatesPut(s *state.State, r *http.Request) response.Response {
 		return response.BadRequest(fmt.Errorf("Certificate name cannot be a path"))
 	}
 
+	var certificateDir string
+	if certificateName == "cluster" {
+		certificateDir = s.OS.StateDir
+	} else {
+		certificateDir = s.OS.CertificatesDir
+	}
+
 	// If a CA was specified, validate that as well.
 	if req.CA != "" {
 		caBlock, _ := pem.Decode([]byte(req.CA))
@@ -85,19 +92,19 @@ func clusterCertificatesPut(s *state.State, r *http.Request) response.Response {
 			return response.BadRequest(fmt.Errorf("CA must be base64 encoded PEM key"))
 		}
 
-		err = os.WriteFile(filepath.Join(s.OS.StateDir, fmt.Sprintf("%s.ca", certificateName)), []byte(req.CA), 0664)
+		err = os.WriteFile(filepath.Join(certificateDir, fmt.Sprintf("%s.ca", certificateName)), []byte(req.CA), 0664)
 		if err != nil {
 			return response.SmartError(err)
 		}
 	}
 
 	// Write the keypair to the state directory.
-	err = os.WriteFile(filepath.Join(s.OS.StateDir, fmt.Sprintf("%s.crt", certificateName)), []byte(req.PublicKey), 0664)
+	err = os.WriteFile(filepath.Join(certificateDir, fmt.Sprintf("%s.crt", certificateName)), []byte(req.PublicKey), 0664)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	err = os.WriteFile(filepath.Join(s.OS.StateDir, fmt.Sprintf("%s.key", certificateName)), []byte(req.PrivateKey), 0600)
+	err = os.WriteFile(filepath.Join(certificateDir, fmt.Sprintf("%s.key", certificateName)), []byte(req.PrivateKey), 0600)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/internal/rest/resources/certificates.go
+++ b/internal/rest/resources/certificates.go
@@ -35,7 +35,7 @@ func clusterCertificatesPut(s *state.State, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	req := types.ClusterCertificatePut{}
+	req := types.KeyPair{}
 
 	// Parse the request.
 	err = json.NewDecoder(r.Body).Decode(&req)
@@ -63,12 +63,12 @@ func clusterCertificatesPut(s *state.State, r *http.Request) response.Response {
 		}
 	}
 
-	certBlock, _ := pem.Decode([]byte(req.PublicKey))
+	certBlock, _ := pem.Decode([]byte(req.Cert))
 	if certBlock == nil {
 		return response.BadRequest(fmt.Errorf("Certificate must be base64 encoded PEM certificate"))
 	}
 
-	keyBlock, _ := pem.Decode([]byte(req.PrivateKey))
+	keyBlock, _ := pem.Decode([]byte(req.Key))
 	if keyBlock == nil {
 		return response.BadRequest(fmt.Errorf("Private key must be base64 encoded PEM key"))
 	}
@@ -113,12 +113,12 @@ func clusterCertificatesPut(s *state.State, r *http.Request) response.Response {
 	}
 
 	// Write the keypair to the state directory.
-	err = os.WriteFile(filepath.Join(certificateDir, fmt.Sprintf("%s.crt", certificateName)), []byte(req.PublicKey), 0664)
+	err = os.WriteFile(filepath.Join(certificateDir, fmt.Sprintf("%s.crt", certificateName)), []byte(req.Cert), 0664)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	err = os.WriteFile(filepath.Join(certificateDir, fmt.Sprintf("%s.key", certificateName)), []byte(req.PrivateKey), 0600)
+	err = os.WriteFile(filepath.Join(certificateDir, fmt.Sprintf("%s.key", certificateName)), []byte(req.Key), 0600)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/internal/rest/resources/certificates.go
+++ b/internal/rest/resources/certificates.go
@@ -72,19 +72,19 @@ func clusterCertificatesPut(s *state.State, r *http.Request) response.Response {
 			return response.BadRequest(fmt.Errorf("CA must be base64 encoded PEM key"))
 		}
 
-		err = os.WriteFile(filepath.Join(s.OS.StateDir, "cluster.ca"), []byte(req.CA), 0650)
+		err = os.WriteFile(filepath.Join(s.OS.StateDir, "cluster.ca"), []byte(req.CA), 0664)
 		if err != nil {
 			return response.SmartError(err)
 		}
 	}
 
 	// Write the keypair to the state directory.
-	err = os.WriteFile(filepath.Join(s.OS.StateDir, "cluster.crt"), []byte(req.PublicKey), 0650)
+	err = os.WriteFile(filepath.Join(s.OS.StateDir, "cluster.crt"), []byte(req.PublicKey), 0664)
 	if err != nil {
 		return response.SmartError(err)
 	}
 
-	err = os.WriteFile(filepath.Join(s.OS.StateDir, "cluster.key"), []byte(req.PrivateKey), 0650)
+	err = os.WriteFile(filepath.Join(s.OS.StateDir, "cluster.key"), []byte(req.PrivateKey), 0600)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/internal/rest/resources/certificates.go
+++ b/internal/rest/resources/certificates.go
@@ -56,7 +56,7 @@ func clusterCertificatesPut(s *state.State, r *http.Request) response.Response {
 		}
 
 		err = cluster.Query(s.Context, true, func(ctx context.Context, c *client.Client) error {
-			return c.UpdateClusterCertificate(ctx, certificateName, req)
+			return c.UpdateCertificate(ctx, types.CertificateName(certificateName), req)
 		})
 		if err != nil {
 			return response.SmartError(fmt.Errorf("Failed to update %q certificate on peers: %w", certificateName, err))
@@ -79,7 +79,7 @@ func clusterCertificatesPut(s *state.State, r *http.Request) response.Response {
 	}
 
 	var certificateDir string
-	if certificateName == "cluster" {
+	if certificateName == string(types.ClusterCertificateName) {
 		certificateDir = s.OS.StateDir
 	} else {
 		certificateDir = s.OS.CertificatesDir
@@ -124,7 +124,7 @@ func clusterCertificatesPut(s *state.State, r *http.Request) response.Response {
 	}
 
 	// Load the new cert from the state directory on this node.
-	err = state.ReloadCert(certificateName)
+	err = state.ReloadCert(types.CertificateName(certificateName))
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/internal/rest/resources/certificates.go
+++ b/internal/rest/resources/certificates.go
@@ -123,12 +123,10 @@ func clusterCertificatesPut(s *state.State, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	if certificateName == "cluster" {
-		// Load the new cluster cert from the state directory on this node.
-		err = state.ReloadClusterCert()
-		if err != nil {
-			return response.SmartError(err)
-		}
+	// Load the new cert from the state directory on this node.
+	err = state.ReloadCert(certificateName)
+	if err != nil {
+		return response.SmartError(err)
 	}
 
 	return response.EmptySyncResponse

--- a/internal/rest/resources/certificates.go
+++ b/internal/rest/resources/certificates.go
@@ -56,7 +56,7 @@ func clusterCertificatesPut(s *state.State, r *http.Request) response.Response {
 		}
 
 		err = cluster.Query(s.Context, true, func(ctx context.Context, c *client.Client) error {
-			return c.UpdateClusterCertificate(ctx, req)
+			return c.UpdateClusterCertificate(ctx, certificateName, req)
 		})
 		if err != nil {
 			return response.SmartError(fmt.Errorf("Failed to update %q certificate on peers: %w", certificateName, err))

--- a/internal/rest/resources/certificates.go
+++ b/internal/rest/resources/certificates.go
@@ -83,6 +83,20 @@ func clusterCertificatesPut(s *state.State, r *http.Request) response.Response {
 		certificateDir = s.OS.StateDir
 	} else {
 		certificateDir = s.OS.CertificatesDir
+
+		// Check if an additional listener exists for that name.
+		// We cannot query the daemon's config of the additional listeners as
+		// they might not yet be confiugred on every cluster member.
+		found := false
+		for _, name := range s.ExtensionServers() {
+			if name == certificateName {
+				found = true
+			}
+		}
+
+		if !found {
+			return response.BadRequest(fmt.Errorf("No matching additional server found for %q", certificateName))
+		}
 	}
 
 	// If a CA was specified, validate that as well.

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -176,9 +176,24 @@ func joinWithToken(state *state.State, r *http.Request, req *internalTypes.Contr
 		}
 	})
 
+	// Set up cluster certificate.
 	err = util.WriteCert(state.OS.StateDir, "cluster", []byte(joinInfo.ClusterCert.String()), []byte(joinInfo.ClusterKey), nil)
 	if err != nil {
 		return response.SmartError(err)
+	}
+
+	// Setup any additional certificates.
+	for name, cert := range joinInfo.ClusterAdditionalCerts {
+		// Only write the CA if present.
+		var ca []byte
+		if cert.CA != "" {
+			ca = []byte(cert.CA)
+		}
+
+		err := util.WriteCert(state.OS.CertificatesDir, name, []byte(cert.Cert), []byte(cert.Key), ca)
+		if err != nil {
+			return response.SmartError(err)
+		}
 	}
 
 	joinAddrs := types.AddrPorts{}

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -177,7 +177,7 @@ func joinWithToken(state *state.State, r *http.Request, req *internalTypes.Contr
 	})
 
 	// Set up cluster certificate.
-	err = util.WriteCert(state.OS.StateDir, "cluster", []byte(joinInfo.ClusterCert.String()), []byte(joinInfo.ClusterKey), nil)
+	err = util.WriteCert(state.OS.StateDir, string(types.ClusterCertificateName), []byte(joinInfo.ClusterCert.String()), []byte(joinInfo.ClusterKey), nil)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/internal/rest/resources/daemon.go
+++ b/internal/rest/resources/daemon.go
@@ -1,0 +1,79 @@
+package resources
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/lxd/shared"
+
+	"github.com/canonical/microcluster/rest"
+	"github.com/canonical/microcluster/rest/access"
+	"github.com/canonical/microcluster/rest/types"
+	"github.com/canonical/microcluster/state"
+)
+
+var daemonCmd = rest.Endpoint{
+	Path: "daemon/servers",
+
+	Get: rest.EndpointAction{Handler: daemonServersGet, AccessHandler: access.AllowAuthenticated},
+	Put: rest.EndpointAction{Handler: daemonServersPut, AccessHandler: access.AllowAuthenticated},
+}
+
+func daemonServersGet(s *state.State, r *http.Request) response.Response {
+	return response.SyncResponse(true, s.LocalConfig().GetServers())
+}
+
+func daemonServersPut(s *state.State, r *http.Request) response.Response {
+	req := make(map[string]types.ServerConfig)
+
+	// Parse the request.
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		return response.BadRequest(err)
+	}
+
+	// Check if an additional listener exists for that name.
+	for serverName := range req {
+		found := false
+		for _, name := range s.ExtensionServers() {
+			if name == serverName {
+				found = true
+			}
+		}
+
+		if !found {
+			return response.BadRequest(fmt.Errorf("No matching additional listener found for %q", serverName))
+		}
+	}
+
+	// Validate if there is an address conflict.
+	// Initialize the list of active server addresses with the server's address.
+	var serverAddresses = []string{s.Address().URL.Host}
+	for _, server := range req {
+		serverAddress := server.Address.String()
+
+		if shared.ValueInSlice(serverAddress, serverAddresses) {
+			return response.BadRequest(fmt.Errorf("Address %q is already in use", serverAddress))
+		}
+
+		serverAddresses = append(serverAddresses, serverAddress)
+	}
+
+	daemonConfig := s.LocalConfig()
+	daemonConfig.SetServers(req)
+
+	// Persist the configuration changes to file.
+	err = daemonConfig.Write()
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	// Update the additional listeners.
+	err = s.UpdateServers()
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	return response.EmptySyncResponse
+}

--- a/internal/rest/resources/hooks.go
+++ b/internal/rest/resources/hooks.go
@@ -9,7 +9,7 @@ import (
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/gorilla/mux"
 
-	"github.com/canonical/microcluster/internal/rest/types"
+	internalTypes "github.com/canonical/microcluster/internal/rest/types"
 	"github.com/canonical/microcluster/internal/state"
 	"github.com/canonical/microcluster/rest"
 	"github.com/canonical/microcluster/rest/access"
@@ -28,9 +28,9 @@ func hooksPost(s *state.State, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	switch types.HookType(hookTypeStr) {
-	case types.PreRemove:
-		var req types.HookRemoveMemberOptions
+	switch internalTypes.HookType(hookTypeStr) {
+	case internalTypes.PreRemove:
+		var req internalTypes.HookRemoveMemberOptions
 		err = json.NewDecoder(r.Body).Decode(&req)
 		if err != nil {
 			return response.BadRequest(err)
@@ -40,8 +40,8 @@ func hooksPost(s *state.State, r *http.Request) response.Response {
 		if err != nil {
 			return response.SmartError(fmt.Errorf("Failed to execute pre-remove hook on cluster member %q: %w", s.Name(), err))
 		}
-	case types.PostRemove:
-		var req types.HookRemoveMemberOptions
+	case internalTypes.PostRemove:
+		var req internalTypes.HookRemoveMemberOptions
 		err = json.NewDecoder(r.Body).Decode(&req)
 		if err != nil {
 			return response.BadRequest(err)
@@ -52,8 +52,8 @@ func hooksPost(s *state.State, r *http.Request) response.Response {
 			return response.SmartError(fmt.Errorf("Failed to execute post-remove hook on cluster member %q: %w", s.Name(), err))
 		}
 
-	case types.OnNewMember:
-		var req types.HookNewMemberOptions
+	case internalTypes.OnNewMember:
+		var req internalTypes.HookNewMemberOptions
 		err = json.NewDecoder(r.Body).Decode(&req)
 		if err != nil {
 			return response.BadRequest(err)

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -75,8 +75,8 @@ func ValidateEndpoints(extensionServers map[string]rest.Server, coreAddress stri
 			return fmt.Errorf("Cannot serve non-core API resources over the core unix socket")
 		}
 
-		if server.CoreAPI && server.Certificate != nil {
-			return fmt.Errorf("Core API server cannot have a pre-defined certificate")
+		if server.CoreAPI && server.DedicatedCertificate {
+			return fmt.Errorf("Core API server cannot have a dedicated certificate")
 		}
 
 		if server.CoreAPI && server.Address != (types.AddrPort{}) {

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -52,7 +52,7 @@ var InternalEndpoints = rest.Resources{
 // - The address of the server clashes with another server.
 // - The server does not have defined resources.
 // If the Server is a core API server, its resources must not conflict with any other server, and it must not have a defined address or certificate.
-func ValidateEndpoints(extensionServers []rest.Server, coreAddress string) error {
+func ValidateEndpoints(extensionServers map[string]rest.Server, coreAddress string) error {
 	allExistingEndpoints := []rest.Resources{UnixEndpoints, PublicEndpoints, InternalEndpoints}
 	existingEndpointPaths := make(map[string]bool)
 	serverAddresses := map[string]bool{coreAddress: true}

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -90,8 +90,6 @@ func ValidateEndpoints(extensionServers map[string]rest.Server, coreAddress stri
 			}
 
 			serverAddresses[server.Address.String()] = true
-		} else if server.Protocol != "" {
-			return fmt.Errorf("Server protocol defined without address")
 		}
 
 		// Ensure no endpoint path conflicts with another endpoint on the same server.

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -42,6 +42,7 @@ var InternalEndpoints = rest.Resources{
 		trustCmd,
 		trustEntryCmd,
 		hooksCmd,
+		daemonCmd,
 	},
 }
 

--- a/internal/rest/types/hooks.go
+++ b/internal/rest/types/hooks.go
@@ -32,6 +32,9 @@ const (
 
 	// OnHeartbeat is run after a successful heartbeat round.
 	OnHeartbeat HookType = "on-heartbeat"
+
+	// OnDaemonConfigUpdate is run after the local daemon received a config update.
+	OnDaemonConfigUpdate HookType = "on-daemon-config-update"
 )
 
 // HookRemoveMemberOptions holds configuration pertaining to the PreRemove and PostRemove hooks.

--- a/internal/rest/types/tokens.go
+++ b/internal/rest/types/tokens.go
@@ -13,6 +13,13 @@ type TokenRecord struct {
 	Token string `json:"token" yaml:"token"`
 }
 
+// KeyPair holds a certificate together with its private key and optional CA.
+type KeyPair struct {
+	Cert string `json:"cert" yaml:"cert"`
+	Key  string `json:"key" yaml:"key"`
+	CA   string `json:"ca" yaml:"ca"`
+}
+
 // TokenResponse holds the information for connecting to a cluster by a node with a valid join token.
 type TokenResponse struct {
 	// ClusterCert is the public key used across the cluster.
@@ -24,6 +31,9 @@ type TokenResponse struct {
 	// ClusterMembers is the full list of cluster members that are currently present and available in the cluster.
 	// The joiner supplies this list to dqlite so that it can start its database.
 	ClusterMembers []ClusterMemberLocal `json:"cluster_members" yaml:"cluster_members"`
+
+	// ClusterAdditionalCerts is the full list of certificates added for additional listeners.
+	ClusterAdditionalCerts map[string]KeyPair
 
 	// TrustedMember contains the address of the existing cluster member
 	// who was dqlite leader at the time that the joiner supplied its join token.

--- a/internal/rest/types/tokens.go
+++ b/internal/rest/types/tokens.go
@@ -13,13 +13,6 @@ type TokenRecord struct {
 	Token string `json:"token" yaml:"token"`
 }
 
-// KeyPair holds a certificate together with its private key and optional CA.
-type KeyPair struct {
-	Cert string `json:"cert" yaml:"cert"`
-	Key  string `json:"key" yaml:"key"`
-	CA   string `json:"ca" yaml:"ca"`
-}
-
 // TokenResponse holds the information for connecting to a cluster by a node with a valid join token.
 type TokenResponse struct {
 	// ClusterCert is the public key used across the cluster.
@@ -33,7 +26,7 @@ type TokenResponse struct {
 	ClusterMembers []ClusterMemberLocal `json:"cluster_members" yaml:"cluster_members"`
 
 	// ClusterAdditionalCerts is the full list of certificates added for additional listeners.
-	ClusterAdditionalCerts map[string]KeyPair
+	ClusterAdditionalCerts map[string]types.KeyPair
 
 	// TrustedMember contains the address of the existing cluster member
 	// who was dqlite leader at the time that the joiner supplied its join token.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -58,6 +58,9 @@ type State struct {
 	// Initialize APIs and bootstrap/join database.
 	StartAPI func(bootstrap bool, initConfig map[string]string, newConfig *trust.Location, joinAddresses ...string) error
 
+	// Update the additional listeners.
+	UpdateServers func() error
+
 	// Stop fully stops the daemon, its database, and all listeners.
 	Stop func() (exit func(), stopErr error)
 

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -59,6 +59,9 @@ type State struct {
 
 	// Runtime extensions.
 	Extensions extensions.Extensions
+
+	// Returns an immutable list of the daemon's additional listeners.
+	ExtensionServers func() []string
 }
 
 // StopListeners stops the network listeners and the fsnotify listener.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -8,6 +8,7 @@ import (
 	"github.com/canonical/lxd/shared/api"
 
 	"github.com/canonical/microcluster/client"
+	internalConfig "github.com/canonical/microcluster/internal/config"
 	"github.com/canonical/microcluster/internal/db"
 	"github.com/canonical/microcluster/internal/endpoints"
 	"github.com/canonical/microcluster/internal/extensions"
@@ -44,6 +45,9 @@ type State struct {
 
 	// Cluster certificate is used for downstream connections within a cluster.
 	ClusterCert func() *shared.CertInfo
+
+	// Local daemon's config.
+	LocalConfig func() *internalConfig.DaemonConfig
 
 	// Database.
 	Database *db.DB

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -91,7 +91,7 @@ var OnNewMemberHook func(state *State) error
 var OnDaemonConfigUpdate func(state *State, config types.DaemonConfig) error
 
 // ReloadCert reloads the given keypair from the state directory.
-var ReloadCert func(name string) error
+var ReloadCert func(name types.CertificateName) error
 
 // Cluster returns a client for every member of a cluster, except
 // this one.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -15,6 +15,7 @@ import (
 	internalClient "github.com/canonical/microcluster/internal/rest/client"
 	"github.com/canonical/microcluster/internal/sys"
 	"github.com/canonical/microcluster/internal/trust"
+	"github.com/canonical/microcluster/rest/types"
 )
 
 // State is a gateway to the stateful components of the microcluster daemon.
@@ -85,6 +86,9 @@ var OnHeartbeatHook func(state *State) error
 
 // OnNewMemberHook is a post-action hook that is run on all cluster members when a new cluster member joins the cluster.
 var OnNewMemberHook func(state *State) error
+
+// OnDaemonConfigUpdate is a post-action hook that is run on all cluster members when any cluster member receives a local configuration update.
+var OnDaemonConfigUpdate func(state *State, config types.DaemonConfig) error
 
 // ReloadCert reloads the given keypair from the state directory.
 var ReloadCert func(name string) error

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -86,8 +86,8 @@ var OnHeartbeatHook func(state *State) error
 // OnNewMemberHook is a post-action hook that is run on all cluster members when a new cluster member joins the cluster.
 var OnNewMemberHook func(state *State) error
 
-// ReloadClusterCert reloads the cluster keypair from the state directory.
-var ReloadClusterCert func() error
+// ReloadCert reloads the given keypair from the state directory.
+var ReloadCert func(name string) error
 
 // Cluster returns a client for every member of a cluster, except
 // this one.

--- a/internal/sys/os.go
+++ b/internal/sys/os.go
@@ -8,6 +8,8 @@ import (
 
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
+
+	"github.com/canonical/microcluster/rest/types"
 )
 
 // OS contains fields and methods for interacting with the state directory.
@@ -135,11 +137,11 @@ func (s *OS) ServerCert() (*shared.CertInfo, error) {
 
 // ClusterCert gets the local cluster certificate from the state directory.
 func (s *OS) ClusterCert() (*shared.CertInfo, error) {
-	if !shared.PathExists(filepath.Join(s.StateDir, "cluster.crt")) {
-		return nil, fmt.Errorf("Failed to get cluster.crt from directory %q", s.StateDir)
+	if !shared.PathExists(filepath.Join(s.StateDir, fmt.Sprintf("%s.crt", types.ClusterCertificateName))) {
+		return nil, fmt.Errorf("Failed to get %s.crt from directory %q", types.ClusterCertificateName, s.StateDir)
 	}
 
-	cert, err := shared.KeyPairAndCA(s.StateDir, "cluster", shared.CertServer, true)
+	cert, err := shared.KeyPairAndCA(s.StateDir, string(types.ClusterCertificateName), shared.CertServer, true)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to load TLS certificate: %w", err)
 	}

--- a/internal/sys/os.go
+++ b/internal/sys/os.go
@@ -12,11 +12,12 @@ import (
 
 // OS contains fields and methods for interacting with the state directory.
 type OS struct {
-	StateDir    string
-	DatabaseDir string
-	TrustDir    string
-	LogFile     string
-	SocketGroup string
+	StateDir        string
+	DatabaseDir     string
+	TrustDir        string
+	CertificatesDir string
+	LogFile         string
+	SocketGroup     string
 }
 
 // DefaultOS returns a fresh uninitialized OS instance with default values.
@@ -32,11 +33,12 @@ func DefaultOS(stateDir string, socketGroup string, createDir bool) (*OS, error)
 	// TODO: Configurable log file path.
 
 	os := &OS{
-		StateDir:    stateDir,
-		DatabaseDir: filepath.Join(stateDir, "database"),
-		TrustDir:    filepath.Join(stateDir, "truststore"),
-		LogFile:     "",
-		SocketGroup: socketGroup,
+		StateDir:        stateDir,
+		DatabaseDir:     filepath.Join(stateDir, "database"),
+		TrustDir:        filepath.Join(stateDir, "truststore"),
+		CertificatesDir: filepath.Join(stateDir, "certificates"),
+		LogFile:         "",
+		SocketGroup:     socketGroup,
 	}
 
 	err := os.init(createDir)
@@ -55,6 +57,7 @@ func (s *OS) init(createDir bool) error {
 		{s.StateDir, 0711},
 		{s.DatabaseDir, 0700},
 		{s.TrustDir, 0700},
+		{s.CertificatesDir, 0700},
 	}
 
 	for _, dir := range dirs {

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -44,9 +44,9 @@ type Args struct {
 	StateDir    string
 	SocketGroup string
 
-	ListenPort string
-	Client     *client.Client
-	Proxy      func(*http.Request) (*url.URL, error)
+	PreInitListenAddress string
+	Client               *client.Client
+	Proxy                func(*http.Request) (*url.URL, error)
 
 	extensionServers map[string]rest.Server
 }
@@ -92,7 +92,7 @@ func (m *MicroCluster) Start(ctx context.Context, extensionsSchema []schema.Upda
 	ctx, cancel := signal.NotifyContext(ctx, unix.SIGPWR, unix.SIGTERM, unix.SIGINT, unix.SIGQUIT)
 	defer cancel()
 
-	err = d.Run(ctx, m.args.ListenPort, m.FileSystem.StateDir, m.FileSystem.SocketGroup, extensionsSchema, apiExtensions, m.args.extensionServers, hooks)
+	err = d.Run(ctx, m.args.PreInitListenAddress, m.FileSystem.StateDir, m.FileSystem.SocketGroup, extensionsSchema, apiExtensions, m.args.extensionServers, hooks)
 	if err != nil {
 		return fmt.Errorf("Daemon stopped with error: %w", err)
 	}

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -493,11 +493,11 @@ func (m *MicroCluster) SQL(ctx context.Context, query string) (string, *internal
 
 // UpdateCertificate allows updating the cluster certificate and any additional ones.
 // If you want to update the cluster certificate set name to cluster.
-func (m *MicroCluster) UpdateCertificate(ctx context.Context, name string, keypair types.KeyPair) error {
+func (m *MicroCluster) UpdateCertificate(ctx context.Context, name types.CertificateName, keypair types.KeyPair) error {
 	c, err := m.LocalClient()
 	if err != nil {
 		return err
 	}
 
-	return c.UpdateClusterCertificate(ctx, name, keypair)
+	return c.UpdateCertificate(ctx, name, keypair)
 }

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -48,7 +48,7 @@ type Args struct {
 	Client     *client.Client
 	Proxy      func(*http.Request) (*url.URL, error)
 
-	extensionServers []rest.Server
+	extensionServers map[string]rest.Server
 }
 
 // App returns an instance of MicroCluster with a newly initialized filesystem if one does not exist.
@@ -101,7 +101,7 @@ func (m *MicroCluster) Start(ctx context.Context, extensionsSchema []schema.Upda
 }
 
 // AddServers adds additional server configurations to microcluster.
-func (m *MicroCluster) AddServers(servers []rest.Server) {
+func (m *MicroCluster) AddServers(servers map[string]rest.Server) {
 	m.args.extensionServers = servers
 }
 

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -480,3 +480,14 @@ func (m *MicroCluster) SQL(ctx context.Context, query string) (string, *internal
 
 	return "", batch, err
 }
+
+// UpdateCertificate allows updating the cluster certificate and any additional ones.
+// If you want to update the cluster certificate set name to cluster.
+func (m *MicroCluster) UpdateCertificate(ctx context.Context, name string, keypair types.KeyPair) error {
+	c, err := m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	return c.UpdateClusterCertificate(ctx, name, keypair)
+}

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -105,6 +105,16 @@ func (m *MicroCluster) AddServers(servers []rest.Server) {
 	m.args.extensionServers = servers
 }
 
+// UpdateServers updates the mutable fields of the additional server configuration.
+func (m *MicroCluster) UpdateServers(ctx context.Context, serversConfig map[string]types.ServerConfig) error {
+	c, err := m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	return c.UpdateServers(ctx, serversConfig)
+}
+
 // Status returns basic status information about the cluster.
 func (m *MicroCluster) Status(ctx context.Context) (*internalTypes.Server, error) {
 	c, err := m.LocalClient()

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/shared"
-
 	"github.com/canonical/microcluster/rest/types"
 	"github.com/canonical/microcluster/state"
 )
@@ -47,6 +46,8 @@ type Resources struct {
 
 // Server contains configuration and handlers for additional listeners to be instantiated after app startup.
 type Server struct {
+	types.ServerConfig
+
 	// CoreAPI determines whether the the resources of the server should be served over the default cluster API.
 	CoreAPI bool
 
@@ -55,14 +56,6 @@ type Server struct {
 
 	// ServeUnix sets whether the resources of this endpoint should also be served over the unix socket.
 	ServeUnix bool
-
-	// Protocol is the server protocol.
-	// Example: https
-	Protocol string
-
-	// Address is the server listen address.
-	// Example: 127.0.0.1:9000
-	Address types.AddrPort
 
 	// Certificate is used for setting up TLS on the server.
 	// x509 PEM Certificate

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -4,7 +4,6 @@ import (
 	"net/http"
 
 	"github.com/canonical/lxd/lxd/response"
-	"github.com/canonical/lxd/shared"
 	"github.com/canonical/microcluster/rest/types"
 	"github.com/canonical/microcluster/state"
 )
@@ -57,9 +56,11 @@ type Server struct {
 	// ServeUnix sets whether the resources of this endpoint should also be served over the unix socket.
 	ServeUnix bool
 
-	// Certificate is used for setting up TLS on the server.
-	// x509 PEM Certificate
-	Certificate *shared.CertInfo
+	// DedicatedCertificate sets whether the additional listener should use its own self signed certificate.
+	// If false it tries to use a custom certificate from the daemon's state `/certificates` directory
+	// based on the name provided when creating the server.
+	// In case there isn't any custom certificate it falls back to the cluster certificate of the core API.
+	DedicatedCertificate bool
 
 	// Resources is the list of resources offered by this server.
 	Resources []Resources

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -4,6 +4,7 @@ import (
 	"net/http"
 
 	"github.com/canonical/lxd/lxd/response"
+
 	"github.com/canonical/microcluster/rest/types"
 	"github.com/canonical/microcluster/state"
 )

--- a/rest/types/certificate.go
+++ b/rest/types/certificate.go
@@ -7,6 +7,13 @@ import (
 	"fmt"
 )
 
+// KeyPair holds a certificate together with its private key and optional CA.
+type KeyPair struct {
+	Cert string `json:"cert" yaml:"cert"`
+	Key  string `json:"key" yaml:"key"`
+	CA   string `json:"ca" yaml:"ca"`
+}
+
 // ClusterCertificatePut represents the content of a new cluster keypair and CA.
 type ClusterCertificatePut struct {
 	PublicKey  string `json:"public_key"  yaml:"public_key"`

--- a/rest/types/certificate.go
+++ b/rest/types/certificate.go
@@ -7,6 +7,14 @@ import (
 	"fmt"
 )
 
+// CertificateName represents the name of a certificate.
+type CertificateName string
+
+const (
+	// ClusterCertificateName represents the name of the cluster certificate used by the core API.
+	ClusterCertificateName CertificateName = "cluster"
+)
+
 // KeyPair holds a certificate together with its private key and optional CA.
 type KeyPair struct {
 	Cert string `json:"cert" yaml:"cert"`

--- a/rest/types/config.go
+++ b/rest/types/config.go
@@ -1,0 +1,8 @@
+package types
+
+// DaemonConfig is the in memory version of the local daemon.yaml file.
+type DaemonConfig struct {
+	Name    string                  `json:"name" yaml:"name"`
+	Address AddrPort                `json:"address" yaml:"address"`
+	Servers map[string]ServerConfig `json:"servers" yaml:"servers"`
+}

--- a/rest/types/server.go
+++ b/rest/types/server.go
@@ -1,0 +1,8 @@
+package types
+
+// ServerConfig represents the mutable fields of an additional network listener.
+type ServerConfig struct {
+	// Address is the server listen address.
+	// Example: 127.0.0.1:9000
+	Address AddrPort `json:"address" yaml:"address"`
+}


### PR DESCRIPTION
This PR adds missing features to the additional network listeners feature:

1. **Add additional servers by name**
   This allows referencing them later when updating their configuration and loading the server certificates
2. **API for setting arbitrary certificates**
   You can now set arbitrary certificates (besides the `cluster` certificate) which allows downstream projects to provide custom certificates. They are distributed across active cluster members and shared between new members joining the cluster .
3. **API to modify additional network listeners**
   The local daemon's config got moved into its own type which allows easy access to downstream components. This is used to allow updating the non-immutable fields of additional network listeners.
4. **Local daemon's config update hook**
   As soon as the local daemon's config receives an update, a new hook is triggered on all other cluster members which allows the entire cluster to be aware of configuration changes on individual members.

Furthermore the following changes have been applied:
* Use locking when accessing the list of the daemon's `extensionServers` field as this one is now accessed during startup and when modifying the additional network listeners.
* Store any additional certificate (besides `cluster`) in it's own `{state-dir}/certificates` directory. 
* Consistently use client structs (for request bodies) from the `rest/types` package. Another type `KeyPair` has been added for certificate management.
* Add helpers to the `Endpoint` type to allow updating and stopping individual endpoints
* A fix that ensures the `/cluster/1.0` endpoint can be called without errors in a pre-init state.

LXD-1174