### PR TITLE
Rest: Return validation errors from the database handlers

### DIFF
--- a/internal/rest/resources/database.go
+++ b/internal/rest/resources/database.go
@@ -29,7 +29,7 @@ func databasePost(state state.State, r *http.Request) response.Response {
 
 	_, err := strconv.Atoi(versionHeader)
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Invalid dqlite vesion: %w", err))
+		return response.BadRequest(fmt.Errorf("Invalid dqlite version: %w", err))
 	}
 
 	// Handle leader address requests.
@@ -50,7 +50,7 @@ func databasePatch(s state.State, r *http.Request) response.Response {
 
 	_, err := strconv.Atoi(versionHeader)
 	if err != nil {
-		return response.BadRequest(fmt.Errorf("Invalid dqlite vesion: %w", err))
+		return response.BadRequest(fmt.Errorf("Invalid dqlite version: %w", err))
 	}
 
 	intState, err := state.ToInternal(s)


### PR DESCRIPTION
Fixes https://github.com/canonical/microcluster/issues/240

This PR ensures that any request validation for the database handlers happens before hijacking the connection so that errors can be returned to the caller.