### PR TITLE
Use daemon context for bootstrap hooks

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -463,9 +463,7 @@ func (d *Daemon) StartAPI(ctx context.Context, bootstrap bool, initConfig map[st
 	}
 
 	if bootstrap {
-		ctx, cancel := context.WithCancel(ctx)
-		err := d.hooks.PreBootstrap(ctx, d.State(), initConfig)
-		cancel()
+		err := d.hooks.PreBootstrap(d.shutdownCtx, d.State(), initConfig)
 		if err != nil {
 			return fmt.Errorf("Failed to run pre-bootstrap hook before starting the API: %w", err)
 		}
@@ -550,9 +548,7 @@ func (d *Daemon) StartAPI(ctx context.Context, bootstrap bool, initConfig map[st
 			return err
 		}
 
-		ctx, cancel := context.WithCancel(ctx)
-		err = d.hooks.PostBootstrap(ctx, d.State(), initConfig)
-		cancel()
+		err = d.hooks.PostBootstrap(d.shutdownCtx, d.State(), initConfig)
 		if err != nil {
 			return fmt.Errorf("Failed to run post-bootstrap actions: %w", err)
 		}


### PR DESCRIPTION
Follow-up on https://github.com/canonical/microcluster/pull/190

We require the daemon context to perform cleanup tasks which are performed in a separate Go-routine. See https://github.com/canonical/k8s-snap/blob/ede6335f40969b8d1846e528b8376b20190b5921/src/k8s/pkg/k8sd/app/hooks_bootstrap.go#L62-L91

While I understand that long-running tasks are discouraged in those hooks once the daemon is set up, I think it makes sense to have the daemons lifecycle context for setup hooks