### PR TITLE
v2: Backport FQDN validation

### DIFF
--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -4,6 +4,7 @@ package main
 import (
 	"context"
 	"os"
+	"time"
 
 	"github.com/canonical/lxd/shared/logger"
 	"github.com/spf13/cobra"
@@ -44,6 +45,8 @@ type cmdDaemon struct {
 
 	flagStateDir    string
 	flagSocketGroup string
+
+	flagHeartbeatInterval time.Duration
 }
 
 func (c *cmdDaemon) command() *cobra.Command {
@@ -72,7 +75,8 @@ func (c *cmdDaemon) run(cmd *cobra.Command, args []string) error {
 		Debug:   c.global.flagLogDebug,
 		Version: version.Version(),
 
-		SocketGroup: c.flagSocketGroup,
+		SocketGroup:       c.flagSocketGroup,
+		HeartbeatInterval: c.flagHeartbeatInterval,
 
 		ExtensionsSchema: database.SchemaExtensions,
 		APIExtensions:    api.Extensions(),
@@ -204,6 +208,8 @@ func main() {
 
 	app.PersistentFlags().StringVar(&daemonCmd.flagStateDir, "state-dir", "", "Path to store state information"+"``")
 	app.PersistentFlags().StringVar(&daemonCmd.flagSocketGroup, "socket-group", "", "Group to set socket's group ownership to")
+
+	app.PersistentFlags().DurationVar(&daemonCmd.flagHeartbeatInterval, "heartbeat", time.Second*10, "Time between attempted heartbeats")
 
 	app.SetVersionTemplate("{{.Version}}\n")
 

--- a/example/test/main.sh
+++ b/example/test/main.sh
@@ -90,7 +90,7 @@ test_misc() {
   microctl --state-dir "${test_dir}/c1" init "c1" 127.0.0.1:9001 --bootstrap
 
   # Ensure only valid member names are used for join
-  token_node2=$(microctl --state-dir "${test_dir}/c1" tokens add "c/2")
+  token_node2=$(microctl --state-dir "${test_dir}/c1" tokens add "c2")
   ! microctl --state-dir "${test_dir}/c2" init "c/2" 127.0.0.1:9002 --token "${token_node2}" || false
 
   shutdown_systems
@@ -100,17 +100,25 @@ test_tokens() {
   new_systems 3 --heartbeat 4s
   bootstrap_systems
 
-  microctl --state-dir "${test_dir}/c1" tokens add default_expiry
+  # Ensure tokens with invalid names cannot be created
+  ! microctl --state-dir "${test_dir}/c1" tokens add ""
+  ! microctl --state-dir "${test_dir}/c1" tokens add "invalid_name"
+  ! microctl --state-dir "${test_dir}/c1" tokens add "invalid_"
+  ! microctl --state-dir "${test_dir}/c1" tokens add "_invalid"
+  ! microctl --state-dir "${test_dir}/c1" tokens add "invalid."
+  ! microctl --state-dir "${test_dir}/c1" tokens add ".invalid"
 
-  microctl --state-dir "${test_dir}/c1" tokens add short_expiry --expire-after 1s
+  microctl --state-dir "${test_dir}/c1" tokens add default-expiry
 
-  microctl --state-dir "${test_dir}/c1" tokens add long_expiry --expire-after 400h
+  microctl --state-dir "${test_dir}/c1" tokens add short-expiry --expire-after 1s
+
+  microctl --state-dir "${test_dir}/c1" tokens add long-expiry --expire-after 400h
 
   sleep 1
 
-  ! microctl --state-dir "${test_dir}/c1" tokens list --format csv | grep -q short_expiry || false
-  microctl --state-dir "${test_dir}/c1" tokens list --format csv | grep -q default_expiry
-  microctl --state-dir "${test_dir}/c1" tokens list --format csv | grep -q long_expiry
+  ! microctl --state-dir "${test_dir}/c1" tokens list --format csv | grep -q short-expiry || false
+  microctl --state-dir "${test_dir}/c1" tokens list --format csv | grep -q default-expiry
+  microctl --state-dir "${test_dir}/c1" tokens list --format csv | grep -q long-expiry
 
   # Ensure expired tokens cannot be used to join the cluster
   mkdir -p "${test_dir}/c4"

--- a/example/test/main.sh
+++ b/example/test/main.sh
@@ -11,6 +11,7 @@ if [ -n "${DEBUG:-}" ]; then
 fi
 
 if [ -n "${CLUSTER_VERBOSE:-}" ]; then
+  set -x
   cluster_flags+=("--verbose")
 fi
 
@@ -23,10 +24,12 @@ new_systems() {
     rm -r "${test_dir}"
   fi
 
+  microd_args=("${@}")
+
   for member in $(seq --format c%g "${1}"); do
     state_dir="${test_dir}/${member}"
     mkdir -p "${state_dir}"
-    microd --state-dir "${state_dir}" "${cluster_flags[@]}" &
+    microd --state-dir "${state_dir}" "${cluster_flags[@]}" "${microd_args[@]:2}" &
     microctl --state-dir "${state_dir}" waitready
   done
 }
@@ -76,7 +79,7 @@ shutdown_systems() {
 }
 
 test_misc() {
-  new_systems 2
+  new_systems 2 --heartbeat 2s
 
     # Ensure two daemons cannot start in the same state dir
   ! microd --state-dir "${test_dir}/c1" "${cluster_flags[@]}" || false
@@ -94,17 +97,16 @@ test_misc() {
 }
 
 test_tokens() {
-  new_systems 3
+  new_systems 3 --heartbeat 4s
   bootstrap_systems
 
   microctl --state-dir "${test_dir}/c1" tokens add default_expiry
 
-  microctl --state-dir "${test_dir}/c1" tokens add short_expiry --expire-after 5s
+  microctl --state-dir "${test_dir}/c1" tokens add short_expiry --expire-after 1s
 
   microctl --state-dir "${test_dir}/c1" tokens add long_expiry --expire-after 400h
 
-  # Need at least one heartbeat (every 10s)
-  sleep 15
+  sleep 1
 
   ! microctl --state-dir "${test_dir}/c1" tokens list --format csv | grep -q short_expiry || false
   microctl --state-dir "${test_dir}/c1" tokens list --format csv | grep -q default_expiry
@@ -115,10 +117,9 @@ test_tokens() {
   microd --state-dir "${test_dir}/c4" "${cluster_flags[@]}" &
   microctl --state-dir "${test_dir}/c4" waitready
 
-  # Assumes that heartbeats are 10s apart
-  token=$(microctl --state-dir "${test_dir}/c1" tokens add "c4" --expire-after 12s)
+  token=$(microctl --state-dir "${test_dir}/c1" tokens add "c4" --expire-after 1s)
 
-  sleep 12
+  sleep 1
 
   ! microctl --state-dir "${test_dir}/c4" init "c4" "127.0.0.1:9005" --token "${token}" || false
 
@@ -126,7 +127,7 @@ test_tokens() {
 }
 
 test_recover() {
-  new_systems 5
+  new_systems 5 --heartbeat 2s
   bootstrap_systems
   shutdown_systems
 
@@ -149,11 +150,12 @@ test_recover() {
 
   for member in c1 c2; do
     state_dir="${test_dir}/${member}"
-    microd --state-dir "${state_dir}" "${cluster_flags[@]}" > /dev/null &
+    microd --state-dir "${state_dir}" "${cluster_flags[@]}" --heartbeat 2s &
   done
+  microctl --state-dir "${test_dir}/c1" waitready
 
-  # microcluster takes a long time to update the member roles in the core_cluster_members table
-  sleep 90
+  # Allow for a round of heartbeats to update the member roles in core_cluster_members
+  sleep 3
 
   microctl --state-dir "${test_dir}/c1" cluster list
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -197,7 +197,7 @@ func (d *Daemon) Run(ctx context.Context, stateDir string, args Args) error {
 		// Check if the name is a valid FQDN as it might be used for the certificates SAN.
 		err := utils.ValidateFQDN(k)
 		if err != nil {
-			return fmt.Errorf("Invalid server name %q: %w", k, err)
+			return fmt.Errorf("Server name %q is not a valid FQDN: %w", k, err)
 		}
 
 		// `core` and `unix` are reserved server names.

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -91,7 +91,7 @@ func clusterPost(s state.State, r *http.Request) response.Response {
 
 	err = utils.ValidateFQDN(req.Name)
 	if err != nil {
-		return response.SmartError(fmt.Errorf("Invalid cluster member name %q: %w", req.Name, err))
+		return response.SmartError(fmt.Errorf("Cluster member name %q is not a valid FQDN: %w", req.Name, err))
 	}
 
 	// Check if any of the remote's addresses are currently in use.

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -51,7 +51,7 @@ func controlPost(state state.State, r *http.Request) response.Response {
 
 	err = utils.ValidateFQDN(req.Name)
 	if err != nil {
-		return response.SmartError(fmt.Errorf("Invalid cluster member name %q: %w", req.Name, err))
+		return response.SmartError(fmt.Errorf("Cluster member name %q is not a valid FQDN: %w", req.Name, err))
 	}
 
 	intState, err := internalState.ToInternal(state)

--- a/internal/rest/resources/tokens.go
+++ b/internal/rest/resources/tokens.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"time"
@@ -16,6 +17,7 @@ import (
 	"github.com/canonical/microcluster/v2/cluster"
 	internalTypes "github.com/canonical/microcluster/v2/internal/rest/types"
 	"github.com/canonical/microcluster/v2/internal/state"
+	"github.com/canonical/microcluster/v2/internal/utils"
 	"github.com/canonical/microcluster/v2/rest"
 	"github.com/canonical/microcluster/v2/rest/access"
 	"github.com/canonical/microcluster/v2/rest/types"
@@ -41,6 +43,11 @@ func tokensPost(state state.State, r *http.Request) response.Response {
 	err := json.NewDecoder(r.Body).Decode(&req)
 	if err != nil {
 		return response.BadRequest(err)
+	}
+
+	err = utils.ValidateFQDN(req.Name)
+	if err != nil {
+		return response.SmartError(fmt.Errorf("Token name %q is not a valid FQDN: %w", req.Name, err))
 	}
 
 	// Generate join token for new member. This will be stored alongside the join

--- a/internal/utils/validation.go
+++ b/internal/utils/validation.go
@@ -1,9 +1,10 @@
 package utils
 
 import (
-	"fmt"
+	"net/http"
 	"strings"
 
+	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/validate"
 )
 
@@ -11,14 +12,14 @@ import (
 func ValidateFQDN(name string) error {
 	// Validate length
 	if len(name) < 1 || len(name) > 255 {
-		return fmt.Errorf("Name must be 1-255 characters long")
+		return api.StatusErrorf(http.StatusBadRequest, "%s", "Name must be 1-255 characters long")
 	}
 
 	hostnames := strings.Split(name, ".")
 	for _, h := range hostnames {
 		err := validate.IsHostname(h)
 		if err != nil {
-			return err
+			return api.StatusErrorf(http.StatusBadRequest, "%s", err.Error())
 		}
 	}
 


### PR DESCRIPTION
This also includes the commits from https://github.com/canonical/microcluster/pull/217.

The last commit is taken from https://github.com/canonical/microcluster/pull/246 which should be merged first.