### PR TITLE
Endpoints: Fix implicit shutdown

### DIFF
--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -232,7 +232,7 @@ func (t *daemonsSuite) Test_UpdateServers() {
 		}
 
 		// Close all endpoints.
-		err = daemon.endpoints.Down(endpoints.EndpointNetwork)
+		err = daemon.endpoints.Down(true, endpoints.EndpointNetwork)
 		require.NoError(t.T(), err)
 	}
 }

--- a/internal/endpoints/endpoint.go
+++ b/internal/endpoints/endpoint.go
@@ -5,6 +5,7 @@ type Endpoint interface {
 	Listen() error
 	Serve()
 	Close() error
+	Shutdown() error
 	Type() EndpointType
 }
 

--- a/internal/endpoints/endpoints.go
+++ b/internal/endpoints/endpoints.go
@@ -97,7 +97,7 @@ func (e *Endpoints) up(listeners map[string]Endpoint) error {
 }
 
 // Down closes all of the configured listeners, or any for the type specifically supplied.
-func (e *Endpoints) Down(types ...EndpointType) error {
+func (e *Endpoints) Down(shutdown bool, types ...EndpointType) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -115,6 +115,13 @@ func (e *Endpoints) Down(types ...EndpointType) error {
 				return err
 			}
 
+			if shutdown {
+				err = endpoint.Shutdown()
+				if err != nil {
+					return err
+				}
+			}
+
 			// Delete the stopped endpoint from the slice.
 			delete(e.listeners, name)
 		}
@@ -124,7 +131,7 @@ func (e *Endpoints) Down(types ...EndpointType) error {
 }
 
 // DownByName closes the configured listeners based on its name.
-func (e *Endpoints) DownByName(name string) error {
+func (e *Endpoints) DownByName(shutdown bool, name string) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -135,6 +142,12 @@ func (e *Endpoints) DownByName(name string) error {
 				return err
 			}
 
+			if shutdown {
+				err = endpoint.Shutdown()
+				if err != nil {
+					return err
+				}
+			}
 			// Delete the stopped endpoint from the slice.
 			delete(e.listeners, name)
 		}

--- a/internal/endpoints/endpoints.go
+++ b/internal/endpoints/endpoints.go
@@ -26,7 +26,8 @@ func (e *Endpoints) Up() error {
 	err := e.up(e.listeners)
 	if err != nil {
 		// Attempt to call Down() in case something actually got brought up.
-		_ = e.Down()
+		// Close the listeners and shutdown the underlying servers.
+		_ = e.Down(true)
 
 		return err
 	}
@@ -59,7 +60,8 @@ func (e *Endpoints) Add(endpoints map[string]Endpoint) error {
 	if err != nil {
 		// Attempt to call DownByName() in case something actually got brought up.
 		for name := range endpoints {
-			_ = e.DownByName(name)
+			// Close the listener and shutdown the underlying server.
+			_ = e.DownByName(true, name)
 		}
 
 		return err

--- a/internal/endpoints/network.go
+++ b/internal/endpoints/network.go
@@ -127,10 +127,7 @@ func (n *Network) Serve() {
 	}()
 }
 
-// Close the listener and server.
-// Will attempt to close the server gracefully, if configured with a drain connections timeout.
-// Note that graceful shutdown will timeout if the connections do not finish (e.g.: a request caused the server
-// to Close the endpoints on the same goroutine).
+// Close the listener.
 func (n *Network) Close() error {
 	if n.listener == nil {
 		return nil
@@ -143,10 +140,12 @@ func (n *Network) Close() error {
 	// It does not shutdown the server, or its currently accepted connections.
 	// We need to shut this down separately, as the listener is not passed to the server
 	// if n.Serve() is not called.
-	err := n.listener.Close()
-	if err != nil {
-		return err
-	}
+	return n.listener.Close()
+}
 
+// Shutdown will attempt to close the server gracefully, if configured with a drain connections timeout.
+// Note that graceful shutdown will timeout if the connections do not finish (e.g.: a request caused the server
+// to Close the endpoints on the same goroutine).
+func (n *Network) Shutdown() error {
 	return shutdownServer(n.server, n.drainConnectionsTimeout)
 }

--- a/internal/endpoints/socket.go
+++ b/internal/endpoints/socket.go
@@ -112,10 +112,7 @@ func (s *Socket) Serve() {
 	}()
 }
 
-// Close the listener and server.
-// Will attempt to close the server gracefully, if configured with a drain connections timeout.
-// Note that graceful shutdown will timeout if the connections do not finish (e.g.: a request caused the server
-// to Close the endpoints on the same goroutine).
+// Close the listener.
 func (s *Socket) Close() error {
 	if s.listener == nil {
 		return nil
@@ -128,11 +125,13 @@ func (s *Socket) Close() error {
 	// It does not shutdown the server, or its currently accepted connections.
 	// We need to shut this down separately, as the listener is not passed to the server
 	// if s.Serve() is not called.
-	err := s.listener.Close()
-	if err != nil {
-		return err
-	}
+	return s.listener.Close()
+}
 
+// Shutdown will attempt to close the server gracefully, if configured with a drain connections timeout.
+// Note that graceful shutdown will timeout if the connections do not finish (e.g.: a request caused the server
+// to Close the endpoints on the same goroutine).
+func (s *Socket) Shutdown() error {
 	return shutdownServer(s.server, s.drainConnectionsTimeout)
 }
 


### PR DESCRIPTION
This addresses a regression introduced with https://github.com/canonical/microcluster/pull/295.

Before you were able to close endpoints (listeners) without closing the underlying server. As part of allowing graceful shutdown of servers (and listeners), we added code to implicitly shutdown the listeners underlying server for proper cleanup.

However it looks the code always assumed the underlying server never gets closed which allows instructing a remote Microcluster member to join the cluster without closing the connection that was used to instruct this member to join the cluster.

The PR introduces another flag that explicitly allows shutting down an endpoint's (listener's) underlying server. We can do this in most of the cases but should not do it in the following two:

* Close the server when a remote client instructed to join an existing cluster
* Close the server when restarting one of the extension servers. This allows keeping active connections alive.