### PR TITLE
Reserve core endpoints

### DIFF
--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -3,6 +3,7 @@ package resources
 import (
 	"fmt"
 	"path/filepath"
+	"strings"
 
 	"github.com/canonical/microcluster/v3/internal/endpoints"
 	internalTypes "github.com/canonical/microcluster/v3/internal/rest/types"
@@ -54,7 +55,10 @@ var InternalEndpoints = rest.Resources{
 // - The PathPrefix+Path of an endpoint conflicts with another endpoint in the same server.
 // - The address of the server clashes with another server.
 // - The server does not have defined resources.
-// If the Server is a core API server, its resources must not conflict with any other core API server, and it must not have a defined address or certificate.
+// - If the Server is a core API server:
+//   - The PathPrefix+Path of an endpoint must not begin with `core`.
+//   - Its resources must not conflict with any other core API server.
+//   - It must not have a defined address or certificate.
 func ValidateEndpoints(extensionServers map[string]rest.Server, coreAddress string) error {
 	serverAddresses := map[string]bool{coreAddress: true}
 	baseCoreEndpoints := []rest.Resources{UnixEndpoints, PublicEndpoints, InternalEndpoints}
@@ -106,6 +110,11 @@ func ValidateEndpoints(extensionServers map[string]rest.Server, coreAddress stri
 				internalName := serverName
 				if server.CoreAPI {
 					internalName = endpoints.EndpointsCore
+
+					// Reserve the /core namespace for microcluster
+					if firstPathElement(url) == endpoints.EndpointsCore {
+						return fmt.Errorf("Endpoint from server %q conflicts with reserved namespace \"/%s\"", serverName, endpoints.EndpointsCore)
+					}
 				}
 
 				_, ok := existingEndpointPaths[internalName]
@@ -123,4 +132,28 @@ func ValidateEndpoints(extensionServers map[string]rest.Server, coreAddress stri
 	}
 
 	return nil
+}
+
+// "core/"   -> "core"
+// "/core"   -> "core"
+// "/core/x" -> "core"
+// "/"       -> ""
+// Returns the first non-root path element in `path`.
+func firstPathElement(path string) string {
+	parts := strings.SplitN(path, "/", 3)
+	switch len(parts) {
+	case 0:
+		// Shouldn't be possible
+		return path
+	case 1:
+		return parts[0]
+	default:
+		if parts[0] == "" {
+			// "/core"
+			return parts[1]
+		} else {
+			// "core/"
+			return parts[0]
+		}
+	}
 }

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -102,6 +102,10 @@ func ValidateEndpoints(extensionServers map[string]rest.Server, coreAddress stri
 		// Ensure no endpoint path conflicts with another endpoint on the same server.
 		// If a server is an extension to the core API, it will be compared against all core API paths.
 		for _, resource := range server.Resources {
+			if len(resource.Endpoints) == 0 {
+				return fmt.Errorf("Server %q resource must have defined endpoints", serverName)
+			}
+
 			for _, e := range resource.Endpoints {
 				url := filepath.Join(string(resource.PathPrefix), e.Path)
 

--- a/internal/rest/resources/resources_test.go
+++ b/internal/rest/resources/resources_test.go
@@ -1,0 +1,101 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/canonical/microcluster/v3/rest"
+)
+
+var validServers = map[string]rest.Server{
+	"coreConsumer": {
+		CoreAPI: true,
+		Resources: []rest.Resources{
+			{
+				PathPrefix: "core_consumer",
+			},
+		},
+	},
+}
+
+func TestValidateEndpointsValidServers(t *testing.T) {
+	err := ValidateEndpoints(validServers, "localhost:8000")
+	if err != nil {
+		t.Errorf("Valid server failed validation: %s", err)
+	}
+}
+
+var invalidServers = map[string]rest.Server{
+	"emptyResources": {
+		CoreAPI: true,
+	},
+	"duplicate": {
+		Resources: []rest.Resources{
+			{
+				PathPrefix: "dup",
+				Endpoints: []rest.Endpoint{
+					{
+						Path: "duplicate",
+					},
+				},
+			},
+			{
+				PathPrefix: "dup",
+				Endpoints: []rest.Endpoint{
+					{
+						Path: "duplicate",
+					},
+				},
+			},
+		},
+	},
+	"overlapCore": {
+		CoreAPI: true,
+		Resources: []rest.Resources{
+			{
+				PathPrefix: "core",
+				Endpoints: []rest.Endpoint{
+					{
+						Path: "hello",
+					},
+				},
+			},
+		},
+	},
+	"overlapCoreMultipart": {
+		CoreAPI: true,
+		Resources: []rest.Resources{
+			{
+				PathPrefix: "core/subpoint",
+				Endpoints: []rest.Endpoint{
+					{
+						Path: "hello",
+					},
+				},
+			},
+		},
+	},
+	"overlapCoreEndpoint": {
+		CoreAPI: true,
+		Resources: []rest.Resources{
+			{
+				Endpoints: []rest.Endpoint{
+					{
+						Path: "core/subpoint",
+					},
+				},
+			},
+		},
+	},
+}
+
+func TestValidateEndpointsInvalidServers(t *testing.T) {
+	for serverName, server := range invalidServers {
+		servers := map[string]rest.Server{
+			serverName: server,
+		}
+		err := ValidateEndpoints(servers, "localhost:8000")
+		if err == nil {
+			t.Errorf("Invalid server %q passed validation", serverName)
+		}
+	}
+}

--- a/internal/rest/resources/resources_test.go
+++ b/internal/rest/resources/resources_test.go
@@ -12,6 +12,11 @@ var validServers = map[string]rest.Server{
 		Resources: []rest.Resources{
 			{
 				PathPrefix: "core_consumer",
+				Endpoints: []rest.Endpoint{
+					{
+						Path: "hello",
+					},
+				},
 			},
 		},
 	},
@@ -27,6 +32,10 @@ func TestValidateEndpointsValidServers(t *testing.T) {
 var invalidServers = map[string]rest.Server{
 	"emptyResources": {
 		CoreAPI: true,
+	},
+	"emptyEndpoints": {
+		CoreAPI:   true,
+		Resources: []rest.Resources{},
 	},
 	"duplicate": {
 		Resources: []rest.Resources{


### PR DESCRIPTION
Prevent CoreAPI extension servers from creating endpoints under `/core`.

Fixes #227 