### PR TITLE
feat: support wildcard certificates

### DIFF
--- a/internal/db/update/update.go
+++ b/internal/db/update/update.go
@@ -38,6 +38,7 @@ func NewSchema() *SchemaUpdateManager {
 			mgr.updateFromV3,
 			updateFromV4,
 			updateFromV5,
+			updateFromV6,
 		},
 	}
 
@@ -73,6 +74,32 @@ func (s *SchemaUpdateManager) Schema() *SchemaUpdate {
 func (s *SchemaUpdateManager) AppendSchema(schemaExtensions []schema.Update, apiExtensions extensions.Extensions) {
 	s.updates[updateExternal] = schemaExtensions
 	s.apiExtensions = apiExtensions
+}
+
+// updateFromV6 removed unique constraint on certificates.
+func updateFromV6(ctx context.Context, tx *sql.Tx) error {
+	stmt := `
+CREATE TABLE core_cluster_members_new (
+    id                      INTEGER   PRIMARY  KEY    AUTOINCREMENT  NOT  NULL,
+    name                    TEXT      NOT      NULL,
+    address                 TEXT      NOT      NULL,
+    certificate             TEXT      NOT      NULL,
+    schema_internal         INTEGER   NOT      NULL,
+    schema_external         INTEGER   NOT      NULL,
+    heartbeat               DATETIME  NOT      NULL,
+    role                    TEXT      NOT      NULL,
+    api_extensions          TEXT      NOT      NULL DEFAULT '[]',
+    UNIQUE(name)
+);
+
+INSERT INTO core_cluster_members_new (id, name, address, certificate, schema_internal, schema_external, heartbeat, role, api_extensions)
+SELECT id, name, address, certificate, schema_internal, schema_external, heartbeat, role, api_extensions FROM core_cluster_members;
+
+DROP TABLE core_cluster_members;
+ALTER TABLE core_cluster_members_new RENAME TO core_cluster_members;
+`
+	_, err := tx.ExecContext(ctx, stmt)
+	return err
 }
 
 // updateFromV5 adds an expiration column for join tokens.

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -143,6 +143,10 @@ func clusterPost(s state.State, r *http.Request) response.Response {
 			return err
 		}
 
+		if record.Name != req.Name {
+			return fmt.Errorf("Joining server name doesn't match associated token name")
+		}
+
 		if record.Expired() {
 			return fmt.Errorf("Token expired")
 		}

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -147,7 +147,7 @@ func clusterPost(s state.State, r *http.Request) response.Response {
 			return fmt.Errorf("Token expired")
 		}
 
-		if !shared.ValueInSlice(record.Name, req.Certificate.DNSNames) {
+		if err := req.Certificate.VerifyHostname(record.Name); err != nil {
 			return fmt.Errorf("Joining server certificate SAN does not contain join token name")
 		}
 

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -80,12 +80,12 @@ func controlPost(state state.State, r *http.Request) response.Response {
 		return response.SmartError(err)
 	}
 
-	certNameMatches := shared.ValueInSlice(req.Name, serverCert.DNSNames)
+	certNameMatches := serverCert.VerifyHostname(req.Name)
 	var joinInfo *internalTypes.TokenResponse
 	reverter.Add(func() {
 		// When joining, don't attempt to reset the cluster member if we never received authorization from any cluster members.
 		// This is because we won't have changed any state yet, so resetting the cluster member won't help, and may have its own side-effects.
-		if joinInfo == nil && req.JoinToken != "" && !certNameMatches {
+		if joinInfo == nil && req.JoinToken != "" && certNameMatches != nil {
 			return
 		}
 
@@ -128,7 +128,7 @@ func controlPost(state state.State, r *http.Request) response.Response {
 	})
 
 	// Replace the server keypair if the cluster member name has changed upon initialization.
-	if !certNameMatches {
+	if certNameMatches != nil {
 		err := os.Remove(filepath.Join(state.FileSystem().StateDir, "server.crt"))
 		if err != nil {
 			return response.SmartError(err)


### PR DESCRIPTION
Use [VerifyHostname](https://pkg.go.dev/crypto/x509#Certificate.VerifyHostname) instead of a string comparison, as it allows usage of wildcard certificate for every cluster member.

Release unique constraint on certificate, as in case of wildcard certificate it can be the same for all the cluster members.

Resolves #312