### PR TITLE
Add expiry date column to `core_token_records`

### DIFF
--- a/cluster/token_records.go
+++ b/cluster/token_records.go
@@ -57,7 +57,8 @@ func (t *CoreTokenRecord) ToAPI(clusterCert *x509.Certificate, joinAddresses []t
 	}
 
 	return &internalTypes.TokenRecord{
-		Token: tokenString,
-		Name:  t.Name,
+		Token:     tokenString,
+		Name:      t.Name,
+		ExpiresAt: t.ExpiryDate.Time,
 	}, nil
 }

--- a/cluster/token_records.go
+++ b/cluster/token_records.go
@@ -2,6 +2,7 @@ package cluster
 
 import (
 	"crypto/x509"
+	"database/sql"
 
 	"github.com/canonical/lxd/shared"
 
@@ -29,9 +30,10 @@ import (
 
 // CoreTokenRecord is the database representation of a join token record.
 type CoreTokenRecord struct {
-	ID     int
-	Secret string `db:"primary=yes"`
-	Name   string
+	ID         int
+	Secret     string `db:"primary=yes"`
+	Name       string
+	ExpiryDate sql.NullTime
 }
 
 // CoreTokenRecordFilter is the filter struct for filtering results from generated methods.

--- a/example/cmd/microctl/tokens.go
+++ b/example/cmd/microctl/tokens.go
@@ -61,7 +61,7 @@ func (c *cmdTokensAdd) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	token, err := m.NewJoinToken(cmd.Context(), args[0])
+	token, err := m.NewJoinToken(cmd.Context(), args[0], 0)
 	if err != nil {
 		return err
 	}

--- a/internal/rest/client/tokens.go
+++ b/internal/rest/client/tokens.go
@@ -10,12 +10,12 @@ import (
 )
 
 // RequestToken requests a join token with the given name.
-func (c *Client) RequestToken(ctx context.Context, name string) (string, error) {
+func (c *Client) RequestToken(ctx context.Context, name string, expireAfter time.Duration) (string, error) {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	var token string
-	tokenRecord := types.TokenRecord{Name: name}
+	tokenRecord := types.TokenRequest{Name: name, ExpireAfter: expireAfter}
 	err := c.QueryStruct(queryCtx, "POST", types.ControlEndpoint, api.NewURL().Path("tokens"), tokenRecord, &token)
 
 	return token, err

--- a/internal/rest/resources/tokens.go
+++ b/internal/rest/resources/tokens.go
@@ -34,7 +34,7 @@ var tokenCmd = rest.Endpoint{
 }
 
 func tokensPost(state state.State, r *http.Request) response.Response {
-	req := internalTypes.TokenRecord{}
+	req := internalTypes.TokenRequest{}
 
 	// Parse the request.
 	err := json.NewDecoder(r.Body).Decode(&req)

--- a/internal/rest/types/tokens.go
+++ b/internal/rest/types/tokens.go
@@ -3,14 +3,22 @@ package types
 import (
 	"encoding/base64"
 	"encoding/json"
+	"time"
 
 	"github.com/canonical/microcluster/rest/types"
 )
 
-// TokenRecord holds information for requesting a join token.
+// TokenRequest holds information for requesting a join token.
+type TokenRequest struct {
+	Name        string        `json:"name" yaml:"name"`
+	ExpireAfter time.Duration `json:"expire_after" yaml:"expire_after"`
+}
+
+// TokenRecord represents the internal record of a join token.
 type TokenRecord struct {
-	Name  string `json:"name" yaml:"name"`
-	Token string `json:"token" yaml:"token"`
+	Name      string    `json:"name" yaml:"name"`
+	Token     string    `json:"token" yaml:"token"`
+	ExpiresAt time.Time `json:"expires_at" yaml:"expires_at"`
 }
 
 // TokenResponse holds the information for connecting to a cluster by a node with a valid join token.

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -266,13 +266,13 @@ func (m *MicroCluster) RecoverFromQuorumLoss(members []cluster.DqliteMember) (st
 // NewJoinToken creates and records a new join token containing all the necessary credentials for joining a cluster.
 // Join tokens are tied to the server certificate of the joining node, and will be deleted once the node has joined the
 // cluster.
-func (m *MicroCluster) NewJoinToken(ctx context.Context, name string) (string, error) {
+func (m *MicroCluster) NewJoinToken(ctx context.Context, name string, expireAfter time.Duration) (string, error) {
 	c, err := m.LocalClient()
 	if err != nil {
 		return "", err
 	}
 
-	secret, err := c.RequestToken(ctx, name)
+	secret, err := c.RequestToken(ctx, name, expireAfter)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
CC @MggMuggins @boltmark 

This adds the necessary schema/client/api type changes necessary for join token expiration, following a similar pattern to LXD's expiration date handling. 

As of now, the field is unused when specified to the API, so the remaining steps would be:
* On `POST` to `/core/internal/tokens`, if `req.ExpireAfter` is non-zero, set the expiration of the token to that duration after the current time, when adding the token record to the database.
* On each heartbeat handled by the leader, check all token expirations and delete any expired ones. There's lots of transactions here that can be re-used.
* Update example CLI to take a flag for setting the expiration, this can default to 3 hours like LXD's join tokens.
* Update example CLI to show the expiration date when listing tokens.