### PR TITLE
internal/rest/resources: Improve join logic to handle unreachable nodes

### DIFF
--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -129,12 +129,14 @@ func joinWithToken(state state.State, r *http.Request, req *internalTypes.Contro
 
 		cert, err := shared.GetRemoteCertificate(url.String(), "")
 		if err != nil {
-			return response.SmartError(fmt.Errorf("Failed to get certificate of cluster member %q: %w", url.URL.Host, err))
+			logger.Warn("Failed to get certificate of cluster member", logger.Ctx{"address": url.String(), "error": err})
+			continue
 		}
 
 		fingerprint := shared.CertFingerprint(cert)
 		if fingerprint != token.Fingerprint {
-			return response.SmartError(fmt.Errorf("Cluster certificate token does not match that of cluster member %q", url.URL.Host))
+			logger.Warn("Cluster certificate token does not match that of cluster member", logger.Ctx{"address": url.String(), "fingerprint": fingerprint, "expected": token.Fingerprint})
+			continue
 		}
 
 		d, err := client.New(*url, state.ServerCert(), cert, false)


### PR DESCRIPTION
Fixes an issue where the join process would fail if a node in the join_address list is unreachable.

When a token is created, it includes the IP addresses of all nodes in the cluster. If a node is removed between the token creation and joining, the join process previously failed because it tried to connect to the non-existent node.

Now, the client discovery logic will continue attempting to connect to other nodes in the join_address list instead of failing early. This ensures that the join process can succeed as long as at least one node is reachable.