### PR TITLE
Backport PreInit hook support, and deprecate PreBootstrap

### DIFF
--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -111,13 +111,13 @@ func (c *cmdDaemon) run(cmd *cobra.Command, args []string) error {
 			return nil
 		},
 
-		PreBootstrap: func(ctx context.Context, s state.State, initConfig map[string]string) error {
+		PreInit: func(ctx context.Context, s state.State, bootstrap bool, initConfig map[string]string) error {
 			logCtx := logger.Ctx{}
 			for k, v := range initConfig {
 				logCtx[k] = v
 			}
 
-			logger.Info("This is a hook that runs before the daemon is initialized and bootstrapped")
+			logger.Info("This is a hook that runs before the daemon is initialized")
 			logger.Info("Here are the extra configuration keys that were passed into the init --bootstrap command", logCtx)
 
 			return nil

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -370,10 +370,12 @@ func (d *Daemon) applyHooks(hooks *state.Hooks) error {
 	}
 
 	// PreBootstrap is deprecated and replaced by PreInit, so unset it if PreInit is set.
+	// nolint:staticcheck
 	if d.hooks.PreInit != nil && d.hooks.PreBootstrap != nil {
 		return fmt.Errorf("PreBootstrap hook is deprecated and cannot be defined if PreInit hook is defined")
 	}
 
+	// nolint:staticcheck
 	if d.hooks.PreBootstrap == nil {
 		d.hooks.PreBootstrap = noOpInitHook
 	}
@@ -529,6 +531,7 @@ func (d *Daemon) setConfig(newConfig trust.Location) error {
 func (d *Daemon) StartAPI(ctx context.Context, bootstrap bool, initConfig map[string]string, joinAddresses ...string) error {
 	if bootstrap {
 		ctx, cancel := context.WithCancel(ctx)
+		// nolint:staticcheck
 		err := d.hooks.PreBootstrap(ctx, d.State(), initConfig)
 		cancel()
 		if err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -506,6 +506,15 @@ func (d *Daemon) initServer(resources ...rest.Resources) *http.Server {
 	}
 }
 
+// setConfig applies and commits to memory the supplied daemon configuration.
+func (d *Daemon) setConfig(newConfig trust.Location) error {
+	d.config.SetAddress(newConfig.Address)
+	d.config.SetName(newConfig.Name)
+
+	// Write the latest config to disk.
+	return d.config.Write()
+}
+
 // StartAPI starts up the admin and consumer APIs, and generates a cluster cert
 // if we are bootstrapping the first node.
 func (d *Daemon) StartAPI(ctx context.Context, bootstrap bool, initConfig map[string]string, joinAddresses ...string) error {
@@ -1080,6 +1089,7 @@ func (d *Daemon) State() state.State {
 		Hooks:                    &d.hooks,
 		Context:                  d.shutdownCtx,
 		ReadyCh:                  d.ReadyChan,
+		SetConfig:                d.setConfig,
 		StartAPI:                 d.StartAPI,
 		Extensions:               d.Extensions,
 		Endpoints:                d.endpoints,

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -355,6 +355,9 @@ func (d *Daemon) applyHooks(hooks *state.Hooks) {
 	noOpHook := func(ctx context.Context, s state.State) error { return nil }
 	noOpRemoveHook := func(ctx context.Context, s state.State, force bool) error { return nil }
 	noOpInitHook := func(ctx context.Context, s state.State, initConfig map[string]string) error { return nil }
+	noOpGenericInitHook := func(ctx context.Context, s state.State, bootstrap bool, initConfig map[string]string) error {
+		return nil
+	}
 	noOpConfigHook := func(ctx context.Context, s state.State, config types.DaemonConfig) error { return nil }
 	noOpNewMemberHook := func(ctx context.Context, s state.State, newMember types.ClusterMemberLocal) error { return nil }
 
@@ -366,6 +369,10 @@ func (d *Daemon) applyHooks(hooks *state.Hooks) {
 
 	if d.hooks.PreBootstrap == nil {
 		d.hooks.PreBootstrap = noOpInitHook
+	}
+
+	if d.hooks.PreInit == nil {
+		d.hooks.PreInit = noOpGenericInitHook
 	}
 
 	if d.hooks.PostBootstrap == nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -438,7 +438,7 @@ func (d *Daemon) reloadIfBootstrapped() error {
 		return fmt.Errorf("Failed to retrieve daemon configuration yaml: %w", err)
 	}
 
-	err = d.StartAPI(d.shutdownCtx, false, nil, nil)
+	err = d.StartAPI(d.shutdownCtx, false, nil)
 	if err != nil {
 		return err
 	}
@@ -508,23 +508,7 @@ func (d *Daemon) initServer(resources ...rest.Resources) *http.Server {
 
 // StartAPI starts up the admin and consumer APIs, and generates a cluster cert
 // if we are bootstrapping the first node.
-func (d *Daemon) StartAPI(ctx context.Context, bootstrap bool, initConfig map[string]string, newConfig *trust.Location, joinAddresses ...string) error {
-	if newConfig != nil {
-		d.config.SetAddress(newConfig.Address)
-		d.config.SetName(newConfig.Name)
-
-		// Write the latest config to disk.
-		err := d.config.Write()
-		if err != nil {
-			return err
-		}
-	} else {
-		err := d.config.Load()
-		if err != nil {
-			return err
-		}
-	}
-
+func (d *Daemon) StartAPI(ctx context.Context, bootstrap bool, initConfig map[string]string, joinAddresses ...string) error {
 	if bootstrap {
 		ctx, cancel := context.WithCancel(ctx)
 		err := d.hooks.PreBootstrap(ctx, d.State(), initConfig)

--- a/internal/rest/resources/certificates.go
+++ b/internal/rest/resources/certificates.go
@@ -82,6 +82,11 @@ func clusterCertificatesPut(s state.State, r *http.Request) response.Response {
 	var certificateDir string
 	if certificateName == string(types.ClusterCertificateName) {
 		certificateDir = s.FileSystem().StateDir
+	} else if certificateName == string(types.ServerCertificateName) {
+		certificateDir = s.FileSystem().StateDir
+		if s.Database().Status() != types.DatabaseNotReady {
+			return response.SmartError(fmt.Errorf("Cannot replace server certificate after initialization"))
+		}
 	} else {
 		certificateDir = s.FileSystem().CertificatesDir
 

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -59,6 +59,12 @@ func controlPost(state state.State, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	daemonConfig := trust.Location{Address: req.Address, Name: req.Name}
+	err = intState.SetConfig(daemonConfig)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	reverter := revert.New()
 	defer reverter.Fail()
 

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -65,6 +65,13 @@ func controlPost(state state.State, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
+	ctx, cancel := context.WithCancel(r.Context())
+	err = intState.Hooks.PreInit(ctx, state, req.Bootstrap, req.InitConfig)
+	cancel()
+	if err != nil {
+		return response.SmartError(fmt.Errorf("Failed to run pre-init hook before starting the API: %w", err))
+	}
+
 	reverter := revert.New()
 	defer reverter.Fail()
 

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -149,8 +149,7 @@ func controlPost(state state.State, r *http.Request) response.Response {
 		return response.EmptySyncResponse
 	}
 
-	daemonConfig := &trust.Location{Address: req.Address, Name: req.Name}
-	err = intState.StartAPI(r.Context(), req.Bootstrap, req.InitConfig, daemonConfig)
+	err = intState.StartAPI(r.Context(), req.Bootstrap, req.InitConfig)
 	if err != nil {
 		return response.SmartError(err)
 	}
@@ -272,7 +271,7 @@ func joinWithToken(state state.State, r *http.Request, req *internalTypes.Contro
 	}
 
 	// Start the HTTPS listeners and join Dqlite.
-	err = intState.StartAPI(r.Context(), false, req.InitConfig, daemonConfig, joinAddrs.Strings()...)
+	err = intState.StartAPI(r.Context(), false, req.InitConfig, joinAddrs.Strings()...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/state/hooks.go
+++ b/internal/state/hooks.go
@@ -12,6 +12,9 @@ type Hooks struct {
 	// PreBootstrap is run before the daemon is initialized and bootstrapped.
 	PreBootstrap func(ctx context.Context, s State, initConfig map[string]string) error
 
+	// PreInit is run before the daemon is initialized.
+	PreInit func(ctx context.Context, s State, bootstrap bool, initConfig map[string]string) error
+
 	// PostBootstrap is run after the daemon is initialized and bootstrapped.
 	PostBootstrap func(ctx context.Context, s State, initConfig map[string]string) error
 

--- a/internal/state/hooks.go
+++ b/internal/state/hooks.go
@@ -10,6 +10,8 @@ import (
 // integrate with other tools.
 type Hooks struct {
 	// PreBootstrap is run before the daemon is initialized and bootstrapped.
+	//
+	// Deprecated: Use PreInit instead.
 	PreBootstrap func(ctx context.Context, s State, initConfig map[string]string) error
 
 	// PreInit is run before the daemon is initialized.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -76,7 +76,7 @@ type InternalState struct {
 	LocalConfig func() *internalConfig.DaemonConfig
 
 	// Initialize APIs and bootstrap/join database.
-	StartAPI func(ctx context.Context, bootstrap bool, initConfig map[string]string, newConfig *trust.Location, joinAddresses ...string) error
+	StartAPI func(ctx context.Context, bootstrap bool, initConfig map[string]string, joinAddresses ...string) error
 
 	// Update the additional listeners.
 	UpdateServers func() error

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -75,6 +75,9 @@ type InternalState struct {
 	// Local daemon's config.
 	LocalConfig func() *internalConfig.DaemonConfig
 
+	// SetConfig Applies and commits to memory the supplied daemon configuration.
+	SetConfig func(trust.Location) error
+
 	// Initialize APIs and bootstrap/join database.
 	StartAPI func(ctx context.Context, bootstrap bool, initConfig map[string]string, joinAddresses ...string) error
 


### PR DESCRIPTION
k8s-snap has requested PreInit to be included in the LTS as they are dependent on it for their LTS.

This feature clashes with the PreBootstrap hook and was meant to replace it, so instead PreBootstrap is set as deprecated, and will be replaced with a noop function if PreInit is defined by the upstream package.