### PR TITLE
Makefile: the toolchain directive should be better supported now

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,8 +27,6 @@ endif
 update-gomod:
 	go get -t -v -d -u ./...
 	go mod tidy -go=$(GOMIN)
-	# Eliminate toolchain directive in go.mod
-	go get toolchain@none
 
 # Update lxd-generate generated database helpers.
 .PHONY: update-schema


### PR DESCRIPTION
Even Go 1.21 has improved support for it since 1.21.11 (https://github.com/golang/go/issues/62278)