### PR TITLE
github: Update golangci-lint and migrate config to new format

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,110 +1,125 @@
+version: "2"
 linters:
   enable:
-    - gci
     - godot
-    - gofmt
     - misspell
     - whitespace
     - revive
-issues:
-  exclude-use-default: false
-linters-settings:
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/canonical/microcluster)
-  errcheck:
-    exclude-functions:
-      - (io.ReadCloser).Close # Commonly ignored error.
-  revive:
+  settings:
+      errcheck:
+        exclude-functions:
+          - (io.ReadCloser).Close # Commonly ignored error.
+      revive:
+        rules:
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#exported
+          - name: exported
+            arguments:
+              - "checkPrivateReceivers"
+              - "disableStutteringCheck"
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#unchecked-type-assertion
+          - name: unchecked-type-assertion
+            arguments:
+              - { "acceptIgnoredAssertionResult": true }
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#var-naming
+          - name: var-naming
+            arguments: # The arguments here are quite odd looking. See the rule description.
+              - [ ]
+              - [ ]
+              - [ { "upperCaseConst": true } ]
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#early-return
+          - name: early-return
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#redundant-import-alias
+          - name: redundant-import-alias
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#redefines-builtin-id
+          - name: redefines-builtin-id
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#struct-tag
+          - name: struct-tag
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#receiver-naming
+          - name: receiver-naming
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#deep-exit
+          - name: deep-exit
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#defer
+          - name: defer
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#bool-literal-in-expr
+          - name: bool-literal-in-expr
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#comment-spacings
+          - name: comment-spacings
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#confusing-results
+          - name: confusing-results
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#use-any
+          - name: use-any
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#bare-return
+          - name: bare-return
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#empty-block
+          - name: empty-block
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#range-val-address
+          - name: range-val-address
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#range-val-in-closure
+          - name: range-val-in-closure
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#var-declaration
+          - name: var-declaration
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#useless-break
+          - name: useless-break
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#error-naming
+          - name: error-naming
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#indent-error-flow
+          - name: indent-error-flow
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#datarace
+          - name: datarace
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#modifies-value-receiver
+          - name: modifies-value-receiver
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#empty-lines
+          - name: empty-lines
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#duplicated-imports
+          - name: duplicated-imports
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#error-return
+          - name: error-return
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#exported
-      - name: exported
-        arguments:
-          - "checkPrivateReceivers"
-          - "disableStutteringCheck"
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#unchecked-type-assertion
-      - name: unchecked-type-assertion
-        arguments:
-          - { "acceptIgnoredAssertionResult": true }
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#var-naming
-      - name: var-naming
-        arguments: # The arguments here are quite odd looking. See the rule description.
-          - [ ]
-          - [ ]
-          - [ { "upperCaseConst": true } ]
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#early-return
-      - name: early-return
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#redundant-import-alias
-      - name: redundant-import-alias
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#redefines-builtin-id
-      - name: redefines-builtin-id
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#struct-tag
-      - name: struct-tag
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#receiver-naming
-      - name: receiver-naming
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#deep-exit
-      - name: deep-exit
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#defer
-      - name: defer
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#bool-literal-in-expr
-      - name: bool-literal-in-expr
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#comment-spacings
-      - name: comment-spacings
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#confusing-results
-      - name: confusing-results
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#use-any
-      - name: use-any
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#bare-return
-      - name: bare-return
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#empty-block
-      - name: empty-block
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#range-val-address
-      - name: range-val-address
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#range-val-in-closure
-      - name: range-val-in-closure
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#var-declaration
-      - name: var-declaration
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#useless-break
-      - name: useless-break
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#error-naming
-      - name: error-naming
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#indent-error-flow
-      - name: indent-error-flow
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#datarace
-      - name: datarace
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#modifies-value-receiver
-      - name: modifies-value-receiver
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#empty-lines
-      - name: empty-lines
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#duplicated-imports
-      - name: duplicated-imports
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#error-return
-      - name: error-return
+      - linters:
+          - staticcheck
+        text: "ST1005:" # ST1005: error strings should not be capitalized
+formatters:
+  enable:
+    - gci
+    - gofmt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/canonical/microcluster)
+  exclusions:
+    generated: lax

--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ check-system:
 .PHONY: check-static
 check-static:
 ifeq ($(shell command -v golangci-lint 2> /dev/null),)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v2.0.0
 endif
 	golangci-lint run --timeout 5m
 	run-parts --verbose --exit-on-error --regex '.sh' test/lint

