### PR TITLE
Add back legacy `/cluster/internal/database` endpoint

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -293,6 +293,7 @@ func (d *Daemon) init(listenAddress string, socketGroup string, heartbeatInterva
 		resources.UnixEndpoints,
 		resources.InternalEndpoints,
 		resources.PublicEndpoints,
+		resources.LegacyEndpoints,
 	}
 
 	d.extensionServersMu.RLock()
@@ -560,7 +561,7 @@ func (d *Daemon) StartAPI(ctx context.Context, bootstrap bool, initConfig map[st
 		return err
 	}
 
-	serverEndpoints := []rest.Resources{resources.InternalEndpoints, resources.PublicEndpoints}
+	serverEndpoints := []rest.Resources{resources.InternalEndpoints, resources.PublicEndpoints, resources.LegacyEndpoints}
 	err = d.addCoreServers(false, *d.Address(), d.ClusterCert(), serverEndpoints)
 	if err != nil {
 		return err

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -49,6 +49,14 @@ var InternalEndpoints = rest.Resources{
 	},
 }
 
+// LegacyEndpoints allows access to the legacy /cluster/internal/database endpoint to facilitate upgrades to the newer endpoint path structure.
+var LegacyEndpoints = rest.Resources{
+	PathPrefix: internalTypes.LegacyEndpoint,
+	Endpoints: []rest.Endpoint{
+		databaseCmd,
+	},
+}
+
 // ValidateEndpoints checks if any endpoints defined in extensionServers conflict with other endpoints.
 // An invalid server is defined as one of the following:
 // - The PathPrefix+Path of an endpoint conflicts with another endpoint in the same server.
@@ -57,7 +65,7 @@ var InternalEndpoints = rest.Resources{
 // If the Server is a core API server, its resources must not conflict with any other core API server, and it must not have a defined address or certificate.
 func ValidateEndpoints(extensionServers map[string]rest.Server, coreAddress string) error {
 	serverAddresses := map[string]bool{coreAddress: true}
-	baseCoreEndpoints := []rest.Resources{UnixEndpoints, PublicEndpoints, InternalEndpoints}
+	baseCoreEndpoints := []rest.Resources{UnixEndpoints, PublicEndpoints, InternalEndpoints, LegacyEndpoints}
 	existingEndpointPaths := map[string]map[string]bool{endpoints.EndpointsCore: {}}
 
 	// Record the paths for all internal endpoints on the core listener.

--- a/internal/rest/types/server.go
+++ b/internal/rest/types/server.go
@@ -23,4 +23,7 @@ const (
 
 	// ControlEndpoint - All internal endpoints available on the local unix socket.
 	ControlEndpoint types.EndpointPrefix = "core/control"
+
+	// LegacyEndpoint - Legacy endpoint path to facilitate system upgrades from the older server structure.
+	LegacyEndpoint types.EndpointPrefix = "cluster/internal"
 )


### PR DESCRIPTION
We renamed `/cluster/internal`, `/cluster/control`, and `/cluster/1.0` to `/core/...` but this leads to an issue when upgrading from v1 to v2 where the newer members cannot connect to dqlite until all un-upgraded members are offline. This is because the dqlite leader will still be communicating over `/cluster/internal/database`. 

This makes upgrades noticeably slower, while also undoing the work we had done earlier to show upgrade progress with the `cluster list` command, because we can't connect to dqlite to inspect the schema versions. Instead, the daemon just reports `Database is still starting` because the dqlite connection cannot be established. The upgrade still does work, it just takes an additional 30-60s or so because the upgraded daemons will be constantly restarting until all cluster members have been upgraded.


To work around this, we can add back `/cluster/internal/database` as a core API endpoint. For the most part, this won't be used, as it will only be relevant while upgrading from an existing setup that uses the old API endpoints. This path will be reserved so extension servers cannot use `/cluster/internal/database` as a path. 

Functionally, when establishing a connection to dqlite, if we encounter a `404` error on `/core/internal/database`, we will try `/cluster/internal/database` as a fallback, allowing us to connect to legacy systems to compare schema versions.


Rather than adding this to v3 and backporting to v2, I thought we might as well fully drop the legacy support from v3 since it likely won't be released for some time, meaning direct upgrades from v1->v3 should be rather sparse. And since this doesn't actually affect the result of an upgrade, I don't think it's worth the extra maintenance.