### PR TITLE
Client: Add new `QueryRaw` function

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -31,6 +31,15 @@ func (c *Client) Query(ctx context.Context, method string, prefix types.Endpoint
 	return c.QueryStruct(queryCtx, method, prefix, path, in, &out)
 }
 
+// QueryRaw is a helper for initiating a request on any endpoints defined external to microcluster.
+// Unlike Query it returns the raw HTTP response.
+func (c *Client) QueryRaw(ctx context.Context, method string, prefix types.EndpointPrefix, path *api.URL, in any) (*http.Response, error) {
+	queryCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	return c.QueryStructRaw(queryCtx, method, prefix, path, in)
+}
+
 // Websocket is a helper for upgrading a request to websocket on any endpoints defined external to microcluster.
 // This function should be used for all client methods defined externally from microcluster.
 func (c *Client) Websocket(ctx context.Context, prefix types.EndpointPrefix, path *api.URL) (*websocket.Conn, error) {

--- a/internal/rest/client/client.go
+++ b/internal/rest/client/client.go
@@ -255,6 +255,8 @@ func (c *Client) rawQuery(ctx context.Context, method string, url *api.URL, data
 }
 
 // MakeRequest performs a request and parses the response into an api.Response.
+// This function can be used instead of the QueryStruct if custom settings have
+// to be applied to the request struct.
 func (c *Client) MakeRequest(r *http.Request) (*api.Response, error) {
 	// Send the request
 	resp, err := c.Do(r)

--- a/internal/rest/client/client.go
+++ b/internal/rest/client/client.go
@@ -24,6 +24,7 @@ import (
 	"github.com/canonical/lxd/shared/tcp"
 	"github.com/gorilla/websocket"
 
+	"github.com/canonical/microcluster/v3/rest/response"
 	"github.com/canonical/microcluster/v3/rest/types"
 )
 
@@ -261,15 +262,9 @@ func (c *Client) MakeRequest(r *http.Request) (*api.Response, error) {
 		return nil, err
 	}
 
-	parsedResponse, err := parseResponse(resp)
+	parsedResponse, err := response.ParseResponse(resp)
 	if err != nil {
 		return nil, err
-	}
-
-	defer resp.Body.Close()
-	_, err = io.Copy(io.Discard, resp.Body)
-	if err != nil {
-		logger.Error("Failed to read response body", logger.Ctx{"error": err})
 	}
 
 	return parsedResponse, nil
@@ -365,7 +360,7 @@ func (c *Client) RawWebsocket(ctx context.Context, endpointType types.EndpointPr
 	conn, resp, err := dialer.DialContext(ctx, localURL.String(), nil)
 	if err != nil {
 		if resp != nil {
-			_, err := parseResponse(resp)
+			_, err := response.ParseResponse(resp)
 			if err != nil {
 				return nil, fmt.Errorf("Failed websocket upgrade request: %w", err)
 			}

--- a/internal/rest/client/client.go
+++ b/internal/rest/client/client.go
@@ -191,7 +191,7 @@ func IsForwardedRequest(r *http.Request) bool {
 	return r.Header.Get("User-Agent") == clusterRequest.UserAgentNotifier
 }
 
-func (c *Client) rawQuery(ctx context.Context, method string, url *api.URL, data any) (*api.Response, error) {
+func (c *Client) rawQuery(ctx context.Context, method string, url *api.URL, data any) (*http.Response, error) {
 	var req *http.Request
 	var err error
 
@@ -244,7 +244,13 @@ func (c *Client) rawQuery(ctx context.Context, method string, url *api.URL, data
 		}
 	}
 
-	return c.MakeRequest(req)
+	// Send the request
+	resp, err := c.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return resp, nil
 }
 
 // MakeRequest performs a request and parses the response into an api.Response.


### PR DESCRIPTION
This PR adds another `QueryRaw` function to the client which allows accessing the raw `*http.Response`.
That is required for the https://github.com/canonical/microcloud/pull/383 in order to access the remotes certificate used in the TLS connection.

Furthermore the parsing of API responses is moved into the public facing package to allow any user of `QueryRaw` to both access the raw response and parsing it as usual.