### PR TITLE
Allow empty AddrPorts

### DIFF
--- a/internal/rest/resources/api_1.0.go
+++ b/internal/rest/resources/api_1.0.go
@@ -21,7 +21,7 @@ var api10Cmd = rest.Endpoint{
 func api10Get(s state.State, r *http.Request) response.Response {
 	addrPort, err := types.ParseAddrPort(s.Address().URL.Host)
 	if err != nil {
-		addrPort = types.AddrPort{}
+		return response.SmartError(err)
 	}
 
 	intState, err := internalState.ToInternal(s)

--- a/rest/types/addrport.go
+++ b/rest/types/addrport.go
@@ -16,6 +16,10 @@ type AddrPorts []AddrPort
 
 // ParseAddrPort parses an IPv4/IPv6 address and port string into an AddrPort.
 func ParseAddrPort(addrPortStr string) (AddrPort, error) {
+	if addrPortStr == "" {
+		return AddrPort{}, nil
+	}
+
 	addrPort, err := netip.ParseAddrPort(addrPortStr)
 	if err != nil {
 		return AddrPort{}, err


### PR DESCRIPTION
https://github.com/canonical/microcluster/pull/179 attempted to allow empty addrports for the `/core/1.0`  API, but did not consider that after sending the request, parsing into a struct it on the other side would still fail. 

So instead, the `types.ParseAddrPort` helper now fully supports empty addresses.