### PR TITLE
Token: Validate name to be FQDN

### DIFF
--- a/example/test/main.sh
+++ b/example/test/main.sh
@@ -90,7 +90,7 @@ test_misc() {
   microctl --state-dir "${test_dir}/c1" init "c1" 127.0.0.1:9001 --bootstrap
 
   # Ensure only valid member names are used for join
-  token_node2=$(microctl --state-dir "${test_dir}/c1" tokens add "c/2")
+  token_node2=$(microctl --state-dir "${test_dir}/c1" tokens add "c2")
   ! microctl --state-dir "${test_dir}/c2" init "c/2" 127.0.0.1:9002 --token "${token_node2}" || false
 
   shutdown_systems
@@ -100,17 +100,25 @@ test_tokens() {
   new_systems 3 --heartbeat 4s
   bootstrap_systems
 
-  microctl --state-dir "${test_dir}/c1" tokens add default_expiry
+  # Ensure tokens with invalid names cannot be created
+  ! microctl --state-dir "${test_dir}/c1" tokens add ""
+  ! microctl --state-dir "${test_dir}/c1" tokens add "invalid_name"
+  ! microctl --state-dir "${test_dir}/c1" tokens add "invalid_"
+  ! microctl --state-dir "${test_dir}/c1" tokens add "_invalid"
+  ! microctl --state-dir "${test_dir}/c1" tokens add "invalid."
+  ! microctl --state-dir "${test_dir}/c1" tokens add ".invalid"
 
-  microctl --state-dir "${test_dir}/c1" tokens add short_expiry --expire-after 1s
+  microctl --state-dir "${test_dir}/c1" tokens add default-expiry
 
-  microctl --state-dir "${test_dir}/c1" tokens add long_expiry --expire-after 400h
+  microctl --state-dir "${test_dir}/c1" tokens add short-expiry --expire-after 1s
+
+  microctl --state-dir "${test_dir}/c1" tokens add long-expiry --expire-after 400h
 
   sleep 1
 
-  ! microctl --state-dir "${test_dir}/c1" tokens list --format csv | grep -q short_expiry || false
-  microctl --state-dir "${test_dir}/c1" tokens list --format csv | grep -q default_expiry
-  microctl --state-dir "${test_dir}/c1" tokens list --format csv | grep -q long_expiry
+  ! microctl --state-dir "${test_dir}/c1" tokens list --format csv | grep -q short-expiry || false
+  microctl --state-dir "${test_dir}/c1" tokens list --format csv | grep -q default-expiry
+  microctl --state-dir "${test_dir}/c1" tokens list --format csv | grep -q long-expiry
 
   # Ensure expired tokens cannot be used to join the cluster
   mkdir -p "${test_dir}/c4"

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -197,7 +197,7 @@ func (d *Daemon) Run(ctx context.Context, stateDir string, args Args) error {
 		// Check if the name is a valid FQDN as it might be used for the certificates SAN.
 		err := utils.ValidateFQDN(k)
 		if err != nil {
-			return fmt.Errorf("Invalid server name %q: %w", k, err)
+			return fmt.Errorf("Server name %q is not a valid FQDN: %w", k, err)
 		}
 
 		// `core` and `unix` are reserved server names.

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -91,7 +91,7 @@ func clusterPost(s state.State, r *http.Request) response.Response {
 
 	err = utils.ValidateFQDN(req.Name)
 	if err != nil {
-		return response.SmartError(fmt.Errorf("Invalid cluster member name %q: %w", req.Name, err))
+		return response.SmartError(fmt.Errorf("Cluster member name %q is not a valid FQDN: %w", req.Name, err))
 	}
 
 	// Check if any of the remote's addresses are currently in use.

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -51,7 +51,7 @@ func controlPost(state state.State, r *http.Request) response.Response {
 
 	err = utils.ValidateFQDN(req.Name)
 	if err != nil {
-		return response.SmartError(fmt.Errorf("Invalid cluster member name %q: %w", req.Name, err))
+		return response.SmartError(fmt.Errorf("Cluster member name %q is not a valid FQDN: %w", req.Name, err))
 	}
 
 	intState, err := internalState.ToInternal(state)

--- a/internal/rest/resources/tokens.go
+++ b/internal/rest/resources/tokens.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/canonical/microcluster/v3/cluster"
 	internalTypes "github.com/canonical/microcluster/v3/internal/rest/types"
 	"github.com/canonical/microcluster/v3/internal/state"
+	"github.com/canonical/microcluster/v3/internal/utils"
 	"github.com/canonical/microcluster/v3/rest"
 	"github.com/canonical/microcluster/v3/rest/access"
 	"github.com/canonical/microcluster/v3/rest/types"
@@ -41,6 +43,11 @@ func tokensPost(state state.State, r *http.Request) response.Response {
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		return response.BadRequest(err)
+	}
+
+	err = utils.ValidateFQDN(req.Name)
+	if err != nil {
+		return response.SmartError(fmt.Errorf("Token name %q is not a valid FQDN: %w", req.Name, err))
 	}
 
 	// Generate join token for new member. This will be stored alongside the join


### PR DESCRIPTION
Thanks @bschimke95 for reporting this.

Check if the supplied token name is a valid FQDN as it will be used later in the process when joining new cluster members into the existing cluster.
Those cluster member names are also validated to be a valid FQDN.