### PR TITLE
internal/rest/resources: Don't allow token issuing over the network

### DIFF
--- a/internal/rest/client/tokens.go
+++ b/internal/rest/client/tokens.go
@@ -16,7 +16,7 @@ func (c *Client) RequestToken(ctx context.Context, name string) (string, error) 
 
 	var token string
 	tokenRecord := types.TokenRecord{Name: name}
-	err := c.QueryStruct(queryCtx, "POST", types.PublicEndpoint, api.NewURL().Path("tokens"), tokenRecord, &token)
+	err := c.QueryStruct(queryCtx, "POST", types.ControlEndpoint, api.NewURL().Path("tokens"), tokenRecord, &token)
 
 	return token, err
 }
@@ -37,7 +37,7 @@ func (c *Client) GetTokenRecords(ctx context.Context) ([]types.TokenRecord, erro
 	defer cancel()
 
 	tokenRecords := []types.TokenRecord{}
-	err := c.QueryStruct(queryCtx, "GET", types.PublicEndpoint, api.NewURL().Path("tokens"), nil, &tokenRecords)
+	err := c.QueryStruct(queryCtx, "GET", types.ControlEndpoint, api.NewURL().Path("tokens"), nil, &tokenRecords)
 
 	return tokenRecords, err
 }

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -16,6 +16,7 @@ var UnixEndpoints = rest.Resources{
 	Endpoints: []rest.Endpoint{
 		controlCmd,
 		shutdownCmd,
+		tokensCmd,
 	},
 }
 
@@ -29,7 +30,6 @@ var PublicEndpoints = rest.Resources{
 		clusterMemberCmd,
 		daemonCmd,
 		tokenCmd,
-		tokensCmd,
 		readyCmd,
 	},
 }


### PR DESCRIPTION
This makes it so that simply trusting the cluster is not enough to issue a join token, it has to be issued from an actual cluster member. 