### PR TITLE
Address changes

### DIFF
--- a/example/cmd/microctl/cluster_members.go
+++ b/example/cmd/microctl/cluster_members.go
@@ -39,7 +39,6 @@ const recoveryYamlComment = `# Member roles can be modified. Unrecoverable nodes
 # - the number of members changes
 # - the name of any member changes
 # - the ID of any member changes
-# - the address of any member changes
 # - no changes are made
 `
 

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -44,13 +44,13 @@ func (db *DB) Open(ext extensions.Extensions, bootstrap bool, project string) er
 
 	err := db.dqlite.Ready(ctx)
 	if err != nil {
-		return err
+		return fmt.Errorf("Ready dqlite: %w", err)
 	}
 
 	if db.db == nil {
 		db.db, err = db.dqlite.Open(db.ctx, db.dbName)
 		if err != nil {
-			return err
+			return fmt.Errorf("Open dqlite: %w", err)
 		}
 	}
 

--- a/internal/recover/recover.go
+++ b/internal/recover/recover.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net/netip"
 	"os"
 	"path"
 	"path/filepath"
@@ -23,9 +24,11 @@ import (
 
 	"github.com/canonical/microcluster/client"
 	"github.com/canonical/microcluster/cluster"
+	"github.com/canonical/microcluster/internal/config"
 	internalTypes "github.com/canonical/microcluster/internal/rest/types"
 	"github.com/canonical/microcluster/internal/sys"
 	"github.com/canonical/microcluster/internal/trust"
+	"github.com/canonical/microcluster/rest/types"
 )
 
 // GetDqliteClusterMembers parses the trust store and
@@ -153,12 +156,50 @@ func RecoverFromQuorumLoss(filesystem *sys.OS, members []cluster.DqliteMember) (
 	}
 
 	// Tar up the m.FileSystem.DatabaseDir and write to `dbExportPath`
-	recoveryTarballPath, err := createRecoveryTarball(filesystem)
+	recoveryTarballPath, err := createRecoveryTarball(filesystem, members)
 	if err != nil {
 		return "", err
 	}
 
+	err = updateTrustStore(filesystem.TrustDir, members)
+	if err != nil {
+		return recoveryTarballPath, fmt.Errorf("Failed to update trust store: %w", err)
+	}
+
+	err = writeGlobalMembersPatch(filesystem, members)
+	if err != nil {
+		return recoveryTarballPath, fmt.Errorf("Failed to write global DB update: %w", err)
+	}
+
 	return recoveryTarballPath, nil
