### PR TITLE
Go: Consistently use `gopkg.in/yaml.v3`

### DIFF
--- a/example/cmd/microctl/cluster_members.go
+++ b/example/cmd/microctl/cluster_members.go
@@ -15,7 +15,7 @@ import (
 	"github.com/canonical/lxd/shared/termios"
 	"github.com/spf13/cobra"
 	"golang.org/x/sys/unix"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/microcluster/client"
 	"github.com/canonical/microcluster/cluster"

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/spf13/cobra v1.8.1
 	github.com/stretchr/testify v1.9.0
 	golang.org/x/sys v0.22.0
-	gopkg.in/yaml.v2 v2.4.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -56,5 +56,5 @@ require (
 	golang.org/x/term v0.22.0 // indirect
 	golang.org/x/text v0.16.0 // indirect
 	gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )

--- a/internal/recover/recover.go
+++ b/internal/recover/recover.go
@@ -17,7 +17,7 @@ import (
 
 	dqlite "github.com/canonical/go-dqlite/client"
 	"github.com/canonical/lxd/shared/logger"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/microcluster/cluster"
 	"github.com/canonical/microcluster/internal/sys"

--- a/internal/trust/remotes.go
+++ b/internal/trust/remotes.go
@@ -14,7 +14,7 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/google/renameio"
-	"gopkg.in/yaml.v2"
+	"gopkg.in/yaml.v3"
 
 	"github.com/canonical/microcluster/client"
 	internalClient "github.com/canonical/microcluster/internal/rest/client"


### PR DESCRIPTION
In the code we are using different versions (v2 and v3) of the yaml dependency.

This should fix future automatic PRs like https://github.com/canonical/microcluster/pull/183 as `v3` was also listed as indirect dependency.

Fixes https://github.com/canonical/microcluster/pull/183.