### PR TITLE
Join: Run the PreRemove hook on join failures

### DIFF
--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -190,6 +190,12 @@ func joinWithToken(state state.State, r *http.Request, req *internalTypes.Contro
 	// If at some point we fail to join the cluster, instruct whoever authorized us to remove us from the cluster.
 	// This should also reset our database and listeners.
 	reverter.Add(func() {
+		// Run the pre-remove hook like we do for cluster node removals.
+		err := intState.Hooks.PreRemove(r.Context(), state, true)
+		if err != nil {
+			logger.Error("Failed to run pre-remove hook on join error", logger.Ctx{"error": err})
+		}
+
 		url := api.NewURL().Scheme("https").Host(joinInfo.TrustedMember.Address.String())
 		cert, err := shared.GetRemoteCertificate(url.String(), "")
 		if err != nil {


### PR DESCRIPTION
Execute the PreRemove hook on the node that tried to join. This aligns a failed join with the behavior of a failed bootstrap. With that, PreRemove can generally be used to add custom cleanup logic.