### PR TITLE
github: Temporary disable TICS job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -113,7 +113,8 @@ jobs:
     name: Tiobe TICS
     runs-on: ubuntu-22.04
     needs: code-tests
-    if: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && github.ref_name == 'v3' && github.repository == 'canonical/microcluster' }}
+    #if: ${{ ( github.event_name == 'workflow_dispatch' || github.event_name == 'schedule' ) && github.ref_name == 'v3' && github.repository == 'canonical/microcluster' }}
+    if: false
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
As per https://discourse.canonical.com/t/end-of-the-year-update-for-tiobe-tics-required-action-to-disable-tics-cicd-pipelines/4890