### PR TITLE
DB: Remove project

### DIFF
--- a/cluster/stmt.go
+++ b/cluster/stmt.go
@@ -29,8 +29,7 @@ func RegisterStmt(sql string) int {
 }
 
 // PrepareStmts prepares all registered statements and stores them in preparedStmts.
-// The project argument is kept for backwards compatibility but is deprecated.
-func PrepareStmts(db *sql.DB, project string, skipErrors bool) error {
+func PrepareStmts(db *sql.DB, skipErrors bool) error {
 	logger.Infof("Preparing statements")
 
 	for code, stmt := range stmts {

--- a/cluster/stmt.go
+++ b/cluster/stmt.go
@@ -72,6 +72,8 @@ func StmtString(code int) (string, error) {
 }
 
 // GetCallerProject will get the go project name of whichever function called `GetCallerProject`.
+//
+// Deprecated: The caller project is no longer required and causes issues when vendoring.
 func GetCallerProject() string {
 	sep := string(os.PathSeparator)
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -79,7 +79,6 @@ type Args struct {
 
 // Daemon holds information for the microcluster daemon.
 type Daemon struct {
-	project string // The project refers to the name of the go-project that is calling MicroCluster.
 	version string // The version of the go-project that is calling MicroCluster
 
 	config *internalConfig.DaemonConfig // Local daemon's configuration from daemon.yaml file.
@@ -115,12 +114,11 @@ type Daemon struct {
 }
 
 // NewDaemon initializes the Daemon context and channels.
-func NewDaemon(project string) *Daemon {
+func NewDaemon() *Daemon {
 	d := &Daemon{
 		shutdownDoneCh:   make(chan error),
 		ReadyChan:        make(chan struct{}),
 		extensionServers: make(map[string]rest.Server),
-		project:          project,
 	}
 
 	d.stop = sync.OnceValue(func() error {
@@ -580,7 +578,7 @@ func (d *Daemon) StartAPI(ctx context.Context, bootstrap bool, initConfig map[st
 
 		clusterMember.SchemaInternal, clusterMember.SchemaExternal, _ = d.db.Schema().Version()
 
-		err = d.db.Bootstrap(d.Extensions, d.project, *d.Address(), clusterMember)
+		err = d.db.Bootstrap(d.Extensions, *d.Address(), clusterMember)
 		if err != nil {
 			return err
 		}
@@ -602,12 +600,12 @@ func (d *Daemon) StartAPI(ctx context.Context, bootstrap bool, initConfig map[st
 	}
 
 	if len(joinAddresses) != 0 {
-		err = d.db.Join(d.Extensions, d.project, *d.Address(), joinAddresses...)
+		err = d.db.Join(d.Extensions, *d.Address(), joinAddresses...)
 		if err != nil {
 			return fmt.Errorf("Failed to join cluster: %w", err)
 		}
 	} else {
-		err = d.db.StartWithCluster(d.Extensions, d.project, *d.Address(), d.trustStore.Remotes().Addresses())
+		err = d.db.StartWithCluster(d.Extensions, *d.Address(), d.trustStore.Remotes().Addresses())
 		if err != nil {
 			return fmt.Errorf("Failed to re-establish cluster connection: %w", err)
 		}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -189,7 +189,7 @@ func (t *daemonsSuite) Test_UpdateServers() {
 		var err error
 
 		// Create a new daemon and set some defaults.
-		daemon := NewDaemon("project")
+		daemon := NewDaemon()
 		daemon.version = "1.0.0"
 		daemon.config = config.NewDaemonConfig(filepath.Join(t.T().TempDir(), "daemon.yaml"))
 		daemon.extensionServers = test.extensionServers

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -27,7 +27,7 @@ import (
 
 // Open opens the dqlite database and loads the schema.
 // Returns true if we need to wait for other nodes to catch up to our version.
-func (db *DqliteDB) Open(ext extensions.Extensions, bootstrap bool, project string) error {
+func (db *DqliteDB) Open(ext extensions.Extensions, bootstrap bool) error {
 	ctx, cancel := context.WithTimeout(db.ctx, 30*time.Second)
 	defer cancel()
 
@@ -71,7 +71,7 @@ func (db *DqliteDB) Open(ext extensions.Extensions, bootstrap bool, project stri
 		db.db = nil
 	})
 
-	err = cluster.PrepareStmts(db.db, project, false)
+	err = cluster.PrepareStmts(db.db, "", false)
 	if err != nil {
 		return err
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -71,7 +71,7 @@ func (db *DqliteDB) Open(ext extensions.Extensions, bootstrap bool) error {
 		db.db = nil
 	})
 
-	err = cluster.PrepareStmts(db.db, "", false)
+	err = cluster.PrepareStmts(db.db, false)
 	if err != nil {
 		return err
 	}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -670,7 +670,7 @@ func NewTestDB(extensionsExternal []schema.Update) (*DqliteDB, error) {
 		return nil, err
 	}
 
-	err = cluster.PrepareStmts(db.db, cluster.GetCallerProject(), false)
+	err = cluster.PrepareStmts(db.db, "", false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -670,7 +670,7 @@ func NewTestDB(extensionsExternal []schema.Update) (*DqliteDB, error) {
 		return nil, err
 	}
 
-	err = cluster.PrepareStmts(db.db, "", false)
+	err = cluster.PrepareStmts(db.db, false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -140,7 +140,7 @@ func (db *DqliteDB) isInitialized() (bool, error) {
 }
 
 // Bootstrap dqlite.
-func (db *DqliteDB) Bootstrap(extensions extensions.Extensions, project string, addr api.URL, clusterRecord cluster.CoreClusterMember) error {
+func (db *DqliteDB) Bootstrap(extensions extensions.Extensions, addr api.URL, clusterRecord cluster.CoreClusterMember) error {
 	var err error
 	db.listenAddr = addr
 	db.dqlite, err = dqlite.New(db.os.DatabaseDir,
@@ -154,7 +154,7 @@ func (db *DqliteDB) Bootstrap(extensions extensions.Extensions, project string, 
 		return fmt.Errorf("Failed to bootstrap dqlite: %w", err)
 	}
 
-	err = db.Open(extensions, true, project)
+	err = db.Open(extensions, true)
 	if err != nil {
 		return err
 	}
@@ -174,7 +174,7 @@ func (db *DqliteDB) Bootstrap(extensions extensions.Extensions, project string, 
 }
 
 // Join a dqlite cluster with the address of a member.
-func (db *DqliteDB) Join(extensions extensions.Extensions, project string, addr api.URL, joinAddresses ...string) error {
+func (db *DqliteDB) Join(extensions extensions.Extensions, addr api.URL, joinAddresses ...string) error {
 	var err error
 	db.listenAddr = addr
 	db.dqlite, err = dqlite.New(db.os.DatabaseDir,
@@ -190,7 +190,7 @@ func (db *DqliteDB) Join(extensions extensions.Extensions, project string, addr 
 	}
 
 	for {
-		err := db.Open(extensions, false, project)
+		err := db.Open(extensions, false)
 		if err == nil {
 			break
 		}
@@ -209,13 +209,13 @@ func (db *DqliteDB) Join(extensions extensions.Extensions, project string, addr 
 }
 
 // StartWithCluster starts up dqlite and joins the cluster.
-func (db *DqliteDB) StartWithCluster(extensions extensions.Extensions, project string, addr api.URL, clusterMembers map[string]types.AddrPort) error {
+func (db *DqliteDB) StartWithCluster(extensions extensions.Extensions, addr api.URL, clusterMembers map[string]types.AddrPort) error {
 	allClusterAddrs := []string{}
 	for _, clusterMemberAddrs := range clusterMembers {
 		allClusterAddrs = append(allClusterAddrs, clusterMemberAddrs.String())
 	}
 
-	return db.Join(extensions, project, addr, allClusterAddrs...)
+	return db.Join(extensions, addr, allClusterAddrs...)
 }
 
 // Leader returns a client connected to the leader of the dqlite cluster.

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -77,7 +77,7 @@ func (m *MicroCluster) Start(ctx context.Context, daemonArgs DaemonArgs) error {
 
 	// Start up a daemon with a basic control socket.
 	defer logger.Info("Daemon stopped")
-	d := daemon.NewDaemon(cluster.GetCallerProject())
+	d := daemon.NewDaemon()
 
 	chIgnore := make(chan os.Signal, 1)
 	signal.Notify(chIgnore, unix.SIGHUP)


### PR DESCRIPTION
This is to explore the idea of not having the extra `project` field but instead tracking both internal and external SQL statements together.

Ultimately this allows getting rid of the "get caller" concept.
It was introduced as part of https://github.com/canonical/microcluster/pull/65 but doesn't seem to be required anymore.

Fixes https://github.com/canonical/microcluster/issues/350.