### PR TITLE
internal/db: Load `StateDir/patch.global.sql` during schema Ensure

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -8,6 +8,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"path"
 	"time"
 
 	"github.com/canonical/lxd/lxd/db/query"
@@ -142,6 +143,8 @@ func (db *DB) waitUpgrade(bootstrap bool, ext extensions.Extensions) error {
 
 	otherNodesBehind := false
 	newSchema := db.Schema()
+	newSchema.File(path.Join(db.os.StateDir, "patch.global.sql"))
+
 	if !bootstrap {
 		checkVersions := func(ctx context.Context, current int, tx *sql.Tx) error {
 			schemaVersionInternal, schemaVersionExternal, _ := newSchema.Version()

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/canonical/microcluster/cluster"
 	"github.com/canonical/microcluster/internal/db/update"
 	"github.com/canonical/microcluster/internal/extensions"
+	"github.com/canonical/microcluster/internal/sys"
 )
 
 type dbSuite struct {
@@ -650,7 +651,12 @@ func (s *dbSuite) Test_waitUpgradeSchemaAndAPI() {
 // NewTedb returns a sqlite DB set up with the default microcluster schema.
 func NewTestDB(extensionsExternal []schema.Update) (*DB, error) {
 	var err error
-	db := &DB{ctx: context.Background(), listenAddr: *api.NewURL().Host("10.0.0.0:8443"), upgradeCh: make(chan struct{}, 1)}
+	db := &DB{
+		ctx:        context.Background(),
+		listenAddr: *api.NewURL().Host("10.0.0.0:8443"),
+		upgradeCh:  make(chan struct{}, 1),
+		os:         &sys.OS{},
+	}
 	db.db, err = sql.Open("sqlite3", ":memory:")
 	if err != nil {
 		return nil, err

--- a/internal/db/update/schema.go
+++ b/internal/db/update/schema.go
@@ -42,6 +42,12 @@ func (s *SchemaUpdate) Fresh(statement string) {
 	s.fresh = statement
 }
 
+// File sets the schema update's path for extra queries to run before schema
+// updates are applied.
+func (s *SchemaUpdate) File(path string) {
+	s.path = path
+}
+
 // Check instructs the schema to invoke the given function whenever Ensure is
 // invoked, before applying any due update. It can be used for aborting the
 // operation.


### PR DESCRIPTION
This is modelled after the same feature in LXD:
  https://github.com/canonical/lxd/blob/34a108012a4b47c045503c9651a37091ddb8bacb/lxd/db/schema/schema.go#L122

This provides a way for an administrator to execute sql during database startup before any schema updates are applied.

It also allows us to queue up changes to the global DB before it has been started (useful during recovery).

LXD-1316