### PR TITLE
(backport v2) Parse go module version out of project name

### DIFF
--- a/cluster/stmt.go
+++ b/cluster/stmt.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"strings"
 
@@ -107,8 +108,15 @@ func GetCallerProject() string {
 
 	// If not a snap build path, the project may be in a go module path of the form .../project@version....
 	before, _, ok := strings.Cut(file, "@")
-	if ok && filepath.Base(before) != "" {
-		return filepath.Base(before)
+	base := filepath.Base(before)
+	if ok && base != "" {
+		// If the base path is a go module version like v2, the project name will be one level down.
+		exp := regexp.MustCompile(`^v\d+$`)
+		if exp.MatchString(base) {
+			return filepath.Base(filepath.Dir(before))
+		}
+
+		return base
 	}
 
 	// If not a go module path,	assume a GOPATH of the form example.com/author/project/packages....


### PR DESCRIPTION
This helper finds microcluster among the cached build files to register internal statements. Since microcluster's module path has been appended with v2, this function now resolves to `v2` as the project name instead of `microcluster`, so this commit properly checks if the path is of the form v[number] and if so, looks one directory back instead.

This should fix external projects failing to register internal microcluster prepared statements.

Signed-off-by: Max Asnaashari <max.asnaashari@canonical.com>
(cherry picked from commit aaec49fa6823ddf8802336b3affbbe8878cc6a52)