### PR TITLE
Manage hook lifecycles with context

### DIFF
--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -2,6 +2,7 @@
 package main
 
 import (
+	"context"
 	"os"
 
 	"github.com/canonical/lxd/shared/logger"
@@ -76,7 +77,7 @@ func (c *cmdDaemon) run(cmd *cobra.Command, args []string) error {
 	// exampleHooks are some example post-action hooks that can be run by MicroCluster.
 	exampleHooks := &state.Hooks{
 		// PostBootstrap is run after the daemon is initialized and bootstrapped.
-		PostBootstrap: func(s state.State, initConfig map[string]string) error {
+		PostBootstrap: func(ctx context.Context, s state.State, initConfig map[string]string) error {
 			logCtx := logger.Ctx{}
 			for k, v := range initConfig {
 				logCtx[k] = v
@@ -101,7 +102,7 @@ func (c *cmdDaemon) run(cmd *cobra.Command, args []string) error {
 			return nil
 		},
 
-		PreBootstrap: func(s state.State, initConfig map[string]string) error {
+		PreBootstrap: func(ctx context.Context, s state.State, initConfig map[string]string) error {
 			logCtx := logger.Ctx{}
 			for k, v := range initConfig {
 				logCtx[k] = v
@@ -114,14 +115,14 @@ func (c *cmdDaemon) run(cmd *cobra.Command, args []string) error {
 		},
 
 		// OnStart is run after the daemon is started.
-		OnStart: func(s state.State) error {
+		OnStart: func(ctx context.Context, s state.State) error {
 			logger.Info("This is a hook that runs after the daemon first starts")
 
 			return nil
 		},
 
 		// PostJoin is run after the daemon is initialized and joins a cluster.
-		PostJoin: func(s state.State, initConfig map[string]string) error {
+		PostJoin: func(ctx context.Context, s state.State, initConfig map[string]string) error {
 			logCtx := logger.Ctx{}
 			for k, v := range initConfig {
 				logCtx[k] = v
@@ -134,7 +135,7 @@ func (c *cmdDaemon) run(cmd *cobra.Command, args []string) error {
 		},
 
 		// PreJoin is run after the daemon is initialized and joins a cluster.
-		PreJoin: func(s state.State, initConfig map[string]string) error {
+		PreJoin: func(ctx context.Context, s state.State, initConfig map[string]string) error {
 			logCtx := logger.Ctx{}
 			for k, v := range initConfig {
 				logCtx[k] = v
@@ -147,35 +148,35 @@ func (c *cmdDaemon) run(cmd *cobra.Command, args []string) error {
 		},
 
 		// PostRemove is run after the daemon is removed from a cluster.
-		PostRemove: func(s state.State, force bool) error {
+		PostRemove: func(ctx context.Context, s state.State, force bool) error {
 			logger.Infof("This is a hook that is run on peer %q after a cluster member is removed, with the force flag set to %v", s.Name(), force)
 
 			return nil
 		},
 
 		// PreRemove is run before the daemon is removed from the cluster.
-		PreRemove: func(s state.State, force bool) error {
+		PreRemove: func(ctx context.Context, s state.State, force bool) error {
 			logger.Infof("This is a hook that is run on peer %q just before it is removed, with the force flag set to %v", s.Name(), force)
 
 			return nil
 		},
 
 		// OnHeartbeat is run after a successful heartbeat round.
-		OnHeartbeat: func(s state.State) error {
+		OnHeartbeat: func(ctx context.Context, s state.State) error {
 			logger.Info("This is a hook that is run on the dqlite leader after a successful heartbeat")
 
 			return nil
 		},
 
 		// OnNewMember is run after a new member has joined.
-		OnNewMember: func(s state.State, newMember types.ClusterMemberLocal) error {
+		OnNewMember: func(ctx context.Context, s state.State, newMember types.ClusterMemberLocal) error {
 			logger.Infof("This is a hook that is run on peer %q when the new cluster member %q has joined", s.Name(), newMember.Name)
 
 			return nil
 		},
 
 		// OnDaemonConfigUpdate is run after the local daemon config of a cluster member got modified.
-		OnDaemonConfigUpdate: func(s state.State, config types.DaemonConfig) error {
+		OnDaemonConfigUpdate: func(ctx context.Context, s state.State, config types.DaemonConfig) error {
 			logger.Infof("Running OnDaemonConfigUpdate triggered by %q", config.Name)
 
 			return nil

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -296,11 +296,11 @@ func (d *Daemon) init(listenAddress string, schemaExtensions []schema.Update, ap
 
 func (d *Daemon) applyHooks(hooks *state.Hooks) {
 	// Apply a no-op hooks for any missing hooks.
-	noOpHook := func(s state.State) error { return nil }
-	noOpRemoveHook := func(s state.State, force bool) error { return nil }
-	noOpInitHook := func(s state.State, initConfig map[string]string) error { return nil }
-	noOpConfigHook := func(s state.State, config types.DaemonConfig) error { return nil }
-	noOpNewMemberHook := func(s state.State, newMember types.ClusterMemberLocal) error { return nil }
+	noOpHook := func(ctx context.Context, s state.State) error { return nil }
+	noOpRemoveHook := func(ctx context.Context, s state.State, force bool) error { return nil }
+	noOpInitHook := func(ctx context.Context, s state.State, initConfig map[string]string) error { return nil }
+	noOpConfigHook := func(ctx context.Context, s state.State, config types.DaemonConfig) error { return nil }
+	noOpNewMemberHook := func(ctx context.Context, s state.State, newMember types.ClusterMemberLocal) error { return nil }
 
 	if hooks == nil {
 		d.hooks = state.Hooks{}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -375,7 +375,7 @@ func (d *Daemon) reloadIfBootstrapped() error {
 		return fmt.Errorf("Failed to retrieve daemon configuration yaml: %w", err)
 	}
 
-	err = d.StartAPI(false, nil, nil)
+	err = d.StartAPI(d.shutdownCtx, false, nil, nil)
 	if err != nil {
 		return err
 	}
@@ -445,7 +445,7 @@ func (d *Daemon) initServer(resources ...rest.Resources) *http.Server {
 
 // StartAPI starts up the admin and consumer APIs, and generates a cluster cert
 // if we are bootstrapping the first node.
-func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfig *trust.Location, joinAddresses ...string) error {
+func (d *Daemon) StartAPI(ctx context.Context, bootstrap bool, initConfig map[string]string, newConfig *trust.Location, joinAddresses ...string) error {
 	if newConfig != nil {
 		d.config.SetAddress(newConfig.Address)
 		d.config.SetName(newConfig.Name)
@@ -463,7 +463,9 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 	}
 
 	if bootstrap {
-		err := d.hooks.PreBootstrap(d.State(), initConfig)
+		ctx, cancel := context.WithCancel(ctx)
+		err := d.hooks.PreBootstrap(ctx, d.State(), initConfig)
+		cancel()
 		if err != nil {
 			return fmt.Errorf("Failed to run pre-bootstrap hook before starting the API: %w", err)
 		}
@@ -548,7 +550,9 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 			return err
 		}
 
-		err = d.hooks.PostBootstrap(d.State(), initConfig)
+		ctx, cancel := context.WithCancel(ctx)
+		err = d.hooks.PostBootstrap(ctx, d.State(), initConfig)
+		cancel()
 		if err != nil {
 			return fmt.Errorf("Failed to run post-bootstrap actions: %w", err)
 		}
@@ -587,7 +591,9 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 
 	localMemberInfo := types.ClusterMemberLocal{Name: localNode.Name, Address: localNode.Address, Certificate: localNode.Certificate}
 	if len(joinAddresses) > 0 {
-		err = d.hooks.PreJoin(d.State(), initConfig)
+		ctx, cancel := context.WithCancel(ctx)
+		err = d.hooks.PreJoin(ctx, d.State(), initConfig)
+		cancel()
 		if err != nil {
 			return err
 		}
@@ -666,7 +672,10 @@ func (d *Daemon) StartAPI(bootstrap bool, initConfig map[string]string, newConfi
 	}
 
 	if len(joinAddresses) > 0 {
-		return d.hooks.PostJoin(d.State(), initConfig)
+		ctx, cancel := context.WithCancel(ctx)
+		defer cancel()
+
+		return d.hooks.PostJoin(ctx, d.State(), initConfig)
 	}
 
 	return nil

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -171,7 +171,7 @@ func (d *Daemon) Run(ctx context.Context, listenAddress string, stateDir string,
 		return fmt.Errorf("Daemon failed to start: %w", err)
 	}
 
-	err = d.hooks.OnStart(d.State())
+	err = d.hooks.OnStart(d.shutdownCtx, d.State())
 	if err != nil {
 		return fmt.Errorf("Failed to run post-start hook: %w", err)
 	}

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -627,7 +627,9 @@ func clusterMemberDelete(s state.State, r *http.Request) response.Response {
 	}
 
 	// Run the PostRemove hook locally.
-	err = intState.Hooks.PostRemove(s, force)
+	hookCtx, hookCancel := context.WithCancel(r.Context())
+	err = intState.Hooks.PostRemove(hookCtx, s, force)
+	hookCancel()
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -76,7 +76,7 @@ func controlPost(state state.State, r *http.Request) response.Response {
 	}
 
 	daemonConfig := &trust.Location{Address: req.Address, Name: req.Name}
-	err = intState.StartAPI(req.Bootstrap, req.InitConfig, daemonConfig)
+	err = intState.StartAPI(r.Context(), req.Bootstrap, req.InitConfig, daemonConfig)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -226,7 +226,7 @@ func joinWithToken(state state.State, r *http.Request, req *internalTypes.Contro
 	}
 
 	// Start the HTTPS listeners and join Dqlite.
-	err = intState.StartAPI(false, req.InitConfig, daemonConfig, joinAddrs.Strings()...)
+	err = intState.StartAPI(r.Context(), false, req.InitConfig, daemonConfig, joinAddrs.Strings()...)
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/internal/rest/resources/heartbeat.go
+++ b/internal/rest/resources/heartbeat.go
@@ -287,7 +287,9 @@ func beginHeartbeat(s state.State, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	err = intState.Hooks.OnHeartbeat(s)
+	hookCtx, hookCancel := context.WithCancel(r.Context())
+	err = intState.Hooks.OnHeartbeat(hookCtx, s)
+	hookCancel()
 	if err != nil {
 		return response.SmartError(err)
 	}

--- a/internal/rest/resources/hooks_test.go
+++ b/internal/rest/resources/hooks_test.go
@@ -35,19 +35,19 @@ func (t *hooksSuite) Test_hooks() {
 		Context:      context.TODO(),
 		InternalName: func() string { return "n0" },
 		Hooks: &state.Hooks{
-			PostRemove: func(state state.State, force bool) error {
+			PostRemove: func(ctx context.Context, state state.State, force bool) error {
 				ranHook = internalTypes.PostRemove
 				isForce = force
 				return nil
 			},
 
-			PreRemove: func(state state.State, force bool) error {
+			PreRemove: func(ctx context.Context, state state.State, force bool) error {
 				ranHook = internalTypes.PreRemove
 				isForce = force
 				return nil
 			},
 
-			OnNewMember: func(state state.State, newMember types.ClusterMemberLocal) error {
+			OnNewMember: func(ctx context.Context, state state.State, newMember types.ClusterMemberLocal) error {
 				ranHook = internalTypes.OnNewMember
 				return nil
 			},

--- a/internal/state/hooks.go
+++ b/internal/state/hooks.go
@@ -1,6 +1,8 @@
 package state
 
 import (
+	"context"
+
 	"github.com/canonical/microcluster/rest/types"
 )
 
@@ -8,34 +10,34 @@ import (
 // integrate with other tools.
 type Hooks struct {
 	// PreBootstrap is run before the daemon is initialized and bootstrapped.
-	PreBootstrap func(s State, initConfig map[string]string) error
+	PreBootstrap func(ctx context.Context, s State, initConfig map[string]string) error
 
 	// PostBootstrap is run after the daemon is initialized and bootstrapped.
-	PostBootstrap func(s State, initConfig map[string]string) error
+	PostBootstrap func(ctx context.Context, s State, initConfig map[string]string) error
 
 	// OnStart is run after the daemon is started.
-	OnStart func(s State) error
+	OnStart func(ctx context.Context, s State) error
 
 	// PostJoin is run after the daemon is initialized, joined the cluster and existing members triggered
 	// their 'OnNewMember' hooks.
-	PostJoin func(s State, initConfig map[string]string) error
+	PostJoin func(ctx context.Context, s State, initConfig map[string]string) error
 
 	// PreJoin is run after the daemon is initialized and joined the cluster but before existing members triggered
 	// their 'OnNewMember' hooks.
-	PreJoin func(s State, initConfig map[string]string) error
+	PreJoin func(ctx context.Context, s State, initConfig map[string]string) error
 
 	// PreRemove is run on a cluster member just before it is removed from the cluster.
-	PreRemove func(s State, force bool) error
+	PreRemove func(ctx context.Context, s State, force bool) error
 
 	// PostRemove is run on all other peers after one is removed from the cluster.
-	PostRemove func(s State, force bool) error
+	PostRemove func(ctx context.Context, s State, force bool) error
 
 	// OnHeartbeat is run after a successful heartbeat round.
-	OnHeartbeat func(s State) error
+	OnHeartbeat func(ctx context.Context, s State) error
 
 	// OnNewMember is run on each peer after a new cluster member has joined and executed their 'PreJoin' hook.
-	OnNewMember func(s State, newMember types.ClusterMemberLocal) error
+	OnNewMember func(ctx context.Context, s State, newMember types.ClusterMemberLocal) error
 
 	// OnDaemonConfigUpdate is a post-action hook that is run on all cluster members when any cluster member receives a local configuration update.
-	OnDaemonConfigUpdate func(s State, config types.DaemonConfig) error
+	OnDaemonConfigUpdate func(ctx context.Context, s State, config types.DaemonConfig) error
 }

--- a/internal/state/hooks.go
+++ b/internal/state/hooks.go
@@ -15,7 +15,7 @@ type Hooks struct {
 	// PostBootstrap is run after the daemon is initialized and bootstrapped.
 	PostBootstrap func(ctx context.Context, s State, initConfig map[string]string) error
 
-	// OnStart is run after the daemon is started.
+	// OnStart is run after the daemon is started. Its context will not be cancelled until the daemon is shutting down.
 	OnStart func(ctx context.Context, s State) error
 
 	// PostJoin is run after the daemon is initialized, joined the cluster and existing members triggered

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -76,7 +76,7 @@ type InternalState struct {
 	LocalConfig func() *internalConfig.DaemonConfig
 
 	// Initialize APIs and bootstrap/join database.
-	StartAPI func(bootstrap bool, initConfig map[string]string, newConfig *trust.Location, joinAddresses ...string) error
+	StartAPI func(ctx context.Context, bootstrap bool, initConfig map[string]string, newConfig *trust.Location, joinAddresses ...string) error
 
 	// Update the additional listeners.
 	UpdateServers func() error


### PR DESCRIPTION
Since we are no longer exposing `state.Context`, we need to pass a context as argument to each hook to manage its lifetime.

For most hooks, this means their parent context is the request context for the API that triggered the hook. The actual context passed to the hook will be cancelled immediately after the hook returns. This is to discourage long-lived goroutines running in these hooks.


The exception is `OnStart`. For `OnStart`, which is intended to start services that work with microcluster, the lifetime should be equivalent to the daemon itself. So the shutdown context of the daemon is supplied to this hook. Its comment has been updated to reference this.