### PR TITLE
Harmonize public facing endpoints

### DIFF
--- a/internal/rest/client/client.go
+++ b/internal/rest/client/client.go
@@ -26,23 +26,6 @@ import (
 	"github.com/canonical/microcluster/rest/types"
 )
 
-// EndpointType is a type specifying the endpoint on with the resource exists.
-type EndpointType string
-
-const (
-	// ExtendedEndpoint - All endpoints added managed by external usage of MicroCluster.
-	ExtendedEndpoint EndpointType = "1.0"
-
-	// PublicEndpoint - Internally managed APIs available without authentication.
-	PublicEndpoint EndpointType = "core/1.0"
-
-	// InternalEndpoint - all endpoints restricted to trusted servers.
-	InternalEndpoint EndpointType = "core/internal"
-
-	// ControlEndpoint - all endpoints available on the local unix socket.
-	ControlEndpoint EndpointType = "core/control"
-)
-
 // Client is a rest client for the daemon.
 type Client struct {
 	*http.Client

--- a/internal/rest/client/cluster.go
+++ b/internal/rest/client/cluster.go
@@ -67,5 +67,5 @@ func (c *Client) UpdateCertificate(ctx context.Context, name types.CertificateNa
 	defer cancel()
 
 	endpoint := api.NewURL().Path("cluster", "certificates", string(name))
-	return c.QueryStruct(queryCtx, "PUT", internalTypes.InternalEndpoint, endpoint, args, nil)
+	return c.QueryStruct(queryCtx, "PUT", internalTypes.PublicEndpoint, endpoint, args, nil)
 }

--- a/internal/rest/client/cluster.go
+++ b/internal/rest/client/cluster.go
@@ -16,7 +16,7 @@ func (c *Client) AddClusterMember(ctx context.Context, args types.ClusterMember)
 	defer cancel()
 
 	tokenResponse := internalTypes.TokenResponse{}
-	err := c.QueryStruct(queryCtx, "POST", internalTypes.PublicEndpoint, api.NewURL().Path("cluster"), args, &tokenResponse)
+	err := c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, api.NewURL().Path("cluster"), args, &tokenResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -58,7 +58,7 @@ func (c *Client) ResetClusterMember(ctx context.Context, name string, force bool
 		endpoint = endpoint.WithQuery("force", "1")
 	}
 
-	return c.QueryStruct(queryCtx, "PUT", internalTypes.PublicEndpoint, endpoint, nil, nil)
+	return c.QueryStruct(queryCtx, "PUT", internalTypes.InternalEndpoint, endpoint, nil, nil)
 }
 
 // UpdateCertificate sets a new keypair and CA.

--- a/internal/rest/client/daemon.go
+++ b/internal/rest/client/daemon.go
@@ -16,5 +16,5 @@ func (c *Client) UpdateServers(ctx context.Context, config map[string]apiTypes.S
 	defer cancel()
 
 	endpoint := api.NewURL().Path("daemon", "servers")
-	return c.QueryStruct(queryCtx, "PUT", types.InternalEndpoint, endpoint, config, nil)
+	return c.QueryStruct(queryCtx, "PUT", types.PublicEndpoint, endpoint, config, nil)
 }

