### PR TITLE
Join token expiration

### DIFF
--- a/cluster/token_records.go
+++ b/cluster/token_records.go
@@ -1,11 +1,13 @@
 package cluster
 
 import (
+	"context"
 	"crypto/x509"
 	"database/sql"
 	"time"
 
 	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/logger"
 
 	internalTypes "github.com/canonical/microcluster/internal/rest/types"
 	"github.com/canonical/microcluster/rest/types"
@@ -67,4 +69,25 @@ func (t *CoreTokenRecord) ToAPI(clusterCert *x509.Certificate, joinAddresses []t
 // Expired compares the token's expiry date with the current time.
 func (t *CoreTokenRecord) Expired() bool {
 	return t.ExpiryDate.Valid && t.ExpiryDate.Time.Before(time.Now())
+}
+
+// DeleteExpiredCoreTokenRecords cleans up expired tokens.
+func DeleteExpiredCoreTokenRecords(ctx context.Context, tx *sql.Tx) error {
+	tokens, err := GetCoreTokenRecords(ctx, tx)
+	if err != nil {
+		return err
+	}
+
+	for _, token := range tokens {
+		if token.Expired() {
+			err = DeleteCoreTokenRecord(ctx, tx, token.Name)
+			if err != nil {
+				return err
+			}
+
+			logger.Info("Removed expired join token", logger.Ctx{"name": token.Name})
+		}
+	}
+
+	return nil
 }

--- a/cluster/token_records.go
+++ b/cluster/token_records.go
@@ -3,6 +3,7 @@ package cluster
 import (
 	"crypto/x509"
 	"database/sql"
+	"time"
 
 	"github.com/canonical/lxd/shared"
 
@@ -61,4 +62,9 @@ func (t *CoreTokenRecord) ToAPI(clusterCert *x509.Certificate, joinAddresses []t
 		Name:      t.Name,
 		ExpiresAt: t.ExpiryDate.Time,
 	}, nil
+}
+
+// Expired compares the token's expiry date with the current time.
+func (t *CoreTokenRecord) Expired() bool {
+	return t.ExpiryDate.Valid && t.ExpiryDate.Time.Before(time.Now())
 }

--- a/example/cmd/microctl/tokens.go
+++ b/example/cmd/microctl/tokens.go
@@ -102,10 +102,10 @@ func (c *cmdTokensList) run(cmd *cobra.Command, args []string) error {
 
 	data := make([][]string, len(records))
 	for i, record := range records {
-		data[i] = []string{record.Name, record.Token}
+		data[i] = []string{record.Name, record.Token, record.ExpiresAt.String()}
 	}
 
-	header := []string{"NAME", "TOKENS"}
+	header := []string{"NAME", "TOKENS", "EXPIRES AT"}
 	sort.Sort(cli.SortColumnsNaturally(data))
 
 	return cli.RenderTable(cli.TableFormatTable, header, data, records)

--- a/example/cmd/microctl/tokens.go
+++ b/example/cmd/microctl/tokens.go
@@ -82,6 +82,8 @@ func (c *cmdTokensAdd) run(cmd *cobra.Command, args []string) error {
 
 type cmdTokensList struct {
 	common *CmdControl
+
+	flagFormat string
 }
 
 func (c *cmdTokensList) command() *cobra.Command {
@@ -90,6 +92,7 @@ func (c *cmdTokensList) command() *cobra.Command {
 		Short: "List join tokens available for use",
 		RunE:  c.run,
 	}
+	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", cli.TableFormatTable, "Format (csv|json|table|yaml|compact)")
 
 	return cmd
 }
@@ -117,7 +120,7 @@ func (c *cmdTokensList) run(cmd *cobra.Command, args []string) error {
 	header := []string{"NAME", "TOKENS", "EXPIRES AT"}
 	sort.Sort(cli.SortColumnsNaturally(data))
 
-	return cli.RenderTable(cli.TableFormatTable, header, data, records)
+	return cli.RenderTable(c.flagFormat, header, data, records)
 }
 
 type cmdTokensRevoke struct {

--- a/example/cmd/microctl/tokens.go
+++ b/example/cmd/microctl/tokens.go
@@ -3,6 +3,7 @@ package main
 import (
 	"fmt"
 	"sort"
+	"time"
 
 	cli "github.com/canonical/lxd/shared/cmd"
 	"github.com/spf13/cobra"
@@ -39,6 +40,8 @@ func (c *cmdSecrets) run(cmd *cobra.Command, args []string) error {
 
 type cmdTokensAdd struct {
 	common *CmdControl
+
+	flagExpireAfter string
 }
 
 func (c *cmdTokensAdd) command() *cobra.Command {
@@ -47,6 +50,7 @@ func (c *cmdTokensAdd) command() *cobra.Command {
 		Short: "Add a new join token under the given name",
 		RunE:  c.run,
 	}
+	cmd.Flags().StringVarP(&c.flagExpireAfter, "expire-after", "e", "3h", "Set the lifetime for the token")
 
 	return cmd
 }
@@ -61,7 +65,12 @@ func (c *cmdTokensAdd) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	token, err := m.NewJoinToken(cmd.Context(), args[0], 0)
+	expireAfter, err := time.ParseDuration(c.flagExpireAfter)
+	if err != nil {
+		return fmt.Errorf("Invalid value for expire-after: %w", err)
+	}
+
+	token, err := m.NewJoinToken(cmd.Context(), args[0], expireAfter)
 	if err != nil {
 		return err
 	}

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -143,6 +143,10 @@ func clusterPost(s state.State, r *http.Request) response.Response {
 			return err
 		}
 
+		if record.Expired() {
+			return fmt.Errorf("Token expired")
+		}
+
 		if !shared.ValueInSlice(record.Name, req.Certificate.DNSNames) {
 			return fmt.Errorf("Joining server certificate SAN does not contain join token name")
 		}

--- a/internal/rest/resources/heartbeat.go
+++ b/internal/rest/resources/heartbeat.go
@@ -239,7 +239,7 @@ func beginHeartbeat(ctx context.Context, s state.State, hbReq internalTypes.Hear
 			}
 		}
 
-		return nil
+		return cluster.DeleteExpiredCoreTokenRecords(ctx, tx)
 	})
 	if err != nil {
 		return response.SmartError(err)

--- a/internal/rest/resources/tokens.go
+++ b/internal/rest/resources/tokens.go
@@ -110,6 +110,10 @@ func tokensGet(state state.State, r *http.Request) response.Response {
 
 		records = make([]internalTypes.TokenRecord, 0, len(tokens))
 		for _, token := range tokens {
+			if token.Expired() {
+				continue
+			}
+
 			apiToken, err := token.ToAPI(clusterCert, joinAddresses)
 			if err != nil {
 				return err

--- a/internal/rest/resources/tokens.go
+++ b/internal/rest/resources/tokens.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/shared"
@@ -67,6 +68,13 @@ func tokensPost(state state.State, r *http.Request) response.Response {
 		}
 	}
 
+	expiryDate := sql.NullTime{
+		Valid: req.ExpireAfter != 0,
+	}
+	if expiryDate.Valid {
+		expiryDate.Time = time.Now().Add(req.ExpireAfter)
+	}
+
 	token := internalTypes.Token{
 		Secret:        tokenKey,
 		Fingerprint:   shared.CertFingerprint(clusterCert),
@@ -79,7 +87,11 @@ func tokensPost(state state.State, r *http.Request) response.Response {
 	}
 
 	err = state.Database().Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
-		_, err = cluster.CreateCoreTokenRecord(ctx, tx, cluster.CoreTokenRecord{Name: req.Name, Secret: tokenKey})
+		_, err = cluster.CreateCoreTokenRecord(ctx, tx, cluster.CoreTokenRecord{
+			Name:       req.Name,
+			Secret:     tokenKey,
+			ExpiryDate: expiryDate,
+		})
 		return err
 	})
 	if err != nil {

--- a/internal/rest/resources/tokens.go
+++ b/internal/rest/resources/tokens.go
@@ -87,6 +87,11 @@ func tokensPost(state state.State, r *http.Request) response.Response {
 	}
 
 	err = state.Database().Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
+		err = cluster.DeleteExpiredCoreTokenRecords(ctx, tx)
+		if err != nil {
+			return err
+		}
+
 		_, err = cluster.CreateCoreTokenRecord(ctx, tx, cluster.CoreTokenRecord{
 			Name:       req.Name,
 			Secret:     tokenKey,


### PR DESCRIPTION
Fixes #199.

I got sick of feeling like I couldn't test effectively with the system tests, so this includes a refactor to separate them out a bit. Should make reviewing changes easier in future. They're far from perfect but still better than they were. I can split them into a different PR if that would be preferred.

Regarding tokens:
- Don't return an expired token from `GET tokens/`
- Insert an expiry date if one is provided during token creation
- Delete expired tokens on heartbeat
- Token support in `microctl`

LXD-1349