### PR TITLE
Shutdown servers when resetting cluster membership

### DIFF
--- a/internal/endpoints/util.go
+++ b/internal/endpoints/util.go
@@ -1,0 +1,40 @@
+package endpoints
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"net/http"
+	"time"
+
+	"github.com/canonical/lxd/shared/logger"
+)
+
+// shutdownServer will shutdown the given server.
+// If the given timeout is 0, it will forcefully shut it down. Otherwise, it will gracefully shut it down.
+func shutdownServer(server *http.Server, timeout time.Duration) error {
+	// If the given timeout is 0, force the shutdown.
+	if timeout == 0 {
+		err := server.Close()
+		if errors.Is(err, net.ErrClosed) {
+			return nil
+		}
+		return err
+	}
+
+	// server.Shutdown will gracefully stop the server, allowing existing requests to finish.
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+	err := server.Shutdown(shutdownCtx)
+	if err != nil {
+		logger.Error("Failed to gracefully shutdown server", logger.Ctx{"err": err})
+		closeErr := server.Close()
+		if closeErr != nil {
+			logger.Error("Failed to close server", logger.Ctx{"err": closeErr})
+			return fmt.Errorf("Encountered error while closing server: %w, after failing to gracefully shutdown the server: %w", closeErr, err)
+		}
+		return err
+	}
+	return nil
+}

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -357,11 +357,6 @@ func resetClusterMember(ctx context.Context, s state.State, force bool) (reExec 
 		return nil, fmt.Errorf("Failed shutting down database: %w", err)
 	}
 
-	err = intState.StopListeners()
-	if err != nil && !force {
-		return nil, fmt.Errorf("Failed shutting down listeners: %w", err)
-	}
-
 	err = os.RemoveAll(s.FileSystem().StateDir)
 	if err != nil && !force {
 		return nil, fmt.Errorf("Failed to remove the s directory: %w", err)
@@ -369,6 +364,21 @@ func resetClusterMember(ctx context.Context, s state.State, force bool) (reExec 
 
 	reExec = func() {
 		<-ctx.Done() // Wait until request has finished.
+
+		// NOTE(claudiub): In the case we fail to bootstrap / join the cluster, or if we remove the node
+		// from the cluster, we'll be resetting the node's cluster membership. This includes closing the
+		// HTTPS and unix socket servers we have open.
+		// However, we cannot gracefully shutdown the servers, as there's at least one connection that is
+		// still open: the bootstrap / join request. Forcing the connection to close before we're able
+		// to write the request response will result in the client getting an EOF error, and no information
+		// regarding the failure.
+		// Gracefully shutting down the servers in a goroutine will address this issue: while this action
+		// happens, we'll be able to write the HTTP response and then close the connection, finally
+		// allowing the servers to gracefully shutdown, and the clients to be happy.
+		err = intState.StopListeners()
+		if err != nil && !force {
+			logger.Error("Failed shutting down listeners", logger.Ctx{"err": err})
+		}
 
 		// Wait until we can acquire the lock. This way if another request is holding the lock we won't
 		// replace/stop the LXD daemon until that request has finished.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -87,10 +87,10 @@ type InternalState struct {
 	// ReloadCert reloads the given keypair from the state directory.
 	ReloadCert func(name types.CertificateName) error
 
-	// StopListeners stops the network listeners and the fsnotify listener.
+	// StopListeners stops the network listeners and servers, and the fsnotify listener.
 	StopListeners func() error
 
-	// Stop fully stops the daemon, its database, and all listeners.
+	// Stop fully stops the daemon, its database, all listeners, and all servers.
 	Stop func() (exit func(), stopErr error)
 
 	// Runtime extensions.

--- a/rest/rest.go
+++ b/rest/rest.go
@@ -2,6 +2,7 @@ package rest
 
 import (
 	"net/http"
+	"time"
 
 	"github.com/canonical/lxd/lxd/response"
 
@@ -65,4 +66,8 @@ type Server struct {
 
 	// Resources is the list of resources offered by this server.
 	Resources []Resources
+
+	// DrainConnectionsTimeout is the amount of time to allow for all connections to drain when shutting down.
+	// If it's 0, the connections are not drained when shutting down.
+	DrainConnectionsTimeout time.Duration
 }


### PR DESCRIPTION
In the ``k8s-snap``, we're seeing a significant amount of ``EOF`` errors client-side, typically when operations such as ``k8s bootstrap`` or ``k8s join-cluster`` are run and an error occurs server-side.

When closing a listener, the server won't accept any new connections. However, we should still allow for the current connections / requests to finish. Calling ``server.Shutdown`` allows us to wait for them to finish. We'll be doing this only if ``drainConnectionsTimeout`` has been set for the server.

 Note that in the case we fail to bootstrap / join the cluster, we'll be  resetting a few things, including the cluster membership. This includes  the HTTPS and unix socket servers we have open by closing them.

 However, we cannot gracefully shutdown the servers, as there's at least  one connection that is still open: the bootstrap / join request. Forcing  the connection to close before we're able to write the request response  will result in the client getting an EOF error, and no information regarding the failure.

 Running the revert actions in a goroutine will address this issue: while  the revert happens, we'll be able to return and write the HTTP response  and then close the connection, finally allowing the Servers to gracefully  shutdown, and the clients to be happy. As a bonus, this will also  significantly reduce the amount of time spent by the bootstrap / join  requests in case of failures.
