### PR TITLE
Fixes wrapped nil lastErr issue during cluster join

### DIFF
--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -218,13 +218,13 @@ func joinWithToken(state state.State, r *http.Request, req *internalTypes.Contro
 		cert, err := shared.GetRemoteCertificate(url.String(), "")
 		if err != nil {
 			logger.Warn("Failed to get certificate of cluster member", logger.Ctx{"address": url.String(), "error": err})
+			lastErr = err
 			continue
 		}
 
 		fingerprint := shared.CertFingerprint(cert)
 		if fingerprint != token.Fingerprint {
-			logger.Warn("Cluster certificate token does not match that of cluster member", logger.Ctx{"address": url.String(), "fingerprint": fingerprint, "expected": token.Fingerprint})
-			continue
+			return nil, fmt.Errorf("Cluster certificate token does not match that of cluster member. Expected: %q, actual: %q", fingerprint, token.Fingerprint)
 		}
 
 		d, err := internalClient.New(*url, state.ServerCert(), cert, false)


### PR DESCRIPTION
When joining a cluster, we have a list of join addresses we try to connect to. However, ``lastErr`` is only set at the end of a loop, which can lead to confusing error messages like this:

```
The error was: failed to POST /k8sd/cluster/join: failed to join k8sd cluster as control plane: 1 join attempts were unsuccessful. Last error: %!w(<nil>)
```

This can happen if other errors can occur before lastErr is set, skipping the current join address. Additionally, ``lastErr`` may be set from the previous join address checks, and not from the current loop, which can be misleading.

 We're now setting ``lastErr`` appropriately. Additionally, if the  certificate fingerprint does not match, we're returning a new error.
 
 Signed-off-by: Claudiu Belu <claudiu.belu@canonical.com>