### PR TITLE
internal/rest/resources: Reset the daemon if bootstrapping fails

### DIFF
--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -91,6 +91,14 @@ func controlPost(state state.State, r *http.Request) response.Response {
 
 		// Re-exec the daemon to clear any remaining state.
 		go reExec()
+
+		// Run the pre-remove hook like we do for cluster node removals.
+		err = intState.Hooks.PreRemove(r.Context(), state, true)
+		if err != nil {
+			logger.Error("Failed to run pre-remove hook on bootstrap error", logger.Ctx{"error": err})
+
+			return
+		}
 	})
 
 	daemonConfig := &trust.Location{Address: req.Address, Name: req.Name}

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -15,6 +15,7 @@ import (
 	"github.com/canonical/lxd/shared/revert"
 	"github.com/canonical/lxd/shared/validate"
 
+	"github.com/canonical/microcluster/internal/db"
 	"github.com/canonical/microcluster/internal/rest/client"
 	internalTypes "github.com/canonical/microcluster/internal/rest/types"
 	internalState "github.com/canonical/microcluster/internal/state"
@@ -50,6 +51,11 @@ func validateFQDN(name string) error {
 }
 
 func controlPost(state state.State, r *http.Request) response.Response {
+	status := state.Database().Status()
+	if status != db.StatusNotReady {
+		return response.SmartError(fmt.Errorf("Unable to initialize cluster: %s", status))
+	}
+
 	req := &internalTypes.Control{}
 	// Parse the request.
 	err := json.NewDecoder(r.Body).Decode(&req)


### PR DESCRIPTION
We already do this cleanup when a node fails to join the cluster, but we should also try to reset the daemon if bootstrapping fails, so that the node can be easily re-initialized.