### PR TITLE
Support TLS client session cache

### DIFF
--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -333,7 +333,7 @@ func (db *DqliteDB) heartbeat(leaderInfo dqliteClient.NodeInfo, servers []dqlite
 		return nil
 	}
 
-	client, err := internalClient.New(db.os.ControlSocket(), nil, nil, false)
+	client, err := internalClient.New(db.os.ControlSocket(), nil, nil, db.sessionCache, false)
 	if err != nil {
 		logger.Error("Failed to get local client", logger.Ctx{"address": db.listenAddr.String(), "error": err})
 		return nil

--- a/internal/rest/client/client.go
+++ b/internal/rest/client/client.go
@@ -35,7 +35,7 @@ type Client struct {
 }
 
 // New returns a new client configured with the given url and certificates.
-func New(url api.URL, clientCert *shared.CertInfo, remoteCert *x509.Certificate, forwarding bool) (*Client, error) {
+func New(url api.URL, clientCert *shared.CertInfo, remoteCert *x509.Certificate, sessionCache tls.ClientSessionCache, forwarding bool) (*Client, error) {
 	var err error
 	var httpClient *http.Client
 
@@ -49,7 +49,7 @@ func New(url api.URL, clientCert *shared.CertInfo, remoteCert *x509.Certificate,
 			proxy = forwardingProxy
 		}
 
-		httpClient, err = tlsHTTPClient(clientCert, remoteCert, proxy)
+		httpClient, err = tlsHTTPClient(clientCert, remoteCert, sessionCache, proxy)
 	}
 
 	if err != nil {
@@ -94,11 +94,11 @@ func unixHTTPClient(path string) (*http.Client, error) {
 	return client, nil
 }
 
-func tlsHTTPClient(clientCert *shared.CertInfo, remoteCert *x509.Certificate, proxy func(req *http.Request) (*url.URL, error)) (*http.Client, error) {
+func tlsHTTPClient(clientCert *shared.CertInfo, remoteCert *x509.Certificate, sessionCache tls.ClientSessionCache, proxy func(req *http.Request) (*url.URL, error)) (*http.Client, error) {
 	var tlsConfig *tls.Config
 	if remoteCert != nil {
 		var err error
-		tlsConfig, err = TLSClientConfig(clientCert, remoteCert)
+		tlsConfig, err = TLSClientConfig(clientCert, remoteCert, sessionCache)
 		if err != nil {
 			return nil, fmt.Errorf("Failed to parse TLS config: %w", err)
 		}

--- a/internal/rest/client/tls.go
+++ b/internal/rest/client/tls.go
@@ -11,7 +11,7 @@ import (
 // TLSClientConfig returns a TLS configuration suitable for establishing horizontal and vertical connections.
 // clientCert contains the private key pair for the client. remoteCert is the public
 // key of the server we are connecting to.
-func TLSClientConfig(clientCert *shared.CertInfo, remoteCert *x509.Certificate) (*tls.Config, error) {
+func TLSClientConfig(clientCert *shared.CertInfo, remoteCert *x509.Certificate, sessionCache tls.ClientSessionCache) (*tls.Config, error) {
 	if clientCert == nil {
 		return nil, fmt.Errorf("Invalid client certificate")
 	}
@@ -39,6 +39,10 @@ func TLSClientConfig(clientCert *shared.CertInfo, remoteCert *x509.Certificate) 
 	// Always use public key DNS name rather than server cert, so that it matches.
 	if len(remoteCert.DNSNames) > 0 {
 		config.ServerName = remoteCert.DNSNames[0]
+	}
+
+	if sessionCache != nil {
+		config.ClientSessionCache = sessionCache
 	}
 
 	return config, nil

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -115,7 +115,7 @@ func controlPost(state state.State, r *http.Request) response.Response {
 			return
 		}
 
-		client, err := internalClient.New(*url, state.ServerCert(), cert, false)
+		client, err := internalClient.New(*url, state.ServerCert(), cert, intState.InternalDatabase.GetSessionCache(), false)
 		if err != nil {
 			return
 		}
@@ -227,7 +227,7 @@ func joinWithToken(state state.State, r *http.Request, req *internalTypes.Contro
 			continue
 		}
 
-		d, err := internalClient.New(*url, state.ServerCert(), cert, false)
+		d, err := internalClient.New(*url, state.ServerCert(), cert, intState.InternalDatabase.GetSessionCache(), false)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/rest/rest.go
+++ b/internal/rest/rest.go
@@ -106,7 +106,12 @@ func proxyTarget(action rest.EndpointAction, s state.State, r *http.Request) res
 		return response.InternalError(fmt.Errorf("Failed to parse cluster certificate for request: %w", err))
 	}
 
-	client, err := client.New(*targetURL, s.ServerCert(), clusterCert, false)
+	intState, err := internalState.ToInternal(s)
+	if err != nil {
+		return response.InternalError(fmt.Errorf("Failed to parse internal state: %w", err))
+	}
+
+	client, err := client.New(*targetURL, s.ServerCert(), clusterCert, intState.InternalDatabase.GetSessionCache(), false)
 	if err != nil {
 		return response.InternalError(fmt.Errorf("Failed to get a client for the target %q at address %q: %w", target, targetURL.String(), err))
 	}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -188,7 +188,7 @@ func (s *InternalState) Cluster(isNotification bool) (client.Cluster, error) {
 		}
 
 		url := api.NewURL().Scheme("https").Host(clusterMember.Address.String())
-		c, err := internalClient.New(*url, s.ServerCert(), publicKey, isNotification)
+		c, err := internalClient.New(*url, s.ServerCert(), publicKey, s.InternalDatabase.GetSessionCache(), isNotification)
 		if err != nil {
 			return nil, err
 		}
@@ -220,7 +220,7 @@ func (s *InternalState) Leader() (*client.Client, error) {
 	}
 
 	url := api.NewURL().Scheme("https").Host(leaderInfo.Address)
-	c, err := internalClient.New(*url, s.ServerCert(), publicKey, false)
+	c, err := internalClient.New(*url, s.ServerCert(), publicKey, s.InternalDatabase.GetSessionCache(), false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/trust/remotes.go
+++ b/internal/trust/remotes.go
@@ -222,7 +222,7 @@ func (r *Remotes) Cluster(isNotification bool, serverCert *shared.CertInfo, publ
 	cluster := make(client.Cluster, 0, r.Count()-1)
 	for _, addr := range r.Addresses() {
 		url := api.NewURL().Scheme("https").Host(addr.String())
-		c, err := internalClient.New(*url, serverCert, publicKey, isNotification)
+		c, err := internalClient.New(*url, serverCert, publicKey, nil, isNotification)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
@cole-miller pointed me to https://pkg.go.dev/crypto/tls#ClientSessionCache which might be useful in reducing the TLS connection overhead that contributes to the `go-dqlite` performance issues that we see. 

As such, this introduces an LRU cache of size 64, which was chosen as it's the default size if 0 is passed instead, when initializing the cache.

I haven't tested its efficacy yet, so it's just a draft for now.