### PR TITLE
CI: Add linter rules from LXD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,7 @@ ifeq ($(shell command -v golangci-lint 2> /dev/null),)
 	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin
 endif
 	golangci-lint run --timeout 5m
+	run-parts --verbose --exit-on-error --regex '.sh' test/lint
 
 # Update targets.
 .PHONY: update-gomod

--- a/example/cmd/microctl/tokens.go
+++ b/example/cmd/microctl/tokens.go
@@ -50,6 +50,7 @@ func (c *cmdTokensAdd) command() *cobra.Command {
 		Short: "Add a new join token under the given name",
 		RunE:  c.run,
 	}
+
 	cmd.Flags().StringVarP(&c.flagExpireAfter, "expire-after", "e", "3h", "Set the lifetime for the token")
 
 	return cmd
@@ -92,6 +93,7 @@ func (c *cmdTokensList) command() *cobra.Command {
 		Short: "List join tokens available for use",
 		RunE:  c.run,
 	}
+
 	cmd.Flags().StringVarP(&c.flagFormat, "format", "f", cli.TableFormatTable, "Format (csv|json|table|yaml|compact)")
 
 	return cmd

--- a/example/cmd/microctl/waitready.go
+++ b/example/cmd/microctl/waitready.go
@@ -41,6 +41,7 @@ func (c *cmdWaitready) run(cmd *cobra.Command, args []string) error {
 	if c.flagTimeout > 0 {
 		ctx, cancel = context.WithTimeout(ctx, time.Duration(c.flagTimeout)*time.Second)
 	}
+
 	defer cancel()
 
 	return m.Ready(ctx)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -373,6 +373,7 @@ func (d *Daemon) applyHooks(hooks *state.Hooks) {
 	noOpGenericInitHook := func(ctx context.Context, s state.State, bootstrap bool, initConfig map[string]string) error {
 		return nil
 	}
+
 	noOpConfigHook := func(ctx context.Context, s state.State, config types.DaemonConfig) error { return nil }
 	noOpNewMemberHook := func(ctx context.Context, s state.State, newMember types.ClusterMemberLocal) error { return nil }
 	noOpHeartbeatHook := func(ctx context.Context, s state.State, roleStatus map[string]types.RoleStatus) error { return nil }

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -658,6 +658,7 @@ func NewTestDB(extensionsExternal []schema.Update) (*DqliteDB, error) {
 		upgradeCh:  make(chan struct{}, 1),
 		os:         &sys.OS{},
 	}
+
 	db.db, err = sql.Open("sqlite3", ":memory:")
 	if err != nil {
 		return nil, err

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -132,6 +132,7 @@ func (db *DqliteDB) isInitialized() (bool, error) {
 		if os.IsNotExist(err) {
 			return false, nil
 		}
+
 		return false, err
 	}
 

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -127,7 +127,8 @@ func (db *DqliteDB) SchemaVersion() (versionInternal uint64, versionExternal uin
 // isInitialized determines whether the database has been bootstrapped or joined to a cluster.
 // This is an internal helper function; external callers should use Status() instead.
 func (db *DqliteDB) isInitialized() (bool, error) {
-	if _, err := os.Stat(filepath.Join(db.os.DatabaseDir, "info.yaml")); err != nil {
+	_, err := os.Stat(filepath.Join(db.os.DatabaseDir, "info.yaml"))
+	if err != nil {
 		if os.IsNotExist(err) {
 			return false, nil
 		}

--- a/internal/db/update/cluster.go
+++ b/internal/db/update/cluster.go
@@ -101,6 +101,7 @@ func UpdateClusterMemberSchemaVersion(ctx context.Context, tx *sql.Tx, internalV
 	if err != nil {
 		return err
 	}
+
 	if n != 1 {
 		return fmt.Errorf("Updated %d rows instead of 1", n)
 	}
@@ -177,6 +178,7 @@ WHERE name IN ('api_extensions');
 	if err != nil {
 		return err
 	}
+
 	if n != 1 {
 		return fmt.Errorf("Updated %d rows instead of 1", n)
 	}

--- a/internal/db/update/schema.go
+++ b/internal/db/update/schema.go
@@ -336,6 +336,7 @@ SELECT COUNT(name) FROM sqlite_master WHERE type = 'table' AND name = 'schemas'
 	if err != nil {
 		return false, err
 	}
+
 	defer func() { _ = rows.Close() }()
 
 	if !rows.Next() {

--- a/internal/endpoints/util.go
+++ b/internal/endpoints/util.go
@@ -20,6 +20,7 @@ func shutdownServer(server *http.Server, timeout time.Duration) error {
 		if errors.Is(err, net.ErrClosed) {
 			return nil
 		}
+
 		return err
 	}
 
@@ -34,7 +35,9 @@ func shutdownServer(server *http.Server, timeout time.Duration) error {
 			logger.Error("Failed to close server", logger.Ctx{"err": closeErr})
 			return fmt.Errorf("Encountered error while closing server: %w, after failing to gracefully shutdown the server: %w", closeErr, err)
 		}
+
 		return err
 	}
+
 	return nil
 }

--- a/internal/extensions/extensions.go
+++ b/internal/extensions/extensions.go
@@ -217,7 +217,8 @@ func (e Extensions) MarshalYAML() (any, error) {
 // UnmarshalJSON implements the json.Unmarshaler interface.
 func (e *Extensions) UnmarshalJSON(data []byte) error {
 	var v any
-	if err := json.Unmarshal(data, &v); err != nil {
+	err := json.Unmarshal(data, &v)
+	if err != nil {
 		return err
 	}
 
@@ -246,14 +247,16 @@ func (e *Extensions) UnmarshalYAML(value *yaml.Node) error {
 	switch value.Kind {
 	case yaml.ScalarNode:
 		var s string
-		if err := value.Decode(&s); err != nil {
+		err := value.Decode(&s)
+		if err != nil {
 			return err
 		}
 
 		*e = Extensions{s}
 	case yaml.SequenceNode:
 		var slice []string
-		if err := value.Decode(&slice); err != nil {
+		err := value.Decode(&slice)
+		if err != nil {
 			return err
 		}
 

--- a/internal/extensions/extensions.go
+++ b/internal/extensions/extensions.go
@@ -235,6 +235,7 @@ func (e *Extensions) UnmarshalJSON(data []byte) error {
 
 			(*e)[i] = str
 		}
+
 	default:
 		return fmt.Errorf("invalid type for Extension")
 	}

--- a/internal/recover/recover.go
+++ b/internal/recover/recover.go
@@ -77,6 +77,7 @@ func RecoverFromQuorumLoss(filesystem *sys.OS, members []cluster.DqliteMember) (
 		if err != nil {
 			return "", err
 		}
+
 		nodeInfo = append(nodeInfo, *info)
 	}
 
@@ -125,6 +126,7 @@ func RecoverFromQuorumLoss(filesystem *sys.OS, members []cluster.DqliteMember) (
 		if err == nil {
 			return fmt.Errorf("Contacted cluster member at %q; please shut down all cluster members", rslt.Name)
 		}
+
 		return nil
 	})
 	cancel()
@@ -227,6 +229,7 @@ func writeDqliteClusterYaml(path string, members []cluster.DqliteMember) error {
 		if err != nil {
 			return err
 		}
+
 		nodeInfo[i] = *infoPtr
 	}
 
@@ -666,6 +669,7 @@ func unpackTarball(tarballPath string, destRoot string) error {
 			} else if err != nil {
 				return err
 			}
+
 		case tar.TypeDir:
 			err = os.MkdirAll(filepath, fs.FileMode(header.Mode&int64(fs.ModePerm)))
 			if err != nil {

--- a/internal/recover/recover.go
+++ b/internal/recover/recover.go
@@ -409,13 +409,14 @@ func MaybeUnpackRecoveryTarball(filesystem *sys.OS) error {
 	recoveryYamlPath := path.Join(unpackDir, "recovery.yaml")
 
 	// Determine if the recovery tarball exists
-	if _, err := os.Stat(tarballPath); errors.Is(err, os.ErrNotExist) {
+	_, err := os.Stat(tarballPath)
+	if errors.Is(err, os.ErrNotExist) {
 		return nil
 	}
 
 	logger.Warn("Recovery tarball located; attempting DB recovery", logger.Ctx{"tarball": tarballPath})
 
-	err := unpackTarball(tarballPath, unpackDir)
+	err = unpackTarball(tarballPath, unpackDir)
 	if err != nil {
 		return err
 	}

--- a/internal/rest/client/client.go
+++ b/internal/rest/client/client.go
@@ -177,6 +177,7 @@ func forwardingProxy(r *http.Request) (*url.URL, error) {
 	if ok {
 		r.Header.Add(request.HeaderForwardedUsername, val)
 	}
+
 	val, ok = ctx.Value(request.CtxProtocol).(string)
 	if ok {
 		r.Header.Add(request.HeaderForwardedProtocol, val)

--- a/internal/rest/resources/hooks.go
+++ b/internal/rest/resources/hooks.go
@@ -50,6 +50,7 @@ func hooksPost(s state.State, r *http.Request) response.Response {
 		if err != nil {
 			return response.SmartError(fmt.Errorf("Failed to execute pre-remove hook on cluster member %q: %w", s.Name(), err))
 		}
+
 	case internalTypes.PostRemove:
 		var req internalTypes.HookRemoveMemberOptions
 		err = json.NewDecoder(r.Body).Decode(&req)
@@ -77,6 +78,7 @@ func hooksPost(s state.State, r *http.Request) response.Response {
 		if err != nil {
 			return response.SmartError(fmt.Errorf("Failed to run hook after system %q has joined the cluster: %w", req.NewMember.Name, err))
 		}
+
 	case internalTypes.OnDaemonConfigUpdate:
 		var req types.DaemonConfig
 		err = json.NewDecoder(r.Body).Decode(&req)
@@ -88,6 +90,7 @@ func hooksPost(s state.State, r *http.Request) response.Response {
 		if err != nil {
 			return response.SmartError(fmt.Errorf("Failed to run hook on %q after daemon received local config update: %w", s.Name(), err))
 		}
+
 	default:
 		return response.SmartError(fmt.Errorf("No valid hook found for the given type"))
 	}

--- a/internal/rest/resources/hooks_test.go
+++ b/internal/rest/resources/hooks_test.go
@@ -121,6 +121,7 @@ func (t *hooksSuite) Test_hooks() {
 			// Set an URL for response.Render to not cause any panic.
 			URL: &url.URL{},
 		}
+
 		payload, ok := c.req.(internalTypes.HookRemoveMemberOptions)
 		if !ok {
 			payload, ok := c.req.(internalTypes.HookNewMemberOptions)

--- a/internal/rest/resources/resources_test.go
+++ b/internal/rest/resources/resources_test.go
@@ -102,6 +102,7 @@ func TestValidateEndpointsInvalidServers(t *testing.T) {
 		servers := map[string]rest.Server{
 			serverName: server,
 		}
+
 		err := ValidateEndpoints(servers, "localhost:8000")
 		if err == nil {
 			t.Errorf("Invalid server %q passed validation", serverName)

--- a/internal/rest/resources/tokens.go
+++ b/internal/rest/resources/tokens.go
@@ -78,6 +78,7 @@ func tokensPost(state state.State, r *http.Request) response.Response {
 	expiryDate := sql.NullTime{
 		Valid: req.ExpireAfter != 0,
 	}
+
 	if expiryDate.Valid {
 		expiryDate.Time = time.Now().Add(req.ExpireAfter)
 	}

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -49,10 +49,12 @@ func App(args Args) (*MicroCluster, error) {
 	if args.StateDir == "" {
 		return nil, fmt.Errorf("Missing state directory")
 	}
+
 	stateDir, err := filepath.Abs(args.StateDir)
 	if err != nil {
 		return nil, fmt.Errorf("Missing absolute state directory: %w", err)
 	}
+
 	os, err := sys.DefaultOS(stateDir, true)
 	if err != nil {
 		return nil, err

--- a/rest/access/handlers.go
+++ b/rest/access/handlers.go
@@ -89,6 +89,7 @@ func Authenticate(state state.State, r *http.Request, hostAddress string, truste
 				}
 			}
 		}
+
 	default:
 		return false, ErrInvalidHost{error: fmt.Errorf("Invalid request address %q", r.Host)}
 	}

--- a/test/lint/new-line-after-block.sh
+++ b/test/lint/new-line-after-block.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+set -eu
+
+echo "Checking that functional blocks are followed by newlines..."
+
+# Check all .go files except the protobuf bindings (.pb.go)
+files=$(git ls-files --cached --modified --others '*.go')
+
+exit_code=0
+for file in $files
+do
+  # This oneliner has a few steps:
+  # 1. sed:
+  #     a. Check for lines that contain a single closing brace (plus whitespace).
+  #     b. Move the pattern space window forward to the next line.
+  #     c. Match lines that start with a word character. This allows for a closing brace on subsequent lines.
+  #     d. Print the line number.
+  # 2. xargs: Print the filename next to the line number of the matches (piped).
+  # 3. If there were no matches, the file name without the line number is printed, use grep to filter it out.
+  # 4. Replace the space with a colon to make a clickable link.
+  RESULT=$(sed -n -e '/^\s*}\s*$/{n;/^\s*\w/{;=}}' "$file" | xargs -L 1 echo "$file" | grep -v '\.go$' | sed 's/ /:/g')
+  if [ -n "${RESULT}" ]; then
+    echo "${RESULT}"
+    exit_code=1
+  fi
+done
+
+exit $exit_code

--- a/test/lint/no-oneline-assign-and-test.sh
+++ b/test/lint/no-oneline-assign-and-test.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+set -eu
+
+echo "Checking for oneline assign & test..."
+
+# Recursively grep go files for if statements that contain assignments.
+! git grep --untracked -P -n '^\s+if.*:=.*;.*{\s*$' -- '*.go'


### PR DESCRIPTION
This adds two of the linter rules from the LXD repo which should ease PR reviews from outside and keeps the two code bases consistent.