### PR TITLE
internal/db: Set database status based on initialization state

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -285,7 +285,10 @@ func (d *Daemon) init(listenAddress string, socketGroup string, heartbeatInterva
 		return fmt.Errorf("Failed to initialize trust store: %w", err)
 	}
 
-	d.db = db.NewDB(d.shutdownCtx, d.ServerCert, d.ClusterCert, d.Name, d.os, heartbeatInterval)
+	d.db, err = db.NewDB(d.shutdownCtx, d.ServerCert, d.ClusterCert, d.Name, d.os, heartbeatInterval)
+	if err != nil {
+		return fmt.Errorf("Failed to initialize database: %w", err)
+	}
 
 	listenAddr := api.NewURL()
 	if listenAddress != "" {
@@ -343,9 +346,15 @@ func (d *Daemon) init(listenAddress string, socketGroup string, heartbeatInterva
 
 	d.db.SetSchema(schemaExtensions, d.Extensions)
 
-	err = d.reloadIfBootstrapped()
-	if err != nil {
-		return err
+	status := d.db.Status()
+	if status == types.DatabaseStarting {
+		// Database is already bootstrapped, reload the daemon to ensure the latest configuration is applied.
+		err := d.reload()
+		if err != nil {
+			return fmt.Errorf("Failed to reload daemon: %w", err)
+		}
+	} else if status == types.DatabaseNotReady {
+		logger.Warn("Microcluster database is uninitialized")
 	}
 
 	err = d.trustStore.Refresh()
@@ -415,28 +424,8 @@ func (d *Daemon) applyHooks(hooks *state.Hooks) {
 	}
 }
 
-func (d *Daemon) reloadIfBootstrapped() error {
-	_, err := os.Stat(filepath.Join(d.os.DatabaseDir, "info.yaml"))
-	if err != nil {
-		if os.IsNotExist(err) {
-			logger.Warn("microcluster database is uninitialized")
-			return nil
-		}
-
-		return err
-	}
-
-	_, err = os.Stat(filepath.Join(d.os.StateDir, "daemon.yaml"))
-	if err != nil {
-		if os.IsNotExist(err) {
-			logger.Warn("microcluster daemon config is missing")
-			return nil
-		}
-
-		return err
-	}
-
-	err = d.config.Load()
+func (d *Daemon) reload() error {
+	err := d.config.Load()
 	if err != nil {
 		return fmt.Errorf("Failed to retrieve daemon configuration yaml: %w", err)
 	}


### PR DESCRIPTION
Previously, the initial dqlite database status was always set to "DatabaseNotReady", regardless of whether the node was already bootstrapped or joined. As a result, any REST API call during microcluster startup would incorrectly return a 503 error with "Database not yet initialized", even if the node was already bootstrapped and simply restarting.

This commit refactors the handling of the database initialization state:

* Use the database status to determine if a cluster is
      bootstrapped/joined or uninitialized
* Sets the initial database status based on whether the database is already initialized.

With this change:

* Bootstrapped nodes now return "Database still starting" during startup.
* Non-bootstrapped nodes return "Database not yet initialized".

This provides more accurate status reporting and improves API responses during service restarts.