### PR TITLE
Bump delete timeout

### DIFF
--- a/internal/rest/client/cluster.go
+++ b/internal/rest/client/cluster.go
@@ -2,6 +2,8 @@ package client
 
 import (
 	"context"
+	"math"
+	"strconv"
 	"time"
 
 	"github.com/canonical/lxd/shared/api"
@@ -57,6 +59,10 @@ func (c *Client) DeleteClusterMember(ctx context.Context, name string, force boo
 	if force {
 		endpoint = endpoint.WithQuery("force", "1")
 	}
+
+	deadline, _ := queryCtx.Deadline()
+	seconds := int(math.Floor(time.Until(deadline).Seconds()))
+	endpoint.WithQuery("timeout", strconv.Itoa(seconds))
 
 	return c.QueryStruct(queryCtx, "DELETE", internalTypes.PublicEndpoint, endpoint, nil, nil)
 }

--- a/internal/rest/client/cluster.go
+++ b/internal/rest/client/cluster.go
@@ -12,7 +12,7 @@ import (
 
 // AddClusterMember records a new cluster member in the trust store of each current cluster member.
 func AddClusterMember(ctx context.Context, c *Client, args types.ClusterMember) (*internalTypes.TokenResponse, error) {
-	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	queryCtx, cancel := contextWithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	tokenResponse := internalTypes.TokenResponse{}
@@ -26,7 +26,7 @@ func AddClusterMember(ctx context.Context, c *Client, args types.ClusterMember) 
 
 // ResetClusterMember clears the state directory of the cluster member, and re-execs its daemon.
 func ResetClusterMember(ctx context.Context, c *Client, name string, force bool) error {
-	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	queryCtx, cancel := contextWithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	endpoint := api.NewURL().Path("cluster", name)
@@ -39,7 +39,7 @@ func ResetClusterMember(ctx context.Context, c *Client, name string, force bool)
 
 // GetClusterMembers returns the database record of cluster members.
 func (c *Client) GetClusterMembers(ctx context.Context) ([]types.ClusterMember, error) {
-	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	queryCtx, cancel := contextWithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	clusterMembers := []types.ClusterMember{}
@@ -50,7 +50,7 @@ func (c *Client) GetClusterMembers(ctx context.Context) ([]types.ClusterMember, 
 
 // DeleteClusterMember deletes the cluster member with the given name.
 func (c *Client) DeleteClusterMember(ctx context.Context, name string, force bool) error {
-	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	queryCtx, cancel := contextWithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	endpoint := api.NewURL().Path("cluster", name)
@@ -63,7 +63,7 @@ func (c *Client) DeleteClusterMember(ctx context.Context, name string, force boo
 
 // UpdateCertificate sets a new keypair and CA.
 func (c *Client) UpdateCertificate(ctx context.Context, name types.CertificateName, args types.KeyPair) error {
-	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	queryCtx, cancel := contextWithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	endpoint := api.NewURL().Path("cluster", "certificates", string(name))

--- a/internal/rest/client/hooks.go
+++ b/internal/rest/client/hooks.go
@@ -12,7 +12,7 @@ import (
 
 // RunPreRemoveHook executes the PreRemove hook with the given configuration on the cluster member targeted by this client.
 func RunPreRemoveHook(ctx context.Context, c *Client, config internalTypes.HookRemoveMemberOptions) error {
-	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	queryCtx, cancel := contextWithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	return c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, api.NewURL().Path("hooks", string(internalTypes.PreRemove)), config, nil)
@@ -20,7 +20,7 @@ func RunPreRemoveHook(ctx context.Context, c *Client, config internalTypes.HookR
 
 // RunPostRemoveHook executes the PostRemove hook with the given configuration on the cluster member targeted by this client.
 func RunPostRemoveHook(ctx context.Context, c *Client, config internalTypes.HookRemoveMemberOptions) error {
-	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	queryCtx, cancel := contextWithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	return c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, api.NewURL().Path("hooks", string(internalTypes.PostRemove)), config, nil)
@@ -28,7 +28,7 @@ func RunPostRemoveHook(ctx context.Context, c *Client, config internalTypes.Hook
 
 // RunNewMemberHook executes the OnNewMember hook with the given configuration on the cluster member targeted by this client.
 func RunNewMemberHook(ctx context.Context, c *Client, config internalTypes.HookNewMemberOptions) error {
-	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	queryCtx, cancel := contextWithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	return c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, api.NewURL().Path("hooks", string(internalTypes.OnNewMember)), config, nil)
@@ -36,7 +36,7 @@ func RunNewMemberHook(ctx context.Context, c *Client, config internalTypes.HookN
 
 // RunOnDaemonConfigUpdateHook executes the OnDaemonConfigUpdate hook with the given configuration on the cluster member targeted by this client.
 func RunOnDaemonConfigUpdateHook(ctx context.Context, c *Client, config *types.DaemonConfig) error {
-	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	queryCtx, cancel := contextWithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
 	return c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, api.NewURL().Path("hooks", string(internalTypes.OnDaemonConfigUpdate)), config, nil)

--- a/internal/rest/client/util.go
+++ b/internal/rest/client/util.go
@@ -1,0 +1,17 @@
+package client
+
+import (
+	"context"
+	"time"
+)
+
+// contextWithTimeout returns a context with a timeout, if the given context doesn't already have one.
+func contextWithTimeout(ctx context.Context, timeout time.Duration) (context.Context, func()) {
+	_, ok := ctx.Deadline()
+	if ok {
+		// Context already has a timeout. Return it as is, no need to cancel.
+		return ctx, func() {}
+	}
+
+	return context.WithTimeout(ctx, timeout)
+}

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -11,6 +11,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -416,7 +417,18 @@ func clusterMemberDelete(s state.State, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("No remote exists with the given name %q", name))
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), time.Second*30)
+	ctxTimeout := time.Second * 30
+	timeoutParam := r.URL.Query().Get("timeout")
+	if timeoutParam != "" {
+		seconds, err := strconv.Atoi(timeoutParam)
+		if err != nil || seconds <= 0 {
+			return response.SmartError(fmt.Errorf("Invalid timeout %s", timeoutParam))
+		}
+
+		ctxTimeout = time.Second * time.Duration(seconds)
+	}
+
+	ctx, cancel := context.WithTimeout(r.Context(), ctxTimeout)
 	defer cancel()
 
 	leader, err := s.Database().Leader(ctx)
@@ -452,7 +464,7 @@ func clusterMemberDelete(s state.State, r *http.Request) response.Response {
 			return response.SmartError(err)
 		}
 
-		err = client.DeleteClusterMember(r.Context(), name, force)
+		err = client.DeleteClusterMember(ctx, name, force)
 		if err != nil {
 			return response.SmartError(err)
 		}
@@ -570,7 +582,7 @@ func clusterMemberDelete(s state.State, r *http.Request) response.Response {
 			clusterDisableMu.Unlock()
 		}()
 
-		err = client.DeleteClusterMember(r.Context(), name, force)
+		err = client.DeleteClusterMember(ctx, name, force)
 		if err != nil {
 			return response.SmartError(err)
 		}


### PR DESCRIPTION
30 seconds may be too short for the operation, as we're calling both ``DeleteClusterMember`` and ``RunPreRemoveHook``, which may take longer, especially if graceful shutdown is used.

If ``DeleteClusterMember`` and ``RunPreRemoveHook`` receive a context with a timeout, they should use that instead.