### PR TITLE
Bootstrap: Run the PreRemove hook before re-exec

### DIFF
--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -92,6 +92,7 @@ func controlPost(state state.State, r *http.Request) response.Response {
 
 		reExec, err := resetClusterMember(r.Context(), state, true)
 		if err != nil {
+			logger.Error("Failed to reset cluster member on bootstrap error", logger.Ctx{"error": err})
 			return
 		}
 

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -84,6 +84,12 @@ func controlPost(state state.State, r *http.Request) response.Response {
 	reverter := revert.New()
 	defer reverter.Fail()
 	reverter.Add(func() {
+		// Run the pre-remove hook like we do for cluster node removals.
+		err := intState.Hooks.PreRemove(r.Context(), state, true)
+		if err != nil {
+			logger.Error("Failed to run pre-remove hook on bootstrap error", logger.Ctx{"error": err})
+		}
+
 		reExec, err := resetClusterMember(r.Context(), state, true)
 		if err != nil {
 			return
@@ -91,14 +97,6 @@ func controlPost(state state.State, r *http.Request) response.Response {
 
 		// Re-exec the daemon to clear any remaining state.
 		go reExec()
-
-		// Run the pre-remove hook like we do for cluster node removals.
-		err = intState.Hooks.PreRemove(r.Context(), state, true)
-		if err != nil {
-			logger.Error("Failed to run pre-remove hook on bootstrap error", logger.Ctx{"error": err})
-
-			return
-		}
 	})
 
 	daemonConfig := &trust.Location{Address: req.Address, Name: req.Name}


### PR DESCRIPTION
This allows accessing the database from within the hook before
closing the database and re-executing the daemon.