### PR TITLE
internal/recover: Use core/ prefixed endpoint to check online state (v2)

### DIFF
--- a/internal/recover/recover.go
+++ b/internal/recover/recover.go
@@ -121,7 +121,7 @@ func RecoverFromQuorumLoss(filesystem *sys.OS, members []cluster.DqliteMember) (
 	cancelCtx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	err = cluster.Query(cancelCtx, true, func(ctx context.Context, client *client.Client) error {
 		var rslt internalTypes.Server
-		err := client.Query(ctx, "GET", "1.0", api.NewURL(), nil, &rslt)
+		err := client.Query(ctx, "GET", internalTypes.PublicEndpoint, api.NewURL(), nil, &rslt)
 		if err == nil {
 			return fmt.Errorf("Contacted cluster member at %q; please shut down all cluster members", rslt.Name)
 		}


### PR DESCRIPTION
Using just `/1.0` may not work as the upstream project might not have defined it (like in the example package) so it will always return 404

Signed-off-by: Max Asnaashari <max.asnaashari@canonical.com>
(cherry picked from commit 77bb2e0aa7ae39e141b20d0b3a20987f9f13c612)