### PR TITLE
Verify server.crt on cluster join request

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-GOMIN=1.22.4
+GOMIN=1.22.5
 
 .PHONY: default
 default: update-schema

--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,10 @@
 module github.com/canonical/microcluster
 
-go 1.22.4
+go 1.22.5
 
 require (
 	github.com/canonical/go-dqlite v1.22.0
-	github.com/canonical/lxd v0.0.0-20240709081608-9df996e36bac
+	github.com/canonical/lxd v0.0.0-20240725152227-dd8bcf029436
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/google/renameio v1.0.1
 	github.com/gorilla/mux v1.8.1
@@ -22,7 +22,7 @@ require (
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
 	github.com/flosch/pongo2 v0.0.0-20200913210552-0d938eb266f3 // indirect
 	github.com/fvbommel/sortorder v1.1.0 // indirect
-	github.com/go-jose/go-jose/v4 v4.0.2 // indirect
+	github.com/go-jose/go-jose/v4 v4.0.3 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/uuid v1.6.0 // indirect
@@ -37,7 +37,7 @@ require (
 	github.com/muhlemmer/gu v0.3.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pkg/sftp v1.13.6 // indirect
-	github.com/pkg/xattr v0.4.9 // indirect
+	github.com/pkg/xattr v0.4.10 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/robfig/cron/v3 v3.0.1 // indirect
@@ -45,7 +45,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/zitadel/logging v0.6.0 // indirect
-	github.com/zitadel/oidc/v3 v3.25.1 // indirect
+	github.com/zitadel/oidc/v3 v3.26.0 // indirect
 	github.com/zitadel/schema v1.3.0 // indirect
 	go.opentelemetry.io/otel v1.28.0 // indirect
 	go.opentelemetry.io/otel/metric v1.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -52,12 +52,10 @@ github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kB
 github.com/bketelsen/crypt v0.0.4/go.mod h1:aI6NrJ0pMGgvZKL1iVgXLnfIFJtfV+bKCoqOes/6LfM=
 github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwNy7PA4I=
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
-github.com/canonical/go-dqlite v1.21.0 h1:4gLDdV2GF+vg0yv9Ff+mfZZNQ1JGhnQ3GnS2GeZPHfA=
-github.com/canonical/go-dqlite v1.21.0/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
 github.com/canonical/go-dqlite v1.22.0 h1:DuJmfcREl4gkQJyvZzjl2GHFZROhbPyfdjDRQXpkOyw=
 github.com/canonical/go-dqlite v1.22.0/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
-github.com/canonical/lxd v0.0.0-20240709081608-9df996e36bac h1:WqXeS0uyAAmFB9aflCucb/pPZzIdivO9uG4tWw7CEAw=
-github.com/canonical/lxd v0.0.0-20240709081608-9df996e36bac/go.mod h1:S2MXobHv9Wh6cpr3biLo2Kq0vqK2/PxpFuE/8ZsNDic=
+github.com/canonical/lxd v0.0.0-20240725152227-dd8bcf029436 h1:7AfKX3mXg+RX9Vdv8B274DLmTBVyjnvXQjcJnjxIBR4=
+github.com/canonical/lxd v0.0.0-20240725152227-dd8bcf029436/go.mod h1:gD+lZf/ReurMCwQ9qsdCtVpq9chx80fP0hA1xS5DOUw=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -96,8 +94,8 @@ github.com/go-chi/chi/v5 v5.1.0/go.mod h1:DslCQbL2OYiznFReuXYUmQ2hGd1aDpCnlMNITL
 github.com/go-gl/glfw v0.0.0-20190409004039-e6da0acd62b1/go.mod h1:vR7hzQXu2zJy9AVAgeJqvqgH9Q5CA+iKCZ2gyEVpxRU=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20191125211704-12ad95a8df72/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
 github.com/go-gl/glfw/v3.3/glfw v0.0.0-20200222043503-6f7a984d4dc4/go.mod h1:tQ2UAYgL5IevRw8kRxooKSPJfGvJ9fJQFa0TUsXzTg8=
-github.com/go-jose/go-jose/v4 v4.0.2 h1:R3l3kkBds16bO7ZFAEEcofK0MkrAJt3jlJznWZG0nvk=
-github.com/go-jose/go-jose/v4 v4.0.2/go.mod h1:WVf9LFMHh/QVrmqrOfqun0C45tMe3RoiKJMPvgWwLfY=
+github.com/go-jose/go-jose/v4 v4.0.3 h1:o8aphO8Hv6RPmH+GfzVuyf7YXSBibp+8YyHdOoDESGo=
+github.com/go-jose/go-jose/v4 v4.0.3/go.mod h1:NKb5HO1EZccyMpiZNbdUw/14tiXNyUJh188dfnMCAfc=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.2 h1:6pFjapn8bFcIbiKo3XT4j/BhANplGihG6tvd+8rYgrY=
 github.com/go-logr/logr v1.4.2/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=
@@ -269,8 +267,8 @@ github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINE
 github.com/pkg/sftp v1.10.1/go.mod h1:lYOWFsE0bwd1+KfKJaKeuokY15vzFx25BLbzYYoAxZI=
 github.com/pkg/sftp v1.13.6 h1:JFZT4XbOU7l77xGSpOdW+pwIMqP044IyjXX6FGyEKFo=
 github.com/pkg/sftp v1.13.6/go.mod h1:tz1ryNURKu77RL+GuCzmoJYxQczL3wLNNpPWagdg4Qk=
-github.com/pkg/xattr v0.4.9 h1:5883YPCtkSd8LFbs13nXplj9g9tlrwoJRjgpgMu1/fE=
-github.com/pkg/xattr v0.4.9/go.mod h1:di8WF84zAKk8jzR1UBTEWh9AUlIZZ7M/JNt8e9B6ktU=
+github.com/pkg/xattr v0.4.10 h1:Qe0mtiNFHQZ296vRgUjRCoPHPqH7VdTOrZx3g0T+pGA=
+github.com/pkg/xattr v0.4.10/go.mod h1:di8WF84zAKk8jzR1UBTEWh9AUlIZZ7M/JNt8e9B6ktU=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 h1:Jamvg5psRIccs7FGNTlIRMkT8wgtp5eCXdBlqhYGL6U=
 github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
@@ -327,8 +325,8 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zitadel/logging v0.6.0 h1:t5Nnt//r+m2ZhhoTmoPX+c96pbMarqJvW1Vq6xFTank=
 github.com/zitadel/logging v0.6.0/go.mod h1:Y4CyAXHpl3Mig6JOszcV5Rqqsojj+3n7y2F591Mp/ow=
-github.com/zitadel/oidc/v3 v3.25.1 h1:mkGimTWzbb8wARUewIqr6LhTPZnZeL6WOeXWy+iz1aI=
-github.com/zitadel/oidc/v3 v3.25.1/go.mod h1:UDwD+PRFbUBzabyPd9JORrakty3/wec7VpKZYi9Ahh0=
+github.com/zitadel/oidc/v3 v3.26.0 h1:BG3OUK+JpuKz7YHJIyUxL5Sl2JV6ePkG42UP4Xv3J2w=
+github.com/zitadel/oidc/v3 v3.26.0/go.mod h1:Cx6AYPTJO5q2mjqF3jaknbKOUjpq1Xui0SYvVhkKuXU=
 github.com/zitadel/schema v1.3.0 h1:kQ9W9tvIwZICCKWcMvCEweXET1OcOyGEuFbHs4o5kg0=
 github.com/zitadel/schema v1.3.0/go.mod h1:NptN6mkBDFvERUCvZHlvWmmME+gmZ44xzwRXwhzsbtc=
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -223,7 +223,7 @@ func (d *Daemon) init(listenAddress string, heartbeatInterval time.Duration, sch
 		return fmt.Errorf("Failed to initialize trust store: %w", err)
 	}
 
-	d.db = db.NewDB(d.shutdownCtx, d.serverCert, d.ClusterCert, d.os, heartbeatInterval)
+	d.db = db.NewDB(d.shutdownCtx, d.ServerCert, d.ClusterCert, d.os, heartbeatInterval)
 
 	listenAddr := api.NewURL()
 	if listenAddress != "" {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -922,7 +922,7 @@ func (d *Daemon) ReloadCert(name types.CertificateName) error {
 	defer d.clusterMu.Unlock()
 
 	var dir string
-	if name == types.ClusterCertificateName {
+	if name == types.ClusterCertificateName || name == types.ServerCertificateName {
 		dir = d.os.StateDir
 	} else {
 		dir = d.os.CertificatesDir
@@ -936,7 +936,17 @@ func (d *Daemon) ReloadCert(name types.CertificateName) error {
 	// In case the cluster certificate gets reloaded also populate its value.
 	if name == types.ClusterCertificateName {
 		d.clusterCert = cert
+	}
 
+	if name == types.ServerCertificateName {
+		if d.db.Status() != db.StatusNotReady {
+			return fmt.Errorf("Cannot replace server certificate after initialization")
+		}
+
+		d.serverCert = cert
+	}
+
+	if name == types.ClusterCertificateName || name == types.ServerCertificateName {
 		// The core API endpoints are labeled with core.
 		// When the cluster certificate gets updated reload those.
 		d.endpoints.UpdateTLSByName(endpoints.EndpointsCore, cert)
@@ -964,7 +974,10 @@ func (d *Daemon) ReloadCert(name types.CertificateName) error {
 
 // ServerCert ensures both the daemon and state have the same server cert.
 func (d *Daemon) ServerCert() *shared.CertInfo {
-	return d.serverCert
+	d.clusterMu.RLock()
+	defer d.clusterMu.RUnlock()
+
+	return shared.NewCertInfo(d.serverCert.KeyPair(), d.serverCert.CA(), d.serverCert.CRL())
 }
 
 // Address is the listen address for the daemon.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -853,7 +853,7 @@ func (d *Daemon) addExtensionServers(preInit bool, fallbackCert *shared.CertInfo
 		} else {
 			// Generate a dedicated certificate or load the custom one if it exists.
 			// When updating the additional listeners the dedicated certificate from before will be reused.
-			cert, err = shared.KeyPairAndCA(d.os.CertificatesDir, serverName, shared.CertServer, shared.CertOptions{AddHosts: true})
+			cert, err = shared.KeyPairAndCA(d.os.CertificatesDir, serverName, shared.CertServer, shared.CertOptions{AddHosts: true, SubjectName: d.Name()})
 			if err != nil {
 				return fmt.Errorf("Failed to setup dedicated certificate for additional server %q: %w", serverName, err)
 			}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -853,7 +853,7 @@ func (d *Daemon) addExtensionServers(preInit bool, fallbackCert *shared.CertInfo
 		} else {
 			// Generate a dedicated certificate or load the custom one if it exists.
 			// When updating the additional listeners the dedicated certificate from before will be reused.
-			cert, err = shared.KeyPairAndCA(d.os.CertificatesDir, serverName, shared.CertServer, true)
+			cert, err = shared.KeyPairAndCA(d.os.CertificatesDir, serverName, shared.CertServer, shared.CertOptions{AddHosts: true})
 			if err != nil {
 				return fmt.Errorf("Failed to setup dedicated certificate for additional server %q: %w", serverName, err)
 			}
@@ -928,7 +928,7 @@ func (d *Daemon) ReloadCert(name types.CertificateName) error {
 		dir = d.os.CertificatesDir
 	}
 
-	cert, err := shared.KeyPairAndCA(dir, string(name), shared.CertServer, true)
+	cert, err := shared.KeyPairAndCA(dir, string(name), shared.CertServer, shared.CertOptions{AddHosts: true, SubjectName: d.Name()})
 	if err != nil {
 		return fmt.Errorf("Failed to load TLS certificate %q: %w", name, err)
 	}

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -37,7 +37,7 @@ import (
 // DB holds all information internal to the dqlite database.
 type DB struct {
 	clusterCert func() *shared.CertInfo // Cluster certificate for dqlite authentication.
-	serverCert  *shared.CertInfo        // Server certificate for dqlite authentication.
+	serverCert  func() *shared.CertInfo // Server certificate for dqlite authentication.
 	listenAddr  api.URL                 // Listen address for this dqlite node.
 
 	dbName string // This is db.bin.
@@ -92,7 +92,7 @@ func (db *DB) Accept(conn net.Conn) {
 }
 
 // NewDB creates an empty db struct with no dqlite connection.
-func NewDB(ctx context.Context, serverCert *shared.CertInfo, clusterCert func() *shared.CertInfo, os *sys.OS, heartbeatInterval time.Duration) *DB {
+func NewDB(ctx context.Context, serverCert func() *shared.CertInfo, clusterCert func() *shared.CertInfo, os *sys.OS, heartbeatInterval time.Duration) *DB {
 	shutdownCtx, shutdownCancel := context.WithCancel(ctx)
 
 	if heartbeatInterval == 0 {
@@ -371,7 +371,7 @@ func dqliteNetworkDial(ctx context.Context, addr string, db *DB) (net.Conn, erro
 		return nil, err
 	}
 
-	config, err := internalClient.TLSClientConfig(db.serverCert, peerCert)
+	config, err := internalClient.TLSClientConfig(db.serverCert(), peerCert)
 	if err != nil {
 		return nil, fmt.Errorf("Failed to parse TLS config: %w", err)
 	}

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -143,6 +143,10 @@ func clusterPost(s state.State, r *http.Request) response.Response {
 			return err
 		}
 
+		if !shared.ValueInSlice(record.Name, req.Certificate.DNSNames) {
+			return fmt.Errorf("Joining server certificate SAN does not contain join token name")
+		}
+
 		_, err = cluster.CreateCoreClusterMember(ctx, tx, dbClusterMember)
 		if err != nil {
 			return err

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -204,7 +204,7 @@ func clusterPost(s state.State, r *http.Request) response.Response {
 		splittedPath := strings.Split(filepath.Base(path), ".")
 		if len(splittedPath) == 2 && splittedPath[1] == "crt" {
 			// Load the certificate
-			cert, err := shared.KeyPairAndCA(s.FileSystem().CertificatesDir, splittedPath[0], shared.CertServer, true)
+			cert, err := shared.KeyPairAndCA(s.FileSystem().CertificatesDir, splittedPath[0], shared.CertServer, shared.CertOptions{})
 			if err != nil {
 				return fmt.Errorf("Failed to load certificate for additional server %q: %w", splittedPath[0], err)
 			}

--- a/internal/sys/os.go
+++ b/internal/sys/os.go
@@ -127,7 +127,7 @@ func (s *OS) ServerCert() (*shared.CertInfo, error) {
 		return nil, fmt.Errorf("Failed to get server.crt from directory %q", s.StateDir)
 	}
 
-	cert, err := shared.KeyPairAndCA(s.StateDir, "server", shared.CertServer, true)
+	cert, err := shared.KeyPairAndCA(s.StateDir, "server", shared.CertServer, shared.CertOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("Failed to load TLS certificate: %w", err)
 	}
@@ -141,7 +141,7 @@ func (s *OS) ClusterCert() (*shared.CertInfo, error) {
 		return nil, fmt.Errorf("Failed to get %s.crt from directory %q", types.ClusterCertificateName, s.StateDir)
 	}
 
-	cert, err := shared.KeyPairAndCA(s.StateDir, string(types.ClusterCertificateName), shared.CertServer, true)
+	cert, err := shared.KeyPairAndCA(s.StateDir, string(types.ClusterCertificateName), shared.CertServer, shared.CertOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("Failed to load TLS certificate: %w", err)
 	}

--- a/rest/types/certificate.go
+++ b/rest/types/certificate.go
@@ -13,6 +13,9 @@ type CertificateName string
 const (
 	// ClusterCertificateName represents the name of the cluster certificate used by the core API.
 	ClusterCertificateName CertificateName = "cluster"
+
+	// ServerCertificateName represents the name of the identifying certificate of a cluster member.
+	ServerCertificateName CertificateName = "server"
 )
 
 // KeyPair holds a certificate together with its private key and optional CA.


### PR DESCRIPTION
Closes #96 

The LXD dependency was updated as well to be able to set the SAN name of the `server.crt` certificate to something other than the hostname.

Since the `server.crt` is generated when the daemon first starts, it will first be populated with the system hostname. However, during the `init` sequence the daemon name can be set to any valid FQDN, so we have to replace the `server.crt` before it's sent to the cluster to request authorization to join the cluster.

To be able to replace `server.crt`, `ReloadCert` has been updated to accept `server` as a valid certificate to replace as long as the dqlite database has not yet been initialized. 

Finally, when we send the certificate to the dqlite leader, it verifies that the SAN matches the name used when the join token was first issued.
