### PR TITLE
example: Fix bootstrap failure due to unregistered extension

### DIFF
--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -83,11 +83,14 @@ func (c *cmdDaemon) run(cmd *cobra.Command, args []string) error {
 				logCtx[k] = v
 			}
 
-			// You can check your app extensions using the state.State object.
-			hasMissingExt := s.HasExtension("missing_extension")
-			if !hasMissingExt {
-				logger.Warn("The 'missing_extension' is not registered")
-			}
+			/*
+				You can check your app extensions using the state.State object.
+
+				hasMissingExt := s.HasExtension("missing_extension")
+				if !hasMissingExt {
+					logger.Warn("The 'missing_extension' is not registered")
+				}
+			*/
 
 			// You can also check the internal extensions. (starting with "internal:" prefix)
 			// These are read-only and defined at the MicroCluster level and cannot be added at runtime


### PR DESCRIPTION
The example code in `example/README.md` fails to bootstrap with the error: 
"The 'missing_extension' is not registered."
To address this, the example state access code has been commented out to make the example functional again while keeping the code for reference.