### PR TITLE
github: Require all GitHub actions to be pinned (v2)

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -23,6 +23,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
+      - name: Require GHA pinning
+        uses: canonical/lxd/.github/actions/require-gha-pinning@main
+
       - name: Dependency Review
         uses: actions/dependency-review-action@3b139cfc5fae8b618d3eae3675e383bb1769c019 # v4.5.0
         if: github.event_name == 'pull_request'


### PR DESCRIPTION
Signed-off-by: Simon Deziel <simon.deziel@canonical.com>
(cherry picked from commit a119143bcd21917bfe895973fa3726bf949fd62a)