### PR TITLE
internal/recover: Write the global DB patch on all members

### DIFF
--- a/internal/recover/recover.go
+++ b/internal/recover/recover.go
@@ -496,6 +496,11 @@ func MaybeUnpackRecoveryTarball(filesystem *sys.OS) error {
 		return err
 	}
 
+	err = writeGlobalMembersPatch(filesystem, incomingMembers)
+	if err != nil {
+		return fmt.Errorf("Failed to write global DB update: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
Follow-up on the test failures in https://github.com/canonical/microcluster/pull/207. This is almost surely the same race condition I [was seeing in LXD](https://github.com/canonical/lxd/pull/13754#issuecomment-2231001761).

TL;DR we're [selecting](https://github.com/canonical/microcluster/blob/main/cluster/cluster_members.go#L168) on the member's new address before `core_cluster_members` has been updated to include the new addresses. I haven't traced through this as finely as I did for LXD, but like over there, this is likely to be non-trivial/breaking to fix "correctly". Since the query is idempotent, creating the patch file on all nodes is the straightforward fix.