### PR TITLE
Allow empty address for `GET /cluster/1.0`

### DIFF
--- a/internal/rest/resources/api_1.0.go
+++ b/internal/rest/resources/api_1.0.go
@@ -20,7 +20,7 @@ var api10Cmd = rest.Endpoint{
 func api10Get(s *state.State, r *http.Request) response.Response {
 	addrPort, err := types.ParseAddrPort(s.Address().URL.Host)
 	if err != nil {
-		return response.SmartError(err)
+		addrPort = types.AddrPort{}
 	}
 
 	return response.SyncResponse(true, internalTypes.Server{

--- a/rest/types/addrport.go
+++ b/rest/types/addrport.go
@@ -81,6 +81,15 @@ func (a *AddrPort) UnmarshalYAML(unmarshal func(v any) error) error {
 	return nil
 }
 
+// String returns the string representation of the AddrPort, or an empty string if it is empty.
+func (a AddrPort) String() string {
+	if a == (AddrPort{}) {
+		return ""
+	}
+
+	return a.AddrPort.String()
+}
+
 // Strings returns a string slice of the AddrPorts.
 func (a AddrPorts) Strings() []string {
 	addrPortStrs := make([]string, len(a))


### PR DESCRIPTION
This API endpoint should be available at all times to query the daemons' state information. However, if it is not yet initialized, its address may not be set if the project is not using `PreInitListenAddress`. 

In these cases, there is technically no address yet so we can just return an empty `types.AddrPort` instead.

Calling `String()` on this type would return `invalid AddrPort` which I found to be a bit unintuitive so instead the wrapper type has been given its own `String` method which returns an empty string if the AddrPort is empty, and otherwise falls back to the internal `String` implementation.