### PR TITLE
Backport implicit shutdown regression fix and DB project removal (v2)

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,110 +1,125 @@
+version: "2"
 linters:
   enable:
-    - gci
     - godot
-    - gofmt
     - misspell
     - whitespace
     - revive
-issues:
-  exclude-use-default: false
-linters-settings:
-  gci:
-    sections:
-      - standard
-      - default
-      - prefix(github.com/canonical/microcluster)
-  errcheck:
-    exclude-functions:
-      - (io.ReadCloser).Close # Commonly ignored error.
-  revive:
+  settings:
+      errcheck:
+        exclude-functions:
+          - (io.ReadCloser).Close # Commonly ignored error.
+      revive:
+        rules:
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#exported
+          - name: exported
+            arguments:
+              - "checkPrivateReceivers"
+              - "disableStutteringCheck"
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#unchecked-type-assertion
+          - name: unchecked-type-assertion
+            arguments:
+              - { "acceptIgnoredAssertionResult": true }
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#var-naming
+          - name: var-naming
+            arguments: # The arguments here are quite odd looking. See the rule description.
+              - [ ]
+              - [ ]
+              - [ { "upperCaseConst": true } ]
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#early-return
+          - name: early-return
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#redundant-import-alias
+          - name: redundant-import-alias
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#redefines-builtin-id
+          - name: redefines-builtin-id
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#struct-tag
+          - name: struct-tag
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#receiver-naming
+          - name: receiver-naming
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#deep-exit
+          - name: deep-exit
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#defer
+          - name: defer
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#bool-literal-in-expr
+          - name: bool-literal-in-expr
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#comment-spacings
+          - name: comment-spacings
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#confusing-results
+          - name: confusing-results
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#use-any
+          - name: use-any
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#bare-return
+          - name: bare-return
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#empty-block
+          - name: empty-block
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#range-val-address
+          - name: range-val-address
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#range-val-in-closure
+          - name: range-val-in-closure
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#var-declaration
+          - name: var-declaration
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#useless-break
+          - name: useless-break
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#error-naming
+          - name: error-naming
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#indent-error-flow
+          - name: indent-error-flow
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#datarace
+          - name: datarace
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#modifies-value-receiver
+          - name: modifies-value-receiver
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#empty-lines
+          - name: empty-lines
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#duplicated-imports
+          - name: duplicated-imports
+
+          # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#error-return
+          - name: error-return
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
     rules:
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#exported
-      - name: exported
-        arguments:
-          - "checkPrivateReceivers"
-          - "disableStutteringCheck"
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#unchecked-type-assertion
-      - name: unchecked-type-assertion
-        arguments:
-          - { "acceptIgnoredAssertionResult": true }
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#var-naming
-      - name: var-naming
-        arguments: # The arguments here are quite odd looking. See the rule description.
-          - [ ]
-          - [ ]
-          - [ { "upperCaseConst": true } ]
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#early-return
-      - name: early-return
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#redundant-import-alias
-      - name: redundant-import-alias
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#redefines-builtin-id
-      - name: redefines-builtin-id
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#struct-tag
-      - name: struct-tag
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#receiver-naming
-      - name: receiver-naming
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#deep-exit
-      - name: deep-exit
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#defer
-      - name: defer
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#bool-literal-in-expr
-      - name: bool-literal-in-expr
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#comment-spacings
-      - name: comment-spacings
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#confusing-results
-      - name: confusing-results
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#use-any
-      - name: use-any
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#bare-return
-      - name: bare-return
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#empty-block
-      - name: empty-block
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#range-val-address
-      - name: range-val-address
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#range-val-in-closure
-      - name: range-val-in-closure
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#var-declaration
-      - name: var-declaration
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#useless-break
-      - name: useless-break
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#error-naming
-      - name: error-naming
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#indent-error-flow
-      - name: indent-error-flow
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#datarace
-      - name: datarace
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#modifies-value-receiver
-      - name: modifies-value-receiver
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#empty-lines
-      - name: empty-lines
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#duplicated-imports
-      - name: duplicated-imports
-
-      # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#error-return
-      - name: error-return
+      - linters:
+          - staticcheck
+        text: "ST1005:" # ST1005: error strings should not be capitalized
+formatters:
+  enable:
+    - gci
+    - gofmt
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/canonical/microcluster)
+  exclusions:
+    generated: lax

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ check-system:
 .PHONY: check-static
 check-static:
 ifeq ($(shell command -v golangci-lint 2> /dev/null),)
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin v2.0.0
 endif
 	golangci-lint run --timeout 5m
 

