### PR TITLE
Client: Add websocket client and more control over the cert selection

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -6,6 +6,7 @@ import (
 
 	clusterRequest "github.com/canonical/lxd/lxd/cluster/request"
 	"github.com/canonical/lxd/shared/api"
+	"github.com/gorilla/websocket"
 
 	"github.com/canonical/microcluster/v3/internal/rest/client"
 	"github.com/canonical/microcluster/v3/rest/types"
@@ -28,6 +29,15 @@ func (c *Client) Query(ctx context.Context, method string, prefix types.Endpoint
 	defer cancel()
 
 	return c.QueryStruct(queryCtx, method, prefix, path, in, &out)
+}
+
+// Websocket is a helper for upgrading a request to websocket on any endpoints defined external to microcluster.
+// This function should be used for all client methods defined externally from microcluster.
+func (c *Client) Websocket(ctx context.Context, prefix types.EndpointPrefix, path *api.URL) (*websocket.Conn, error) {
+	websocketCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	return c.RawWebsocket(websocketCtx, prefix, path)
 }
 
 // UseTarget returns a new client with the query "?target=name" set.

--- a/client/client.go
+++ b/client/client.go
@@ -12,7 +12,7 @@ import (
 	"github.com/canonical/microcluster/v3/rest/types"
 )
 
-// Client is a rest client for the MicroCluster daemon.
+// Client is a rest client for the microcluster daemon.
 type Client struct {
 	client.Client
 }
@@ -22,8 +22,8 @@ func IsNotification(r *http.Request) bool {
 	return r.Header.Get("User-Agent") == clusterRequest.UserAgentNotifier
 }
 
-// Query is a helper for initiating a request on any endpoints defined external to Microcluster. This function should be used for all client
-// methods defined externally from MicroCluster.
+// Query is a helper for initiating a request on any endpoints defined external to microcluster. This function should be used for all client
+// methods defined externally from microcluster.
 func (c *Client) Query(ctx context.Context, method string, prefix types.EndpointPrefix, path *api.URL, in any, out any) error {
 	queryCtx, cancel := context.WithCancel(ctx)
 	defer cancel()

--- a/internal/rest/client/client.go
+++ b/internal/rest/client/client.go
@@ -22,6 +22,7 @@ import (
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/canonical/lxd/shared/tcp"
+	"github.com/gorilla/websocket"
 
 	"github.com/canonical/microcluster/v3/rest/types"
 )
@@ -315,6 +316,61 @@ func (c *Client) QueryStruct(ctx context.Context, method string, endpointType ty
 	logger.Debug("Got response struct from microcluster daemon", logger.Ctx{"endpoint": localURL.String(), "method": method})
 	// TODO: Log.pretty.
 	return nil
+}
+
+// RawWebsocket dials the provided endpoint and tries to upgrade the connection.
+//
+// The final URL is that provided as the endpoint combined with the applicable prefix for the endpointType and the scheme and host from the client.
+func (c *Client) RawWebsocket(ctx context.Context, endpointType types.EndpointPrefix, endpoint *api.URL) (*websocket.Conn, error) {
+	// Merge the provided URL with the one we have for the client.
+	localURL := c.mergeURL(endpointType, endpoint)
+
+	// Pick the right scheme based on the client configuration.
+	if c.url.URL.Scheme == "http" {
+		localURL.URL.Scheme = "ws"
+	} else {
+		localURL.URL.Scheme = "wss"
+	}
+
+	// Get the transport configuration from the HTTP client.
+	tr, ok := c.Client.Transport.(*http.Transport)
+	if !ok {
+		return nil, fmt.Errorf("Invalid underlying client transport, expected %T, got %T", &http.Transport{}, c.Client.Transport)
+	}
+
+	// Setup a new websocket dialer using the already existing HTTP client.
+	// As the client might be either local or remote always copy the relevant TLS config too.
+	dialer := websocket.Dialer{
+		NetDialContext:    tr.DialContext,
+		NetDialTLSContext: tr.DialTLSContext,
+		TLSClientConfig:   tr.TLSClientConfig,
+		Proxy:             tr.Proxy,
+	}
+
+	// Assign a context timeout if we don't already have one.
+	_, ok = ctx.Deadline()
+	if !ok {
+		timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+		ctx = timeoutCtx
+		defer cancel()
+	}
+
+	// Establish the connection
+	conn, resp, err := dialer.DialContext(ctx, localURL.String(), nil)
+	if err != nil {
+		if resp != nil {
+			_, err := parseResponse(resp)
+			if err != nil {
+				return nil, fmt.Errorf("Failed websocket upgrade request: %w", err)
+			}
+		}
+
+		return nil, fmt.Errorf("Failed to establish websocket connection: %w", err)
+	}
+
+	logger.Debug("Established websocket connection", logger.Ctx{"endpoint": localURL.String()})
+
+	return conn, nil
 }
 
 // URL returns the address used for the client.

--- a/internal/rest/client/client.go
+++ b/internal/rest/client/client.go
@@ -268,12 +268,7 @@ func (c *Client) MakeRequest(r *http.Request) (*api.Response, error) {
 	return parsedResponse, nil
 }
 
-// QueryStruct sends a request of the specified method to the provided endpoint (optional) on the API matching the endpointType.
-// The response gets unpacked into the target struct. POST requests can optionally provide raw data to be sent through.
-//
-// The final URL is that provided as the endpoint combined with the applicable prefix for the endpointType and the scheme and host from the client.
-func (c *Client) QueryStruct(ctx context.Context, method string, endpointType types.EndpointPrefix, endpoint *api.URL, data any, target any) error {
-	// Merge the provided URL with the one we have for the client.
+func (c *Client) mergeURL(endpointType types.EndpointPrefix, endpoint *api.URL) *api.URL {
 	localURL := api.NewURL()
 	if endpoint != nil {
 		// Get a new local struct to avoid modifying the provided one.
@@ -293,6 +288,16 @@ func (c *Client) QueryStruct(ctx context.Context, method string, endpointType ty
 	}
 
 	localURL.URL.RawQuery = clientQuery.Encode()
+	return localURL
+}
+
+// QueryStruct sends a request of the specified method to the provided endpoint (optional) on the API matching the endpointType.
+// The response gets unpacked into the target struct. POST requests can optionally provide raw data to be sent through.
+//
+// The final URL is that provided as the endpoint combined with the applicable prefix for the endpointType and the scheme and host from the client.
+func (c *Client) QueryStruct(ctx context.Context, method string, endpointType types.EndpointPrefix, endpoint *api.URL, data any, target any) error {
+	// Merge the provided URL with the one we have for the client.
+	localURL := c.mergeURL(endpointType, endpoint)
 
 	// Send the actual query through.
 	resp, err := c.rawQuery(ctx, method, localURL, data)


### PR DESCRIPTION
This PR adds a new client `Websocket` function that allows upgrading a HTTP connection using either the local or remote client.

Furthermore another `RemoteClientWithCert` app function is added which allows providing a custom remote server cert in case the remote is not using the common cluster cert. 
This is helpful during the pre-init phase (MicroCloud explicit trust establishment) as well as when trying to connect to additional servers making use of mTLS.