### PR TITLE
GitHub: Update dependabot and renovate configs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,9 +5,25 @@ updates:
     labels: []
     schedule:
       interval: "weekly"
+    target-branch: "v3"
 
   - package-ecosystem: "gomod"
     directory: "/"
     labels: []
     schedule:
       interval: "weekly"
+    target-branch: "v3"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    labels: []
+    schedule:
+      interval: "weekly"
+    target-branch: "v2"
+
+  - package-ecosystem: "gomod"
+    directory: "/"
+    labels: []
+    schedule:
+      interval: "weekly"
+    target-branch: "v2"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,0 +1,3 @@
+{
+  "enabled": false
+}


### PR DESCRIPTION
This ensures that dependabot is monitoring both the `v2` and `v3` branches and that renovate is using the same config as in LXD. 

In addition `:gitSignOff` is added to the renovate `extends` directive to make sure commits made by renovate also contain the `Signed-off-by:` line.
Furthermore `baseBranches` now point to both `v2` and `v3` to receive updates for both of them.