### PR TITLE
Renovate: Another try to disable the dashboard

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,8 +1,9 @@
 {
-  "enabled": false
-  "dependencyDashboard": false
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "enabled": false,
+  "dependencyDashboard": false,
   "extends": [
     "config:recommended",
-    ":disableDependencyDashboard",
+    ":disableDependencyDashboard"
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,0 @@
-{
-  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": [
-    "config:base",
-    "schedule:earlyMondays"
-  ]
-}


### PR DESCRIPTION
This PR fixes the json file and removes the redundant instance of `renovate.json` in the root directory.