+}
+
+func readYaml(path string, v any) error {
+	yml, err := os.ReadFile(path)
+	if err != nil {
+		return err
+	}
+
+	err = yaml.Unmarshal(yml, v)
+	if err != nil {
+		return fmt.Errorf("Unmarshal %q: %w", path, err)
+	}
+
+	return nil
+}
+
+func writeYaml(path string, v any) error {
+	yml, err := yaml.Marshal(v)
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(path, yml, os.FileMode(0o644))
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // ReadTrustStore parses the trust store. This is not thread safe!
@@ -167,6 +208,40 @@ func readTrustStore(dir string) (*trust.Remotes, error) {
 	err := remotes.Load(dir)
 
 	return remotes, err
+}
+
+// Update the trust store with the new member addresses.
+func updateTrustStore(dir string, members []cluster.DqliteMember) error {
+	remotes, err := readTrustStore(dir)
+	if err != nil {
+		return err
+	}
+
+	remotesByName := remotes.RemotesByName()
+
+	trustMembers := make([]types.ClusterMember, 0, len(members))
+	for _, member := range members {
+		cert := remotesByName[member.Name].Certificate
+		addr, err := netip.ParseAddrPort(member.Address)
+		if err != nil {
+			return fmt.Errorf("Invalid address %q: %w", member.Address, err)
+		}
+
+		trustMembers = append(trustMembers, types.ClusterMember{
+			ClusterMemberLocal: types.ClusterMemberLocal{
+				Name:        member.Name,
+				Address:     types.AddrPort{AddrPort: addr},
+				Certificate: cert,
+			},
+		})
+	}
+
+	err = remotes.Replace(dir, trustMembers...)
+	if err != nil {
+		return fmt.Errorf("Update trust store at %q: %w", dir, err)
+	}
+
+	return nil
 }
 
 // ValidateMemberChanges compares two arrays of members to ensure:
@@ -180,10 +255,8 @@ func ValidateMemberChanges(oldMembers []cluster.DqliteMember, newMembers []clust
 	for _, newMember := range newMembers {
 		memberValid := false
 		for _, oldMember := range oldMembers {
-			// FIXME: Allow changing member addresses as part of cluster recovery
 			membersMatch := newMember.DqliteID == oldMember.DqliteID &&
-				newMember.Name == oldMember.Name &&
-				newMember.Address == oldMember.Address
+				newMember.Name == oldMember.Name
 
 			if membersMatch {
 				memberValid = true
@@ -192,7 +265,36 @@ func ValidateMemberChanges(oldMembers []cluster.DqliteMember, newMembers []clust
 		}
 
 		if !memberValid {
-			return fmt.Errorf("ID or address changed for member %s", newMember.Name)
+			return fmt.Errorf("ID or name changed for member %s", newMember.Name)
+		}
+	}
+
+	return nil
+}
+
+func writeGlobalMembersPatch(filesystem *sys.OS, members []cluster.DqliteMember) error {
+	sql := ""
+	for _, member := range members {
+		sql += fmt.Sprintf("UPDATE core_cluster_members SET address = %q WHERE name = %q;\n", member.Address, member.Name)
+	}
+
+	if len(sql) > 0 {
+		patchPath := path.Join(filesystem.StateDir, "patch.global.sql")
+		patchFile, err := os.OpenFile(patchPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			return err
+		}
+
+		defer func() { _ = patchFile.Close() }()
+
+		count, err := patchFile.Write([]byte(sql))
+		if err != nil || len(sql) != count {
+			return err
+		}
+
+		err = patchFile.Close()
+		if err != nil {
+			return err
 		}
 	}
 
@@ -202,14 +304,21 @@ func ValidateMemberChanges(oldMembers []cluster.DqliteMember, newMembers []clust
 // CreateRecoveryTarball writes a tarball of filesystem.DatabaseDir to
 // filesystem.StateDir.
 // go-dqlite's info.yaml is excluded from the tarball.
+// The new cluster configuration is included as `recovery.yaml`.
 // This function returns the path to the tarball.
-func createRecoveryTarball(filesystem *sys.OS) (string, error) {
+func createRecoveryTarball(filesystem *sys.OS, members []cluster.DqliteMember) (string, error) {
 	tarballPath := path.Join(filesystem.StateDir, "recovery_db.tar.gz")
+	recoveryYamlPath := path.Join(filesystem.DatabaseDir, "recovery.yaml")
+
+	err := writeYaml(recoveryYamlPath, members)
+	if err != nil {
+		return "", err
+	}
 
 	// info.yaml is used by go-dqlite to keep track of the current cluster member's
 	// ID and address. We shouldn't replicate the recovery member's info.yaml
 	// to all other members, so exclude it from the tarball:
-	err := createTarball(tarballPath, filesystem.DatabaseDir, ".", []string{"info.yaml"})
+	err = createTarball(tarballPath, filesystem.DatabaseDir, ".", []string{"info.yaml"})
 
 	return tarballPath, err
 }
@@ -221,6 +330,7 @@ func createRecoveryTarball(filesystem *sys.OS) (string, error) {
 func MaybeUnpackRecoveryTarball(filesystem *sys.OS) error {
 	tarballPath := path.Join(filesystem.StateDir, "recovery_db.tar.gz")
 	unpackDir := path.Join(filesystem.StateDir, "recovery_db")
+	recoveryYamlPath := path.Join(unpackDir, "recovery.yaml")
 
 	// Determine if the recovery tarball exists
 	if _, err := os.Stat(tarballPath); errors.Is(err, os.ErrNotExist) {
@@ -234,43 +344,44 @@ func MaybeUnpackRecoveryTarball(filesystem *sys.OS) error {
 		return err
 	}
 
-	// sanity check: valid cluster.yaml in the incoming DB dir
-	clusterYamlPath := path.Join(unpackDir, "cluster.yaml")
-	incomingNodeInfo, err := dumpYamlNodeStore(clusterYamlPath)
-	if err != nil {
-		return err
-	}
-
-	// use the local info.yaml so that the dqlite ID is preserved on each
-	// cluster member
+	// We need to set the local info.yaml address with the (possibly changed)
+	// incoming address for this member.
 	localInfoYamlPath := path.Join(filesystem.DatabaseDir, "info.yaml")
 	recoveryInfoYamlPath := path.Join(unpackDir, "info.yaml")
 
-	localInfoYaml, err := os.ReadFile(localInfoYamlPath)
+	var localInfo dqlite.NodeInfo
+	err = readYaml(localInfoYamlPath, &localInfo)
 	if err != nil {
 		return err
 	}
 
-	var localInfo dqlite.NodeInfo
-	err = yaml.Unmarshal(localInfoYaml, &localInfo)
+	var incomingMembers []cluster.DqliteMember
+	err = readYaml(recoveryYamlPath, &incomingMembers)
 	if err != nil {
-		return fmt.Errorf("invalid %q", localInfoYamlPath)
+		return nil
 	}
 
 	found := false
-	for _, incomingInfo := range incomingNodeInfo {
-		found = localInfo.ID == incomingInfo.ID
+	for _, incomingInfo := range incomingMembers {
+		found = localInfo.ID == incomingInfo.DqliteID
 
 		if found {
+			localInfo.Address = incomingInfo.Address
 			break
 		}
 	}
 
 	if !found {
-		return fmt.Errorf("missing local cluster member in incoming cluster.yaml")
+		return fmt.Errorf("Missing local cluster member in incoming recovery.yaml")
 	}
 
-	err = os.WriteFile(recoveryInfoYamlPath, localInfoYaml, 0o664)
+	err = writeYaml(recoveryInfoYamlPath, localInfo)
+	if err != nil {
+		return err
+	}
+
+	// Update the local trust store with the incoming cluster configuration
+	err = updateTrustStore(filesystem.TrustDir, incomingMembers)
 	if err != nil {
 		return err
 	}
@@ -287,6 +398,11 @@ func MaybeUnpackRecoveryTarball(filesystem *sys.OS) error {
 		return err
 	}
 
+	err = os.Remove(recoveryYamlPath)
+	if err != nil {
+		return err
+	}
+
 	err = os.Rename(unpackDir, filesystem.DatabaseDir)
 	if err != nil {
 		return err
@@ -296,6 +412,24 @@ func MaybeUnpackRecoveryTarball(filesystem *sys.OS) error {
 	err = os.Remove(tarballPath)
 	if err != nil {
 		return err
+	}
+
+	// Update daemon.yaml
+	newAddress, err := types.ParseAddrPort(localInfo.Address)
+	if err != nil {
+		return fmt.Errorf("Failed to update daemon.yaml: %w", err)
+	}
+
+	daemonConfig := config.NewDaemonConfig(path.Join(filesystem.StateDir, "daemon.yaml"))
+	err = daemonConfig.Load()
+	if err != nil {
+		return fmt.Errorf("Failed to load daemon.yaml: %w", err)
+	}
+
+	daemonConfig.SetAddress(newAddress)
+	err = daemonConfig.Write()
+	if err != nil {
+		return fmt.Errorf("Failed to update daemon.yaml: %w", err)
 	}
 
 	return nil

--- a/internal/recover/recover.go
+++ b/internal/recover/recover.go
@@ -17,7 +17,6 @@ import (
 	"time"
 
 	"github.com/canonical/go-dqlite"
-	dqliteClient "github.com/canonical/go-dqlite/client"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 	"gopkg.in/yaml.v3"
@@ -35,7 +34,9 @@ import (
 // path.Join(filesystem.DatabaseDir, "cluster.yaml").
 func GetDqliteClusterMembers(filesystem *sys.OS) ([]cluster.DqliteMember, error) {
 	storePath := path.Join(filesystem.DatabaseDir, "cluster.yaml")
-	nodeInfo, err := dumpYamlNodeStore(storePath)
+
+	var nodeInfo []dqlite.NodeInfo
+	err := readYaml(storePath, &nodeInfo)
 	if err != nil {
 		return nil, err
 	}
@@ -62,20 +63,6 @@ func GetDqliteClusterMembers(filesystem *sys.OS) ([]cluster.DqliteMember, error)
 	}
 
 	return members, nil
-}
-
-func dumpYamlNodeStore(path string) ([]dqlite.NodeInfo, error) {
-	store, err := dqliteClient.NewYamlNodeStore(path)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to read %q: %w", path, err)
-	}
-
-	nodeInfo, err := store.Get(context.Background())
-	if err != nil {
-		return nil, fmt.Errorf("Failed to read from node store: %w", err)
-	}
-
-	return nodeInfo, nil
 }
 
 // RecoverFromQuorumLoss resets the dqlite raft log, rewrites the go-dqlite yaml

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -250,14 +250,12 @@ func (m *MicroCluster) GetDqliteClusterMembers() ([]cluster.DqliteMember, error)
 // recovery operation.
 //
 // RecoverFromQuorumLoss should be invoked _exactly once_ for the entire cluster.
-// This function creates a gz-compressed tarball
-// path.Join(m.FileSystem.StateDir, "recovery_db.tar.gz"). This tarball should
-// be manually copied by the user to the state dir of all other cluster members.
+// This function creates a gz-compressed tarball and returns its path. This
+// tarball should be manually copied by the user to the state dir of all other
+// cluster members.
 //
 // On start, Microcluster will automatically check for & load the recovery
 // tarball. A database backup will be taken before the load.
-//
-// RecoverFromQuorumLoss returns the path to the recovery tarball.
 func (m *MicroCluster) RecoverFromQuorumLoss(members []cluster.DqliteMember) (string, error) {
 	// Double check to make sure the cluster configuration has actually changed
 	oldMembers, err := m.GetDqliteClusterMembers()


### PR DESCRIPTION
Allows address changes during cluster recovery.

The PR:
- Moves the rest of the recovery code into `internal/recover` instead of being awkwardly split between `microcluster/app.go` and the recover package
- Adds address updates for:
  - `daemon.yaml`
  - The trust store
  - `database/info.yaml`
  - `database/cluster.yaml`
  - The global database (via `patch.global.sql`)

I'm not a massive fan of  rewriting both `info.yaml` and `cluster.yaml` (owned by go-dqlite) but `dqlite.App` won't start otherwise (see 741e6939a3b0927fa87717f72628198092191707 for details). We also need to update `info.yaml` on every member, so I can't PR against go-dqlite unless we move most of the recovery tarball handling too.

@masnax Not sure what your review process looks like but my feeling is Tom would prefer smaller commits than these. Let me know if you'd like a more granular refactor.