### PR TITLE
Add role change data to `OnHeartbeat` hook

### DIFF
--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -171,9 +171,18 @@ func (c *cmdDaemon) run(cmd *cobra.Command, args []string) error {
 		},
 
 		// OnHeartbeat is run after a successful heartbeat round.
-		OnHeartbeat: func(ctx context.Context, s state.State) error {
-			logger.Info("This is a hook that is run on the dqlite leader after a successful heartbeat")
+		OnHeartbeat: func(ctx context.Context, s state.State, roleStatus map[string]types.RoleStatus) error {
+			logger.Info("This is a hook that is run on the dqlite leader after a successful heartbeat; role information for cluster members is available")
 
+			// You can check if the role of a cluster member has changed since the last heartbeat and determine
+			// its previous and current roles.
+			myStatus := roleStatus[s.Name()]
+			if myStatus.RoleChanged() {
+				logger.Infof("Role of cluster member %s changed from %s to %s", s.Name(), myStatus.Old, myStatus.New)
+				return nil
+			}
+
+			logger.Infof("Role of member %s remains unchanged as %s", s.Name(), myStatus.Old)
 			return nil
 		},
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -345,6 +345,7 @@ func (d *Daemon) applyHooks(hooks *state.Hooks) {
 	noOpInitHook := func(ctx context.Context, s state.State, initConfig map[string]string) error { return nil }
 	noOpConfigHook := func(ctx context.Context, s state.State, config types.DaemonConfig) error { return nil }
 	noOpNewMemberHook := func(ctx context.Context, s state.State, newMember types.ClusterMemberLocal) error { return nil }
+	noOpHeartbeatHook := func(ctx context.Context, s state.State, roleStatus map[string]types.RoleStatus) error { return nil }
 
 	if hooks == nil {
 		d.hooks = state.Hooks{}
@@ -373,7 +374,7 @@ func (d *Daemon) applyHooks(hooks *state.Hooks) {
 	}
 
 	if d.hooks.OnHeartbeat == nil {
-		d.hooks.OnHeartbeat = noOpHook
+		d.hooks.OnHeartbeat = noOpHeartbeatHook
 	}
 
 	if d.hooks.OnNewMember == nil {

--- a/internal/state/hooks.go
+++ b/internal/state/hooks.go
@@ -33,7 +33,7 @@ type Hooks struct {
 	PostRemove func(ctx context.Context, s State, force bool) error
 
 	// OnHeartbeat is run after a successful heartbeat round.
-	OnHeartbeat func(ctx context.Context, s State) error
+	OnHeartbeat func(ctx context.Context, s State, roleStatus map[string]types.RoleStatus) error
 
 	// OnNewMember is run on each peer after a new cluster member has joined and executed their 'PreJoin' hook.
 	OnNewMember func(ctx context.Context, s State, newMember types.ClusterMemberLocal) error

--- a/rest/types/cluster.go
+++ b/rest/types/cluster.go
@@ -28,6 +28,17 @@ type ClusterMemberLocal struct {
 // MemberStatus represents the online status of a cluster member.
 type MemberStatus string
 
+// RoleStatus represents the previous and current role of a cluster member.
+type RoleStatus struct {
+	Old string
+	New string
+}
+
+// RoleChanged returns whether there has been a role change.
+func (rs RoleStatus) RoleChanged() bool {
+	return rs.Old != rs.New
+}
+
 const (
 	// MemberOnline should be the MemberStatus when the node is online and reachable.
 	MemberOnline MemberStatus = "ONLINE"


### PR DESCRIPTION
This PR adds functionality to inject role change information into the `OnHeartbeat` hook.

Closes https://github.com/canonical/microcluster/issues/209.