--- a/example/cmd/microctl/main.go
+++ b/example/cmd/microctl/main.go
@@ -12,7 +12,7 @@ import (
 // CmdControl has functions that are common to the microctl commands.
 // command line tools.
 type CmdControl struct {
-	cmd *cobra.Command //nolint:structcheck,unused // FIXME: Remove the nolint flag when this is in use.
+	cmd *cobra.Command //nolint:unused // FIXME: Remove the nolint flag when this is in use.
 
 	FlagHelp       bool
 	FlagVersion    bool

--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -24,7 +24,7 @@ var Debug bool
 var Verbose bool
 
 type cmdGlobal struct {
-	cmd *cobra.Command //nolint:structcheck,unused // FIXME: Remove the nolint flag when this is in use.
+	cmd *cobra.Command //nolint:unused // FIXME: Remove the nolint flag when this is in use.
 
 	flagHelp    bool
 	flagVersion bool

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -347,13 +347,15 @@ func (d *Daemon) init(listenAddress string, socketGroup string, heartbeatInterva
 	d.db.SetSchema(schemaExtensions, d.Extensions)
 
 	status := d.db.Status()
-	if status == types.DatabaseStarting {
+	switch status {
+	case types.DatabaseStarting:
 		// Database is already bootstrapped, reload the daemon to ensure the latest configuration is applied.
 		err := d.reload()
 		if err != nil {
 			return fmt.Errorf("Failed to reload daemon: %w", err)
 		}
-	} else if status == types.DatabaseNotReady {
+
+	case types.DatabaseNotReady:
 		logger.Warn("Microcluster database is uninitialized")
 	}
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -931,7 +931,7 @@ func (d *Daemon) sendUpgradeNotification(ctx context.Context, c *client.Client) 
 	upgradeRequest.Header.Set("X-Dqlite-Version", fmt.Sprintf("%d", 1))
 	upgradeRequest = upgradeRequest.WithContext(ctx)
 
-	resp, err := c.Client.Do(upgradeRequest)
+	resp, err := c.Do(upgradeRequest)
 	if err != nil {
 		logger.Error("Failed to send database upgrade request", logger.Ctx{"error": err})
 		return nil

--- a/internal/rest/client/client.go
+++ b/internal/rest/client/client.go
@@ -284,15 +284,15 @@ func (c *Client) mergeURL(endpointType types.EndpointPrefix, endpoint *api.URL) 
 	localURL.URL.Host = c.url.URL.Host
 	localURL.URL.Scheme = c.url.URL.Scheme
 	localURL.URL.Path = filepath.Join("/", string(endpointType), localURL.URL.Path)
-	localURL.URL.RawPath = filepath.Join("/", string(endpointType), localURL.URL.RawPath)
+	localURL.RawPath = filepath.Join("/", string(endpointType), localURL.RawPath)
 
-	localQuery := localURL.URL.Query()
-	clientQuery := c.url.URL.Query()
+	localQuery := localURL.Query()
+	clientQuery := c.url.Query()
 	for k := range localQuery {
 		clientQuery.Set(k, localQuery.Get(k))
 	}
 
-	localURL.URL.RawQuery = clientQuery.Encode()
+	localURL.RawQuery = clientQuery.Encode()
 	return localURL
 }
 
@@ -355,9 +355,9 @@ func (c *Client) RawWebsocket(ctx context.Context, endpointType types.EndpointPr
 	}
 
 	// Get the transport configuration from the HTTP client.
-	tr, ok := c.Client.Transport.(*http.Transport)
+	tr, ok := c.Transport.(*http.Transport)
 	if !ok {
-		return nil, fmt.Errorf("Invalid underlying client transport, expected %T, got %T", &http.Transport{}, c.Client.Transport)
+		return nil, fmt.Errorf("Invalid underlying client transport, expected %T, got %T", &http.Transport{}, c.Transport)
 	}
 
 	// Setup a new websocket dialer using the already existing HTTP client.
@@ -406,7 +406,7 @@ func (c *Client) UseTarget(name string) *Client {
 	localURL.URL.Host = c.url.URL.Host
 	localURL.URL.Scheme = c.url.URL.Scheme
 	localURL.URL.Path = c.url.URL.Path
-	localURL.URL.RawQuery = c.url.URL.RawQuery
+	localURL.RawQuery = c.url.RawQuery
 	localURL = localURL.WithQuery("target", name)
 
 	return &Client{

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -301,13 +301,13 @@ func (m *MicroCluster) LocalClient() (*client.Client, error) {
 	}
 
 	if m.args.Proxy != nil {
-		tx, ok := c.Client.Client.Transport.(*http.Transport)
+		tx, ok := c.Transport.(*http.Transport)
 		if !ok {
-			return nil, fmt.Errorf("Invalid underlying client transport, expected %T, got %T", &http.Transport{}, c.Client.Client.Transport)
+			return nil, fmt.Errorf("Invalid underlying client transport, expected %T, got %T", &http.Transport{}, c.Transport)
 		}
 
 		tx.Proxy = m.args.Proxy
-		c.Client.Client.Transport = tx
+		c.Transport = tx
 	}
 
 	return c, nil
@@ -348,13 +348,13 @@ func (m *MicroCluster) RemoteClientWithCert(address string, cert *x509.Certifica
 	}
 
 	if m.args.Proxy != nil {
-		tx, ok := c.Client.Client.Transport.(*http.Transport)
+		tx, ok := c.Transport.(*http.Transport)
 		if !ok {
-			return nil, fmt.Errorf("Invalid underlying client transport, expected %T, got %T", &http.Transport{}, c.Client.Client.Transport)
+			return nil, fmt.Errorf("Invalid underlying client transport, expected %T, got %T", &http.Transport{}, c.Transport)
 		}
 
 		tx.Proxy = m.args.Proxy
-		c.Client.Client.Transport = tx
+		c.Transport = tx
 	}
 
 	return c, nil


### PR DESCRIPTION
Same as in https://github.com/canonical/microcloud/pull/712 and https://github.com/canonical/lxd/pull/15249/.