--- a/internal/rest/client/heartbeat.go
+++ b/internal/rest/client/heartbeat.go
@@ -13,9 +13,9 @@ import (
 const HeartbeatTimeout = 30
 
 // Heartbeat initiates a new heartbeat sequence if this is a leader node.
-func (c *Client) Heartbeat(ctx context.Context, hbInfo types.HeartbeatInfo) error {
+func Heartbeat(ctx context.Context, client *Client, hbInfo types.HeartbeatInfo) error {
 	queryCtx, cancel := context.WithTimeout(ctx, HeartbeatTimeout*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "POST", types.InternalEndpoint, api.NewURL().Path("heartbeat"), hbInfo, nil)
+	return client.QueryStruct(queryCtx, "POST", types.InternalEndpoint, api.NewURL().Path("heartbeat"), hbInfo, nil)
 }

--- a/internal/rest/client/sql.go
+++ b/internal/rest/client/sql.go
@@ -10,7 +10,7 @@ import (
 )
 
 // GetSQL gets a SQL dump of the database.
-func (c *Client) GetSQL(ctx context.Context, schema bool) (*types.SQLDump, error) {
+func GetSQL(ctx context.Context, c *Client, schema bool) (*types.SQLDump, error) {
 	reqCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
@@ -30,7 +30,7 @@ func (c *Client) GetSQL(ctx context.Context, schema bool) (*types.SQLDump, error
 }
 
 // PostSQL executes a SQL query against the database.
-func (c *Client) PostSQL(ctx context.Context, query types.SQLQuery) (*types.SQLBatch, error) {
+func PostSQL(ctx context.Context, c *Client, query types.SQLQuery) (*types.SQLBatch, error) {
 	reqCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 

--- a/internal/rest/client/tokens.go
+++ b/internal/rest/client/tokens.go
@@ -26,7 +26,7 @@ func (c *Client) DeleteTokenRecord(ctx context.Context, name string) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	err := c.QueryStruct(queryCtx, "DELETE", types.InternalEndpoint, api.NewURL().Path("tokens", name), nil, nil)
+	err := c.QueryStruct(queryCtx, "DELETE", types.PublicEndpoint, api.NewURL().Path("tokens", name), nil, nil)
 
 	return err
 }

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -107,7 +107,7 @@ func clusterPost(s state.State, r *http.Request) response.Response {
 			return response.SmartError(err)
 		}
 
-		tokenResponse, err := client.AddClusterMember(r.Context(), req)
+		tokenResponse, err := internalClient.AddClusterMember(r.Context(), &client.Client, req)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -622,7 +622,7 @@ func clusterMemberDelete(s state.State, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	err = c.ResetClusterMember(r.Context(), name, force)
+	err = internalClient.ResetClusterMember(r.Context(), c, name, force)
 	if err != nil && !force {
 		return response.SmartError(err)
 	}

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -40,15 +40,26 @@ var clusterCmd = rest.Endpoint{
 	Path:              "cluster",
 	AllowedBeforeInit: true,
 
+	Get: rest.EndpointAction{Handler: clusterGet, AccessHandler: access.AllowAuthenticated},
+}
+
+var clusterInternalCmd = rest.Endpoint{
+	Path:              "cluster",
+	AllowedBeforeInit: true,
+
 	Post: rest.EndpointAction{Handler: clusterPost, AllowUntrusted: true},
-	Get:  rest.EndpointAction{Handler: clusterGet, AccessHandler: access.AllowAuthenticated},
 }
 
 var clusterMemberCmd = rest.Endpoint{
 	Path: "cluster/{name}",
 
-	Put:    rest.EndpointAction{Handler: clusterMemberPut, AccessHandler: access.AllowAuthenticated},
 	Delete: rest.EndpointAction{Handler: clusterMemberDelete, AccessHandler: access.AllowAuthenticated},
+}
+
+var clusterMemberInternalCmd = rest.Endpoint{
+	Path: "cluster/{name}",
+
+	Put: rest.EndpointAction{Handler: clusterMemberPut, AccessHandler: access.AllowAuthenticated},
 }
 
 func clusterPost(s state.State, r *http.Request) response.Response {

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -16,7 +16,7 @@ import (
 	"github.com/canonical/lxd/shared/validate"
 
 	"github.com/canonical/microcluster/internal/db"
-	"github.com/canonical/microcluster/internal/rest/client"
+	internalClient "github.com/canonical/microcluster/internal/rest/client"
 	internalTypes "github.com/canonical/microcluster/internal/rest/types"
 	internalState "github.com/canonical/microcluster/internal/state"
 	"github.com/canonical/microcluster/internal/trust"
@@ -167,12 +167,12 @@ func joinWithToken(state state.State, r *http.Request, req *internalTypes.Contro
 			continue
 		}
 
-		d, err := client.New(*url, state.ServerCert(), cert, false)
+		d, err := internalClient.New(*url, state.ServerCert(), cert, false)
 		if err != nil {
 			return response.SmartError(err)
 		}
 
-		joinInfo, err = d.AddClusterMember(context.Background(), newClusterMember)
+		joinInfo, err = internalClient.AddClusterMember(context.Background(), d, newClusterMember)
 		if err == nil {
 			break
 		}
@@ -197,7 +197,7 @@ func joinWithToken(state state.State, r *http.Request, req *internalTypes.Contro
 			return
 		}
 
-		client, err := client.New(*url, state.ServerCert(), cert, false)
+		client, err := internalClient.New(*url, state.ServerCert(), cert, false)
 		if err != nil {
 			return
 		}

--- a/internal/rest/resources/heartbeat.go
+++ b/internal/rest/resources/heartbeat.go
@@ -237,7 +237,7 @@ func beginHeartbeat(s state.State, r *http.Request) response.Response {
 			return nil
 		}
 
-		err := c.Heartbeat(ctx, hbInfo)
+		err := internalClient.Heartbeat(ctx, &c.Client, hbInfo)
 		if err != nil {
 			logger.Error("Received error sending heartbeat to cluster member", logger.Ctx{"target": addr, "error": err})
 			return nil

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -26,6 +26,9 @@ var PublicEndpoints = rest.Resources{
 		api10Cmd,
 		clusterCmd,
 		clusterMemberCmd,
+		clusterCertificatesCmd,
+		daemonCmd,
+		tokenCmd,
 		tokensCmd,
 		readyCmd,
 	},
@@ -36,14 +39,11 @@ var InternalEndpoints = rest.Resources{
 	PathPrefix: internalTypes.InternalEndpoint,
 	Endpoints: []rest.Endpoint{
 		databaseCmd,
-		clusterCertificatesCmd,
 		sqlCmd,
-		tokenCmd,
 		heartbeatCmd,
 		trustCmd,
 		trustEntryCmd,
 		hooksCmd,
-		daemonCmd,
 	},
 }
 

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -19,7 +19,7 @@ var UnixEndpoints = rest.Resources{
 	},
 }
 
-// PublicEndpoints are the /cluster/1.0 API endpoints available without authentication.
+// PublicEndpoints are the /core/1.0 API endpoints available at the listen address.
 var PublicEndpoints = rest.Resources{
 	PathPrefix: internalTypes.PublicEndpoint,
 	Endpoints: []rest.Endpoint{
@@ -31,7 +31,7 @@ var PublicEndpoints = rest.Resources{
 	},
 }
 
-// InternalEndpoints are the /cluster/internal API endpoints available at the listen address.
+// InternalEndpoints are the /core/internal API endpoints available at the listen address.
 var InternalEndpoints = rest.Resources{
 	PathPrefix: internalTypes.InternalEndpoint,
 	Endpoints: []rest.Endpoint{

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -24,9 +24,9 @@ var PublicEndpoints = rest.Resources{
 	PathPrefix: internalTypes.PublicEndpoint,
 	Endpoints: []rest.Endpoint{
 		api10Cmd,
+		clusterCertificatesCmd,
 		clusterCmd,
 		clusterMemberCmd,
-		clusterCertificatesCmd,
 		daemonCmd,
 		tokenCmd,
 		tokensCmd,
@@ -38,6 +38,8 @@ var PublicEndpoints = rest.Resources{
 var InternalEndpoints = rest.Resources{
 	PathPrefix: internalTypes.InternalEndpoint,
 	Endpoints: []rest.Endpoint{
+		clusterInternalCmd,
+		clusterMemberInternalCmd,
 		databaseCmd,
 		sqlCmd,
 		heartbeatCmd,

--- a/internal/rest/types/server.go
+++ b/internal/rest/types/server.go
@@ -15,12 +15,12 @@ type Server struct {
 }
 
 const (
-	// PublicEndpoint - Internally managed APIs available without authentication.
-	PublicEndpoint types.EndpointPrefix = "cluster/1.0"
+	// PublicEndpoint - Internally managed APIs.
+	PublicEndpoint types.EndpointPrefix = "core/1.0"
 
-	// InternalEndpoint - all endpoints restricted to trusted servers.
-	InternalEndpoint types.EndpointPrefix = "cluster/internal"
+	// InternalEndpoint - All internal endpoints restricted to trusted servers.
+	InternalEndpoint types.EndpointPrefix = "core/internal"
 
-	// ControlEndpoint - all endpoints available on the local unix socket.
-	ControlEndpoint types.EndpointPrefix = "cluster/control"
+	// ControlEndpoint - All internal endpoints available on the local unix socket.
+	ControlEndpoint types.EndpointPrefix = "core/control"
 )

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -113,16 +113,6 @@ func (m *MicroCluster) AddServers(servers map[string]rest.Server) {
 	m.args.extensionServers = servers
 }
 
-// UpdateServers updates the mutable fields of the additional server configuration.
-func (m *MicroCluster) UpdateServers(ctx context.Context, serversConfig map[string]types.ServerConfig) error {
-	c, err := m.LocalClient()
-	if err != nil {
-		return err
-	}
-
-	return c.UpdateServers(ctx, serversConfig)
-}
-
 // Status returns basic status information about the cluster.
 func (m *MicroCluster) Status(ctx context.Context) (*internalTypes.Server, error) {
 	c, err := m.LocalClient()
@@ -417,15 +407,4 @@ func (m *MicroCluster) SQL(ctx context.Context, query string) (string, *internal
 	batch, err := internalClient.PostSQL(ctx, &c.Client, data)
 
 	return "", batch, err
-}
-
-// UpdateCertificate allows updating the cluster certificate and any additional ones.
-// If you want to update the cluster certificate set name to cluster.
-func (m *MicroCluster) UpdateCertificate(ctx context.Context, name types.CertificateName, keypair types.KeyPair) error {
-	c, err := m.LocalClient()
-	if err != nil {
-		return err
-	}
-
-	return c.UpdateCertificate(ctx, name, keypair)
 }

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -402,7 +402,7 @@ func (m *MicroCluster) SQL(ctx context.Context, query string) (string, *internal
 	}
 
 	if query == ".dump" || query == ".schema" {
-		dump, err := c.GetSQL(ctx, query == ".schema")
+		dump, err := internalClient.GetSQL(ctx, &c.Client, query == ".schema")
 		if err != nil {
 			return "", nil, fmt.Errorf("failed to parse dump response: %w", err)
 		}
@@ -414,7 +414,7 @@ func (m *MicroCluster) SQL(ctx context.Context, query string) (string, *internal
 		Query: query,
 	}
 
-	batch, err := c.PostSQL(ctx, data)
+	batch, err := internalClient.PostSQL(ctx, &c.Client, data)
 
 	return "", batch, err
 }


### PR DESCRIPTION
This PR ensures that all the API endpoints which are used by public facing client functions are also listed under the `/core/1.0` path instead of `/core/internal`.

In addition the PR does the actual rename of `/cluster/(1.0|internal)` to `/core/(1.0|internal)` as https://github.com/canonical/microcluster/pull/137 looks to have modified unused constants. Looks we somehow had duplicate constants in the code base.
I have also moved the public facing `types.ExtendedEndpoint` that represents the `/1.0` prefix into the top level `/rest/types` package.