### PR TITLE
github: Fix database cache update

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -17,9 +17,29 @@ defaults:
     shell: bash
 
 jobs:
+  update-vulnerability-database:
+    name: Trivy - Update cached database
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Install Trivy
+        uses: canonical/lxd/.github/actions/install-trivy@main
+
+      - name: Download Trivy DB
+        id: db_download
+        run: trivy fs --download-db-only --cache-dir /home/runner/vuln-cache
+        continue-on-error: true
+
+      - name: Cache Trivy vulnerability database
+        if: ${{ steps.db_download.outcome == 'success' }}
+        uses: actions/cache/save@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
+        with:
+          path: /home/runner/vuln-cache
+          key: trivy-latest-cache
+
   trivy-repo:
     name: Trivy - Repository
     runs-on: ubuntu-22.04
+    needs: update-vulnerability-database
     strategy:
       matrix:
         version:
@@ -34,13 +54,7 @@ jobs:
       - name: Install Trivy
         uses: canonical/lxd/.github/actions/install-trivy@main
 
-      - name: Download Trivy DB
-        id: db_download
-        run: trivy fs --download-db-only --cache-dir /home/runner/vuln-cache
-        continue-on-error: true
-
       - name: Use previous downloaded database
-        if: ${{ steps.db_download.outcome == 'failure' }}
         uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: /home/runner/vuln-cache
@@ -54,13 +68,6 @@ jobs:
           --cache-dir /home/runner/vuln-cache \
           --severity LOW,MEDIUM,HIGH,CRITICAL \
           --output trivy-microcluster-repo-scan-results.sarif .
-
-      - name: Cache Trivy vulnerability database
-        if: ${{ steps.db_download.outcome == 'success' }}
-        uses: actions/cache/save@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
-        with:
-          path: /home/runner/vuln-cache
-          key: trivy-latest-cache
 
       - name: Upload Trivy scan results to GitHub Security tab
         uses: github/codeql-action/upload-sarif@4f3212b61783c3c68e8309a0f18a699764811cda # v3.27.1

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -34,7 +34,7 @@ jobs:
         uses: actions/cache/save@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: /home/runner/vuln-cache
-          key: trivy-latest-cache
+          key: trivy-cache-${{ github.run_id }}
 
   trivy-repo:
     name: Trivy - Repository
@@ -58,7 +58,9 @@ jobs:
         uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: /home/runner/vuln-cache
-          key: trivy-latest-cache
+          key: trivy-cache-${{ github.run_id }}
+          restore-keys: |
+            trivy-cache-
 
       - name: Run Trivy vulnerability scanner
         run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -27,7 +27,7 @@ jobs:
           - v2
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: ${{ matrix.version }}
 
@@ -63,7 +63,7 @@ jobs:
           key: trivy-latest-cache
 
       - name: Upload Trivy scan results to GitHub Security tab
-        uses: github/codeql-action/upload-sarif@v3
+        uses: github/codeql-action/upload-sarif@4f3212b61783c3c68e8309a0f18a699764811cda # v3.27.1
         with:
           sarif_file: "trivy-microcluster-repo-scan-results.sarif"
           sha: ${{ github.sha }}

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Install Trivy
         uses: canonical/lxd/.github/actions/install-trivy@main
 
-      - name: Use previous downloaded database
+      - name: Use previously downloaded database
         uses: actions/cache/restore@6849a6489940f00c2f30c0fb92c6274307ccb58a # v4.1.2
         with:
           path: /home/runner/vuln-cache


### PR DESCRIPTION
A github cache can not be updated using the same key, so instead we update using a different key each time but use the same key to restore it.

This also adds a step to download/update the vulnerability database as a way to avoid having the v3 and v2 workflows updating the cache concurrently, as that can cause the update to fail.