--- a/cluster/stmt.go
+++ b/cluster/stmt.go
@@ -72,6 +72,8 @@ func StmtString(code int) (string, error) {
 }
 
 // GetCallerProject will get the go project name of whichever function called `GetCallerProject`.
+//
+// Deprecated: The caller project is no longer required and causes issues when vendoring.
 func GetCallerProject() string {
 	sep := string(os.PathSeparator)
 

--- a/example/cmd/microctl/main.go
+++ b/example/cmd/microctl/main.go
@@ -12,7 +12,7 @@ import (
 // CmdControl has functions that are common to the microctl commands.
 // command line tools.
 type CmdControl struct {
-	cmd *cobra.Command //nolint:structcheck,unused // FIXME: Remove the nolint flag when this is in use.
+	cmd *cobra.Command //nolint:unused // FIXME: Remove the nolint flag when this is in use.
 
 	FlagHelp       bool
 	FlagVersion    bool

--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -24,7 +24,7 @@ var Debug bool
 var Verbose bool
 
 type cmdGlobal struct {
-	cmd *cobra.Command //nolint:structcheck,unused // FIXME: Remove the nolint flag when this is in use.
+	cmd *cobra.Command //nolint:unused // FIXME: Remove the nolint flag when this is in use.
 
 	flagHelp    bool
 	flagVersion bool

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -137,7 +137,8 @@ func NewDaemon(project string) *Daemon {
 		}
 
 		if d.endpoints != nil {
-			err := d.endpoints.Down()
+			// Stop the listeners and shutdown the underlying servers.
+			err := d.endpoints.Down(true)
 			if err != nil {
 				return err
 			}
@@ -575,7 +576,9 @@ func (d *Daemon) StartAPI(ctx context.Context, bootstrap bool, initConfig map[st
 
 	d.extensionServersMu.RUnlock()
 
-	err = d.endpoints.Down(endpoints.EndpointNetwork)
+	// Close the listener but don't shutdown the underlying server.
+	// This allows staying connected with the API during the join procedure.
+	err = d.endpoints.Down(false, endpoints.EndpointNetwork)
 	if err != nil {
 		return err
 	}
@@ -774,7 +777,9 @@ func (d *Daemon) UpdateServers() error {
 			d.extensionServers[serverName] = extensionServer
 			d.extensionServersMu.Unlock()
 
-			err := d.endpoints.DownByName(serverName)
+			// Stop the listener and shutdown the underlying server.
+			// Any active connections will be dropped at this point.
+			err := d.endpoints.DownByName(true, serverName)
 			if err != nil {
 				return err
 			}
@@ -805,7 +810,8 @@ func (d *Daemon) UpdateServers() error {
 
 		// Stop the additional listener in case it got modified.
 		if modified {
-			err := d.endpoints.DownByName(serverName)
+			// Don't shutdown the underlying server to keep active connections intact.
+			err := d.endpoints.DownByName(false, serverName)
 			if err != nil {
 				return err
 			}
@@ -1127,7 +1133,8 @@ func (d *Daemon) State() state.State {
 				return err
 			}
 
-			return d.endpoints.Down()
+			// Close the listeners and shutdown the underlying servers.
+			return d.endpoints.Down(true)
 		},
 	}
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -79,7 +79,6 @@ type Args struct {
 
 // Daemon holds information for the microcluster daemon.
 type Daemon struct {
-	project string // The project refers to the name of the go-project that is calling MicroCluster.
 	version string // The version of the go-project that is calling MicroCluster
 
 	config *internalConfig.DaemonConfig // Local daemon's configuration from daemon.yaml file.
@@ -115,12 +114,11 @@ type Daemon struct {
 }
 
 // NewDaemon initializes the Daemon context and channels.
-func NewDaemon(project string) *Daemon {
+func NewDaemon() *Daemon {
 	d := &Daemon{
 		shutdownDoneCh:   make(chan error),
 		ReadyChan:        make(chan struct{}),
 		extensionServers: make(map[string]rest.Server),
-		project:          project,
 	}
 
 	d.stop = sync.OnceValue(func() error {
@@ -607,7 +605,7 @@ func (d *Daemon) StartAPI(ctx context.Context, bootstrap bool, initConfig map[st
 
 		clusterMember.SchemaInternal, clusterMember.SchemaExternal, _ = d.db.Schema().Version()
 
-		err = d.db.Bootstrap(d.Extensions, d.project, *d.Address(), clusterMember)
+		err = d.db.Bootstrap(d.Extensions, *d.Address(), clusterMember)
 		if err != nil {
 			return err
 		}
@@ -629,12 +627,12 @@ func (d *Daemon) StartAPI(ctx context.Context, bootstrap bool, initConfig map[st
 	}
 
 	if len(joinAddresses) != 0 {
-		err = d.db.Join(d.Extensions, d.project, *d.Address(), joinAddresses...)
+		err = d.db.Join(d.Extensions, *d.Address(), joinAddresses...)
 		if err != nil {
 			return fmt.Errorf("Failed to join cluster: %w", err)
 		}
 	} else {
-		err = d.db.StartWithCluster(d.Extensions, d.project, *d.Address(), d.trustStore.Remotes().Addresses())
+		err = d.db.StartWithCluster(d.Extensions, *d.Address(), d.trustStore.Remotes().Addresses())
 		if err != nil {
 			return fmt.Errorf("Failed to re-establish cluster connection: %w", err)
 		}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -349,13 +349,15 @@ func (d *Daemon) init(listenAddress string, socketGroup string, heartbeatInterva
 	d.db.SetSchema(schemaExtensions, d.Extensions)
 
 	status := d.db.Status()
-	if status == types.DatabaseStarting {
+	switch status {
+	case types.DatabaseStarting:
 		// Database is already bootstrapped, reload the daemon to ensure the latest configuration is applied.
 		err := d.reload()
 		if err != nil {
 			return fmt.Errorf("Failed to reload daemon: %w", err)
 		}
-	} else if status == types.DatabaseNotReady {
+
+	case types.DatabaseNotReady:
 		logger.Warn("Microcluster database is uninitialized")
 	}
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -959,7 +959,7 @@ func (d *Daemon) sendUpgradeNotification(ctx context.Context, c *client.Client) 
 	upgradeRequest.Header.Set("X-Dqlite-Version", fmt.Sprintf("%d", 1))
 	upgradeRequest = upgradeRequest.WithContext(ctx)
 
-	resp, err := c.Client.Do(upgradeRequest)
+	resp, err := c.Do(upgradeRequest)
 	if err != nil {
 		logger.Error("Failed to send database upgrade request", logger.Ctx{"error": err})
 		return nil

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -232,7 +232,7 @@ func (t *daemonsSuite) Test_UpdateServers() {
 		}
 
 		// Close all endpoints.
-		err = daemon.endpoints.Down(endpoints.EndpointNetwork)
+		err = daemon.endpoints.Down(true, endpoints.EndpointNetwork)
 		require.NoError(t.T(), err)
 	}
 }

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -189,7 +189,7 @@ func (t *daemonsSuite) Test_UpdateServers() {
 		var err error
 
 		// Create a new daemon and set some defaults.
-		daemon := NewDaemon("project")
+		daemon := NewDaemon()
 		daemon.version = "1.0.0"
 		daemon.config = config.NewDaemonConfig(filepath.Join(t.T().TempDir(), "daemon.yaml"))
 		daemon.extensionServers = test.extensionServers

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -27,7 +27,7 @@ import (
 
 // Open opens the dqlite database and loads the schema.
 // Returns true if we need to wait for other nodes to catch up to our version.
-func (db *DqliteDB) Open(ext extensions.Extensions, bootstrap bool, project string) error {
+func (db *DqliteDB) Open(ext extensions.Extensions, bootstrap bool) error {
 	ctx, cancel := context.WithTimeout(db.ctx, 30*time.Second)
 	defer cancel()
 
@@ -71,7 +71,7 @@ func (db *DqliteDB) Open(ext extensions.Extensions, bootstrap bool, project stri
 		db.db = nil
 	})
 
-	err = cluster.PrepareStmts(db.db, project, false)
+	err = cluster.PrepareStmts(db.db, "", false)
 	if err != nil {
 		return err
 	}

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -669,7 +669,7 @@ func NewTestDB(extensionsExternal []schema.Update) (*DqliteDB, error) {
 		return nil, err
 	}
 
-	err = cluster.PrepareStmts(db.db, cluster.GetCallerProject(), false)
+	err = cluster.PrepareStmts(db.db, "", false)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -138,7 +138,7 @@ func (db *DqliteDB) isInitialized() (bool, error) {
 }
 
 // Bootstrap dqlite.
-func (db *DqliteDB) Bootstrap(extensions extensions.Extensions, project string, addr api.URL, clusterRecord cluster.CoreClusterMember) error {
+func (db *DqliteDB) Bootstrap(extensions extensions.Extensions, addr api.URL, clusterRecord cluster.CoreClusterMember) error {
 	var err error
 	db.listenAddr = addr
 	db.dqlite, err = dqlite.New(db.os.DatabaseDir,
@@ -152,7 +152,7 @@ func (db *DqliteDB) Bootstrap(extensions extensions.Extensions, project string, 
 		return fmt.Errorf("Failed to bootstrap dqlite: %w", err)
 	}
 
-	err = db.Open(extensions, true, project)
+	err = db.Open(extensions, true)
 	if err != nil {
 		return err
 	}
@@ -172,7 +172,7 @@ func (db *DqliteDB) Bootstrap(extensions extensions.Extensions, project string, 
 }
 
 // Join a dqlite cluster with the address of a member.
-func (db *DqliteDB) Join(extensions extensions.Extensions, project string, addr api.URL, joinAddresses ...string) error {
+func (db *DqliteDB) Join(extensions extensions.Extensions, addr api.URL, joinAddresses ...string) error {
 	var err error
 	db.listenAddr = addr
 	db.dqlite, err = dqlite.New(db.os.DatabaseDir,
@@ -188,7 +188,7 @@ func (db *DqliteDB) Join(extensions extensions.Extensions, project string, addr 
 	}
 
 	for {
-		err := db.Open(extensions, false, project)
+		err := db.Open(extensions, false)
 		if err == nil {
 			break
 		}
@@ -207,13 +207,13 @@ func (db *DqliteDB) Join(extensions extensions.Extensions, project string, addr 
 }
 
 // StartWithCluster starts up dqlite and joins the cluster.
-func (db *DqliteDB) StartWithCluster(extensions extensions.Extensions, project string, addr api.URL, clusterMembers map[string]types.AddrPort) error {
+func (db *DqliteDB) StartWithCluster(extensions extensions.Extensions, addr api.URL, clusterMembers map[string]types.AddrPort) error {
 	allClusterAddrs := []string{}
 	for _, clusterMemberAddrs := range clusterMembers {
 		allClusterAddrs = append(allClusterAddrs, clusterMemberAddrs.String())
 	}
 
-	return db.Join(extensions, project, addr, allClusterAddrs...)
+	return db.Join(extensions, addr, allClusterAddrs...)
 }
 
 // Leader returns a client connected to the leader of the dqlite cluster.

--- a/internal/endpoints/endpoint.go
+++ b/internal/endpoints/endpoint.go
@@ -5,6 +5,7 @@ type Endpoint interface {
 	Listen() error
 	Serve()
 	Close() error
+	Shutdown() error
 	Type() EndpointType
 }
 

--- a/internal/endpoints/endpoints.go
+++ b/internal/endpoints/endpoints.go
@@ -97,7 +97,7 @@ func (e *Endpoints) up(listeners map[string]Endpoint) error {
 }
 
 // Down closes all of the configured listeners, or any for the type specifically supplied.
-func (e *Endpoints) Down(types ...EndpointType) error {
+func (e *Endpoints) Down(shutdown bool, types ...EndpointType) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -115,6 +115,13 @@ func (e *Endpoints) Down(types ...EndpointType) error {
 				return err
 			}
 
+			if shutdown {
+				err = endpoint.Shutdown()
+				if err != nil {
+					return err
+				}
+			}
+
 			// Delete the stopped endpoint from the slice.
 			delete(e.listeners, name)
 		}
@@ -124,7 +131,7 @@ func (e *Endpoints) Down(types ...EndpointType) error {
 }
 
 // DownByName closes the configured listeners based on its name.
-func (e *Endpoints) DownByName(name string) error {
+func (e *Endpoints) DownByName(shutdown bool, name string) error {
 	e.mu.Lock()
 	defer e.mu.Unlock()
 
@@ -135,6 +142,12 @@ func (e *Endpoints) DownByName(name string) error {
 				return err
 			}
 
+			if shutdown {
+				err = endpoint.Shutdown()
+				if err != nil {
+					return err
+				}
+			}
 			// Delete the stopped endpoint from the slice.
 			delete(e.listeners, name)
 		}

--- a/internal/endpoints/endpoints.go
+++ b/internal/endpoints/endpoints.go
@@ -26,7 +26,8 @@ func (e *Endpoints) Up() error {
 	err := e.up(e.listeners)
 	if err != nil {
 		// Attempt to call Down() in case something actually got brought up.
-		_ = e.Down()
+		// Close the listeners and shutdown the underlying servers.
+		_ = e.Down(true)
 
 		return err
 	}
@@ -59,7 +60,8 @@ func (e *Endpoints) Add(endpoints map[string]Endpoint) error {
 	if err != nil {
 		// Attempt to call DownByName() in case something actually got brought up.
 		for name := range endpoints {
-			_ = e.DownByName(name)
+			// Close the listener and shutdown the underlying server.
+			_ = e.DownByName(true, name)
 		}
 
 		return err

--- a/internal/endpoints/network.go
+++ b/internal/endpoints/network.go
@@ -127,10 +127,7 @@ func (n *Network) Serve() {
 	}()
 }
 
-// Close the listener and server.
-// Will attempt to close the server gracefully, if configured with a drain connections timeout.
-// Note that graceful shutdown will timeout if the connections do not finish (e.g.: a request caused the server
-// to Close the endpoints on the same goroutine).
+// Close the listener.
 func (n *Network) Close() error {
 	if n.listener == nil {
 		return nil
@@ -143,10 +140,12 @@ func (n *Network) Close() error {
 	// It does not shutdown the server, or its currently accepted connections.
 	// We need to shut this down separately, as the listener is not passed to the server
 	// if n.Serve() is not called.
-	err := n.listener.Close()
-	if err != nil {
-		return err
-	}
+	return n.listener.Close()
+}
 
+// Shutdown will attempt to close the server gracefully, if configured with a drain connections timeout.
+// Note that graceful shutdown will timeout if the connections do not finish (e.g.: a request caused the server
+// to Close the endpoints on the same goroutine).
+func (n *Network) Shutdown() error {
 	return shutdownServer(n.server, n.drainConnectionsTimeout)
 }

--- a/internal/endpoints/socket.go
+++ b/internal/endpoints/socket.go
@@ -112,10 +112,7 @@ func (s *Socket) Serve() {
 	}()
 }
 
-// Close the listener and server.
-// Will attempt to close the server gracefully, if configured with a drain connections timeout.
-// Note that graceful shutdown will timeout if the connections do not finish (e.g.: a request caused the server
-// to Close the endpoints on the same goroutine).
+// Close the listener.
 func (s *Socket) Close() error {
 	if s.listener == nil {
 		return nil
@@ -128,11 +125,13 @@ func (s *Socket) Close() error {
 	// It does not shutdown the server, or its currently accepted connections.
 	// We need to shut this down separately, as the listener is not passed to the server
 	// if s.Serve() is not called.
-	err := s.listener.Close()
-	if err != nil {
-		return err
-	}
+	return s.listener.Close()
+}
 
+// Shutdown will attempt to close the server gracefully, if configured with a drain connections timeout.
+// Note that graceful shutdown will timeout if the connections do not finish (e.g.: a request caused the server
+// to Close the endpoints on the same goroutine).
+func (s *Socket) Shutdown() error {
 	return shutdownServer(s.server, s.drainConnectionsTimeout)
 }
 

--- a/internal/rest/client/client.go
+++ b/internal/rest/client/client.go
@@ -283,15 +283,15 @@ func (c *Client) mergeURL(endpointType types.EndpointPrefix, endpoint *api.URL) 
 	localURL.URL.Host = c.url.URL.Host
 	localURL.URL.Scheme = c.url.URL.Scheme
 	localURL.URL.Path = filepath.Join("/", string(endpointType), localURL.URL.Path)
-	localURL.URL.RawPath = filepath.Join("/", string(endpointType), localURL.URL.RawPath)
+	localURL.RawPath = filepath.Join("/", string(endpointType), localURL.RawPath)
 
-	localQuery := localURL.URL.Query()
-	clientQuery := c.url.URL.Query()
+	localQuery := localURL.Query()
+	clientQuery := c.url.Query()
 	for k := range localQuery {
 		clientQuery.Set(k, localQuery.Get(k))
 	}
 
-	localURL.URL.RawQuery = clientQuery.Encode()
+	localURL.RawQuery = clientQuery.Encode()
 	return localURL
 }
 
@@ -354,9 +354,9 @@ func (c *Client) RawWebsocket(ctx context.Context, endpointType types.EndpointPr
 	}
 
 	// Get the transport configuration from the HTTP client.
-	tr, ok := c.Client.Transport.(*http.Transport)
+	tr, ok := c.Transport.(*http.Transport)
 	if !ok {
-		return nil, fmt.Errorf("Invalid underlying client transport, expected %T, got %T", &http.Transport{}, c.Client.Transport)
+		return nil, fmt.Errorf("Invalid underlying client transport, expected %T, got %T", &http.Transport{}, c.Transport)
 	}
 
 	// Setup a new websocket dialer using the already existing HTTP client.
@@ -405,7 +405,7 @@ func (c *Client) UseTarget(name string) *Client {
 	localURL.URL.Host = c.url.URL.Host
 	localURL.URL.Scheme = c.url.URL.Scheme
 	localURL.URL.Path = c.url.URL.Path
-	localURL.URL.RawQuery = c.url.URL.RawQuery
+	localURL.RawQuery = c.url.RawQuery
 	localURL = localURL.WithQuery("target", name)
 
 	return &Client{

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -75,7 +75,7 @@ func (m *MicroCluster) Start(ctx context.Context, daemonArgs DaemonArgs) error {
 
 	// Start up a daemon with a basic control socket.
 	defer logger.Info("Daemon stopped")
-	d := daemon.NewDaemon(cluster.GetCallerProject())
+	d := daemon.NewDaemon()
 
 	chIgnore := make(chan os.Signal, 1)
 	signal.Notify(chIgnore, unix.SIGHUP)

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -299,13 +299,13 @@ func (m *MicroCluster) LocalClient() (*client.Client, error) {
 	}
 
 	if m.args.Proxy != nil {
-		tx, ok := c.Client.Client.Transport.(*http.Transport)
+		tx, ok := c.Transport.(*http.Transport)
 		if !ok {
-			return nil, fmt.Errorf("Invalid underlying client transport, expected %T, got %T", &http.Transport{}, c.Client.Client.Transport)
+			return nil, fmt.Errorf("Invalid underlying client transport, expected %T, got %T", &http.Transport{}, c.Transport)
 		}
 
 		tx.Proxy = m.args.Proxy
-		c.Client.Client.Transport = tx
+		c.Transport = tx
 	}
 
 	return c, nil
@@ -346,13 +346,13 @@ func (m *MicroCluster) RemoteClientWithCert(address string, cert *x509.Certifica
 	}
 
 	if m.args.Proxy != nil {
-		tx, ok := c.Client.Client.Transport.(*http.Transport)
+		tx, ok := c.Transport.(*http.Transport)
 		if !ok {
-			return nil, fmt.Errorf("Invalid underlying client transport, expected %T, got %T", &http.Transport{}, c.Client.Client.Transport)
+			return nil, fmt.Errorf("Invalid underlying client transport, expected %T, got %T", &http.Transport{}, c.Transport)
 		}
 
 		tx.Proxy = m.args.Proxy
-		c.Client.Client.Transport = tx
+		c.Transport = tx
 	}
 
 	return c, nil


### PR DESCRIPTION
This backports all of https://github.com/canonical/microcluster/pull/353 and the non breaking commits of https://github.com/canonical/microcluster/pull/351.

Furthermore it includes the updated linter fixes from https://github.com/canonical/microcluster/pull/364.