### PR TITLE
Lint: Fix error strings reported by golangci-lint `v1.60.1`

### DIFF
--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -241,7 +241,7 @@ func (db *DqliteDB) IsOpen(ctx context.Context) error {
 	case types.DatabaseOffline:
 		fallthrough
 	case types.DatabaseStarting:
-		return api.StatusErrorf(http.StatusServiceUnavailable, string(status))
+		return api.StatusErrorf(http.StatusServiceUnavailable, "%s", string(status))
 
 	case types.DatabaseWaiting:
 		intVersion, extversion, apiExtensions := db.Schema().Version()

--- a/internal/rest/client/response.go
+++ b/internal/rest/client/response.go
@@ -25,7 +25,7 @@ func parseResponse(resp *http.Response) (*api.Response, error) {
 
 	// Handle errors
 	if response.Type == api.ErrorResponse {
-		return nil, api.StatusErrorf(resp.StatusCode, response.Error)
+		return nil, api.StatusErrorf(resp.StatusCode, "%s", response.Error)
 	}
 
 	return &response, nil

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -243,7 +243,7 @@ func clusterGet(s state.State, r *http.Request) response.Response {
 
 	// If the database is not in a ready or waiting state, we can't be sure it's available for use.
 	if status != types.DatabaseReady && status != types.DatabaseWaiting {
-		return response.SmartError(api.StatusErrorf(http.StatusServiceUnavailable, string(status)))
+		return response.SmartError(api.StatusErrorf(http.StatusServiceUnavailable, "%s", string(status)))
 	}
 
 	var apiClusterMembers []types.ClusterMember

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -375,7 +375,7 @@ func (m *MicroCluster) SQL(ctx context.Context, query string) (string, *internal
 			return "", nil, fmt.Errorf("failed to parse dump response: %w", err)
 		}
 
-		return fmt.Sprintf(dump.Text), nil, nil
+		return dump.Text, nil, nil
 	}
 
 	data := internalTypes.SQLQuery{


### PR DESCRIPTION
The latest release [`v1.60.1`](https://github.com/golangci/golangci-lint/releases/tag/v1.60.1) of `golangci-lint` is reporting some errors during `make check-static` execution on the `v3` branch: https://github.com/canonical/microcluster/actions/runs/10383022374/job/28748044082

This PR fixes the format strings.