### PR TITLE
Update `Render` from LXD and pass request

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.5
 
 require (
 	github.com/canonical/go-dqlite v1.22.0
-	github.com/canonical/lxd v0.0.0-20240822122218-e7b2a7a83230
+	github.com/canonical/lxd v0.0.0-20240906102712-be65fe046f98
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/google/renameio v1.0.1
 	github.com/gorilla/mux v1.8.1
@@ -45,7 +45,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/zitadel/logging v0.6.0 // indirect
-	github.com/zitadel/oidc/v3 v3.27.0 // indirect
+	github.com/zitadel/oidc/v3 v3.28.2 // indirect
 	github.com/zitadel/schema v1.3.0 // indirect
 	go.opentelemetry.io/otel v1.28.0 // indirect
 	go.opentelemetry.io/otel/metric v1.28.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -54,8 +54,8 @@ github.com/bmatcuk/doublestar/v4 v4.6.1 h1:FH9SifrbvJhnlQpztAx++wlkk70QBf0iBWDwN
 github.com/bmatcuk/doublestar/v4 v4.6.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/canonical/go-dqlite v1.22.0 h1:DuJmfcREl4gkQJyvZzjl2GHFZROhbPyfdjDRQXpkOyw=
 github.com/canonical/go-dqlite v1.22.0/go.mod h1:Uvy943N8R4CFUAs59A1NVaziWY9nJ686lScY7ywurfg=
-github.com/canonical/lxd v0.0.0-20240822122218-e7b2a7a83230 h1:YOqZ+/14OPZ+/TOXpRHIX3KLT0C+wZVpewKIwlGUmW0=
-github.com/canonical/lxd v0.0.0-20240822122218-e7b2a7a83230/go.mod h1:YVGI7HStOKsV+cMyXWnJ7RaMPaeWtrkxyIPvGWbgACc=
+github.com/canonical/lxd v0.0.0-20240906102712-be65fe046f98 h1:qIAlzHSoZ5lqAZrY06mEFhq2YOIOPRSqapWktFJna94=
+github.com/canonical/lxd v0.0.0-20240906102712-be65fe046f98/go.mod h1:ebmIFCKHkOrzL0ahCy2maJTmPtk+oadjYFwGJyGVUMc=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
 github.com/chzyer/logex v1.1.10/go.mod h1:+Ywpsq7O8HXn0nuIou7OrIPyXbp3wmkHB+jjWRnGsAI=
 github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e/go.mod h1:nSuG5e5PlCu98SY8svDHJxuZscDgtXS6KTTbou5AhLI=
@@ -325,8 +325,8 @@ github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
 github.com/zitadel/logging v0.6.0 h1:t5Nnt//r+m2ZhhoTmoPX+c96pbMarqJvW1Vq6xFTank=
 github.com/zitadel/logging v0.6.0/go.mod h1:Y4CyAXHpl3Mig6JOszcV5Rqqsojj+3n7y2F591Mp/ow=
-github.com/zitadel/oidc/v3 v3.27.0 h1:zeYpyRH0UcgdCjVHUYzSsqf1jbSwVMPVxYKOnRXstgU=
-github.com/zitadel/oidc/v3 v3.27.0/go.mod h1:ZwBEqSviCpJVZiYashzo53bEGRGXi7amE5Q8PpQg9IM=
+github.com/zitadel/oidc/v3 v3.28.2 h1:poJmUjjJhgSNgfzyVtArnnAlXhXCpefsvEV36rUwM9s=
+github.com/zitadel/oidc/v3 v3.28.2/go.mod h1:WmDFu3dZ9YNKrIoZkmxjGG8QyUR4PbbhsVVSY+rpojM=
 github.com/zitadel/schema v1.3.0 h1:kQ9W9tvIwZICCKWcMvCEweXET1OcOyGEuFbHs4o5kg0=
 github.com/zitadel/schema v1.3.0/go.mod h1:NptN6mkBDFvERUCvZHlvWmmME+gmZ44xzwRXwhzsbtc=
 go.etcd.io/etcd/api/v3 v3.5.0/go.mod h1:cbVKeC6lCfl7j/8jBhAK6aIYO9XOjdptoxU/nLQcPvs=

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -470,7 +470,7 @@ func (d *Daemon) initServer(resources ...rest.Resources) *http.Server {
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		err := response.SyncResponse(true, []string{"/1.0"}).Render(w)
+		err := response.SyncResponse(true, []string{"/1.0"}).Render(w, r)
 		if err != nil {
 			logger.Error("Failed to write HTTP response", logger.Ctx{"url": r.URL, "err": err})
 		}
@@ -479,7 +479,7 @@ func (d *Daemon) initServer(resources ...rest.Resources) *http.Server {
 	mux.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger.Info("Sending top level 404", logger.Ctx{"url": r.URL})
 		w.Header().Set("Content-Type", "application/json")
-		err := response.NotFound(nil).Render(w)
+		err := response.NotFound(nil).Render(w, r)
 		if err != nil {
 			logger.Error("Failed to write HTTP response", logger.Ctx{"url": r.URL, "err": err})
 		}

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -328,7 +328,7 @@ func clusterMemberPut(s state.State, r *http.Request) response.Response {
 	go reExec()
 
 	return response.ManualResponse(func(w http.ResponseWriter) error {
-		err := response.EmptySyncResponse.Render(w)
+		err := response.EmptySyncResponse.Render(w, r)
 		if err != nil {
 			return err
 		}
@@ -448,7 +448,7 @@ func clusterMemberDelete(s state.State, r *http.Request) response.Response {
 		}
 
 		return response.ManualResponse(func(w http.ResponseWriter) error {
-			err := response.EmptySyncResponse.Render(w)
+			err := response.EmptySyncResponse.Render(w, r)
 			if err != nil {
 				return err
 			}
@@ -566,7 +566,7 @@ func clusterMemberDelete(s state.State, r *http.Request) response.Response {
 		}
 
 		return response.ManualResponse(func(w http.ResponseWriter) error {
-			err := response.EmptySyncResponse.Render(w)
+			err := response.EmptySyncResponse.Render(w, r)
 			if err != nil {
 				return err
 			}

--- a/internal/rest/resources/hooks_test.go
+++ b/internal/rest/resources/hooks_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -116,7 +117,10 @@ func (t *hooksSuite) Test_hooks() {
 		ranHook = ""
 		isForce = false
 		expectForce := false
-		req := &http.Request{}
+		req := &http.Request{
+			// Set an URL for response.Render to not cause any panic.
+			URL: &url.URL{},
+		}
 		payload, ok := c.req.(internalTypes.HookRemoveMemberOptions)
 		if !ok {
 			payload, ok := c.req.(internalTypes.HookNewMemberOptions)
@@ -131,7 +135,7 @@ func (t *hooksSuite) Test_hooks() {
 
 		response := hooksPost(s, req)
 		recorder := httptest.NewRecorder()
-		err := response.Render(recorder)
+		err := response.Render(recorder, req)
 		require.NoError(t.T(), err)
 
 		var resp api.Response

--- a/internal/rest/resources/shutdown.go
+++ b/internal/rest/resources/shutdown.go
@@ -38,7 +38,7 @@ func shutdownPost(state state.State, r *http.Request) response.Response {
 
 		// Run shutdown sequence synchronously.
 		exit, stopErr := intState.Stop()
-		err := response.SmartError(stopErr).Render(w)
+		err := response.SmartError(stopErr).Render(w, r)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Starting from https://github.com/canonical/lxd/pull/13825 when using `Render()` we also have to pass the request besides the response writer. 