### PR TITLE
Reserve core endpoints backport to v2

### DIFF
--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -241,7 +241,7 @@ func (db *DqliteDB) IsOpen(ctx context.Context) error {
 	case types.DatabaseOffline:
 		fallthrough
 	case types.DatabaseStarting:
-		return api.StatusErrorf(http.StatusServiceUnavailable, string(status))
+		return api.StatusErrorf(http.StatusServiceUnavailable, "%s", string(status))
 
 	case types.DatabaseWaiting:
 		intVersion, extversion, apiExtensions := db.Schema().Version()

--- a/internal/rest/client/response.go
+++ b/internal/rest/client/response.go
@@ -25,7 +25,7 @@ func parseResponse(resp *http.Response) (*api.Response, error) {
 
 	// Handle errors
 	if response.Type == api.ErrorResponse {
-		return nil, api.StatusErrorf(resp.StatusCode, response.Error)
+		return nil, api.StatusErrorf(resp.StatusCode, "%s", response.Error)
 	}
 
 	return &response, nil

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -243,7 +243,7 @@ func clusterGet(s state.State, r *http.Request) response.Response {
 
 	// If the database is not in a ready or waiting state, we can't be sure it's available for use.
 	if status != types.DatabaseReady && status != types.DatabaseWaiting {
-		return response.SmartError(api.StatusErrorf(http.StatusServiceUnavailable, string(status)))
+		return response.SmartError(api.StatusErrorf(http.StatusServiceUnavailable, "%s", string(status)))
 	}
 
 	var apiClusterMembers []types.ClusterMember

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -110,6 +110,10 @@ func ValidateEndpoints(extensionServers map[string]rest.Server, coreAddress stri
 		// Ensure no endpoint path conflicts with another endpoint on the same server.
 		// If a server is an extension to the core API, it will be compared against all core API paths.
 		for _, resource := range server.Resources {
+			if len(resource.Endpoints) == 0 {
+				return fmt.Errorf("Server %q resource must have defined endpoints", serverName)
+			}
+
 			for _, e := range resource.Endpoints {
 				url := filepath.Join(string(resource.PathPrefix), e.Path)
 

--- a/internal/rest/resources/resources_test.go
+++ b/internal/rest/resources/resources_test.go
@@ -12,6 +12,11 @@ var validServers = map[string]rest.Server{
 		Resources: []rest.Resources{
 			{
 				PathPrefix: "core_consumer",
+				Endpoints: []rest.Endpoint{
+					{
+						Path: "hello",
+					},
+				},
 			},
 		},
 	},
@@ -27,6 +32,10 @@ func TestValidateEndpointsValidServers(t *testing.T) {
 var invalidServers = map[string]rest.Server{
 	"emptyResources": {
 		CoreAPI: true,
+	},
+	"emptyEndpoints": {
+		CoreAPI:   true,
+		Resources: []rest.Resources{},
 	},
 	"duplicate": {
 		Resources: []rest.Resources{

--- a/internal/rest/resources/resources_test.go
+++ b/internal/rest/resources/resources_test.go
@@ -1,0 +1,101 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/canonical/microcluster/v2/rest"
+)
+
+var validServers = map[string]rest.Server{
+	"coreConsumer": {
+		CoreAPI: true,
+		Resources: []rest.Resources{
+			{
+				PathPrefix: "core_consumer",
+			},
+		},
+	},
+}
+
+func TestValidateEndpointsValidServers(t *testing.T) {
+	err := ValidateEndpoints(validServers, "localhost:8000")
+	if err != nil {
+		t.Errorf("Valid server failed validation: %s", err)
+	}
+}
+
+var invalidServers = map[string]rest.Server{
+	"emptyResources": {
+		CoreAPI: true,
+	},
+	"duplicate": {
+		Resources: []rest.Resources{
+			{
+				PathPrefix: "dup",
+				Endpoints: []rest.Endpoint{
+					{
+						Path: "duplicate",
+					},
+				},
+			},
+			{
+				PathPrefix: "dup",
+				Endpoints: []rest.Endpoint{
+					{
+						Path: "duplicate",
+					},
+				},
+			},
+		},
+	},
+	"overlapCore": {
+		CoreAPI: true,
+		Resources: []rest.Resources{
+			{
+				PathPrefix: "core",
+				Endpoints: []rest.Endpoint{
+					{
+						Path: "hello",
+					},
+				},
+			},
+		},
+	},
+	"overlapCoreMultipart": {
+		CoreAPI: true,
+		Resources: []rest.Resources{
+			{
+				PathPrefix: "core/subpoint",
+				Endpoints: []rest.Endpoint{
+					{
+						Path: "hello",
+					},
+				},
+			},
+		},
+	},
+	"overlapCoreEndpoint": {
+		CoreAPI: true,
+		Resources: []rest.Resources{
+			{
+				Endpoints: []rest.Endpoint{
+					{
+						Path: "core/subpoint",
+					},
+				},
+			},
+		},
+	},
+}
+
+func TestValidateEndpointsInvalidServers(t *testing.T) {
+	for serverName, server := range invalidServers {
+		servers := map[string]rest.Server{
+			serverName: server,
+		}
+		err := ValidateEndpoints(servers, "localhost:8000")
+		if err == nil {
+			t.Errorf("Invalid server %q passed validation", serverName)
+		}
+	}
+}

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -375,7 +375,7 @@ func (m *MicroCluster) SQL(ctx context.Context, query string) (string, *internal
 			return "", nil, fmt.Errorf("failed to parse dump response: %w", err)
 		}
 
-		return fmt.Sprintf(dump.Text), nil, nil
+		return dump.Text, nil, nil
 	}
 
 	data := internalTypes.SQLQuery{


### PR DESCRIPTION
Backport of #231

Not sure if I did it right but also backported #236 so that the tests pass