### PR TITLE
v2: Restore changes to `Render`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.22.7
 
 require (
 	github.com/canonical/go-dqlite/v2 v2.0.0
-	github.com/canonical/lxd v0.0.0-20241105095730-921967798cb1
+	github.com/canonical/lxd v0.0.0-20241106123323-f0be5c8f36a6
 	github.com/fsnotify/fsnotify v1.8.0
 	github.com/google/renameio v1.0.1
 	github.com/gorilla/mux v1.8.1

--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,8 @@ github.com/bmatcuk/doublestar/v4 v4.7.1 h1:fdDeAqgT47acgwd9bd9HxJRDmc9UAmPpc+2m0
 github.com/bmatcuk/doublestar/v4 v4.7.1/go.mod h1:xBQ8jztBU6kakFMg+8WGxn0c6z1fTSPVIjEY1Wr7jzc=
 github.com/canonical/go-dqlite/v2 v2.0.0 h1:RNFcFVhHMh70muKKErbW35rSzqmAFswheHdAgxW0Ddw=
 github.com/canonical/go-dqlite/v2 v2.0.0/go.mod h1:IaIC8u4Z1UmPjuAqPzA2r83YMaMHRLoKZdHKI5uHCJI=
-github.com/canonical/lxd v0.0.0-20241105095730-921967798cb1 h1:kJTKpOZlC3dDx0YAMGMlV4D7i/7YLz9p4uEVuMXk1uM=
-github.com/canonical/lxd v0.0.0-20241105095730-921967798cb1/go.mod h1:ORoLmeSj+tQmUgh10kLA9eMtRnbBZPT6X10V2I4cTGs=
+github.com/canonical/lxd v0.0.0-20241106123323-f0be5c8f36a6 h1:dr4LtQbdutkhfxVCGH/jcVpaLxK6067dNCE6tp3Isyw=
+github.com/canonical/lxd v0.0.0-20241106123323-f0be5c8f36a6/go.mod h1:ORoLmeSj+tQmUgh10kLA9eMtRnbBZPT6X10V2I4cTGs=
 github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -467,7 +467,7 @@ func (d *Daemon) initServer(resources ...rest.Resources) *http.Server {
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		err := response.SyncResponse(true, []string{"/1.0"}).Render(w)
+		err := response.SyncResponse(true, []string{"/1.0"}).Render(w, r)
 		if err != nil {
 			logger.Error("Failed to write HTTP response", logger.Ctx{"url": r.URL, "err": err})
 		}
@@ -476,7 +476,7 @@ func (d *Daemon) initServer(resources ...rest.Resources) *http.Server {
 	mux.NotFoundHandler = http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		logger.Info("Sending top level 404", logger.Ctx{"url": r.URL})
 		w.Header().Set("Content-Type", "application/json")
-		err := response.NotFound(nil).Render(w)
+		err := response.NotFound(nil).Render(w, r)
 		if err != nil {
 			logger.Error("Failed to write HTTP response", logger.Ctx{"url": r.URL, "err": err})
 		}

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -328,7 +328,7 @@ func clusterMemberPut(s state.State, r *http.Request) response.Response {
 	go reExec()
 
 	return response.ManualResponse(func(w http.ResponseWriter) error {
-		err := response.EmptySyncResponse.Render(w)
+		err := response.EmptySyncResponse.Render(w, r)
 		if err != nil {
 			return err
 		}
@@ -448,7 +448,7 @@ func clusterMemberDelete(s state.State, r *http.Request) response.Response {
 		}
 
 		return response.ManualResponse(func(w http.ResponseWriter) error {
-			err := response.EmptySyncResponse.Render(w)
+			err := response.EmptySyncResponse.Render(w, r)
 			if err != nil {
 				return err
 			}
@@ -566,7 +566,7 @@ func clusterMemberDelete(s state.State, r *http.Request) response.Response {
 		}
 
 		return response.ManualResponse(func(w http.ResponseWriter) error {
-			err := response.EmptySyncResponse.Render(w)
+			err := response.EmptySyncResponse.Render(w, r)
 			if err != nil {
 				return err
 			}

--- a/internal/rest/resources/hooks_test.go
+++ b/internal/rest/resources/hooks_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"strings"
 	"testing"
 
@@ -116,7 +117,10 @@ func (t *hooksSuite) Test_hooks() {
 		ranHook = ""
 		isForce = false
 		expectForce := false
-		req := &http.Request{}
+		req := &http.Request{
+			// Set an URL for response.Render to not cause any panic.
+			URL: &url.URL{},
+		}
 		payload, ok := c.req.(internalTypes.HookRemoveMemberOptions)
 		if !ok {
 			payload, ok := c.req.(internalTypes.HookNewMemberOptions)
@@ -131,7 +135,7 @@ func (t *hooksSuite) Test_hooks() {
 
 		response := hooksPost(s, req)
 		recorder := httptest.NewRecorder()
-		err := response.Render(recorder)
+		err := response.Render(recorder, req)
 		require.NoError(t.T(), err)
 
 		var resp api.Response

--- a/internal/rest/resources/shutdown.go
+++ b/internal/rest/resources/shutdown.go
@@ -38,7 +38,7 @@ func shutdownPost(state state.State, r *http.Request) response.Response {
 
 		// Run shutdown sequence synchronously.
 		exit, stopErr := intState.Stop()
-		err := response.SmartError(stopErr).Render(w)
+		err := response.SmartError(stopErr).Render(w, r)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
As part of https://github.com/canonical/microcluster/pull/277 the changes to `Render` (originally introduced in https://github.com/canonical/microcluster/pull/252) got reverted to allow tracking `lxd@stable-5.21` which didn't contain the necessary changes to `Render`.

After backporting the changes to LXD's `stable-5.21` with https://github.com/canonical/lxd/pull/14409, we can restore the original changes using the latest version of LXD in `stable-5.21`.