### PR TITLE
fix: Tune CheckReady timeout

### DIFF
--- a/internal/rest/client/cluster.go
+++ b/internal/rest/client/cluster.go
@@ -44,7 +44,8 @@ func (c *Client) GetClusterMembers(ctx context.Context) ([]types.ClusterMember, 
 	defer cancel()
 
 	endpoint := api.NewURL().Path("cluster")
-	if deadline, ok := queryCtx.Deadline(); ok {
+	deadline, ok := queryCtx.Deadline()
+	if ok {
 		timeout := int(time.Until(deadline).Seconds())
 		endpoint = endpoint.WithQuery("timeout", strconv.Itoa(timeout))
 	}

--- a/internal/rest/client/cluster.go
+++ b/internal/rest/client/cluster.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"strconv"
 	"time"
 
 	"github.com/canonical/lxd/shared/api"
@@ -42,8 +43,14 @@ func (c *Client) GetClusterMembers(ctx context.Context) ([]types.ClusterMember, 
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
+	endpoint := api.NewURL().Path("cluster")
+	if deadline, ok := queryCtx.Deadline(); ok {
+		timeout := int(time.Until(deadline).Seconds())
+		endpoint = endpoint.WithQuery("timeout", strconv.Itoa(timeout))
+	}
+
 	clusterMembers := []types.ClusterMember{}
-	err := c.QueryStruct(queryCtx, "GET", internalTypes.PublicEndpoint, api.NewURL().Path("cluster"), nil, &clusterMembers)
+	err := c.QueryStruct(queryCtx, "GET", internalTypes.PublicEndpoint, endpoint, nil, &clusterMembers)
 
 	return clusterMembers, err
 }

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -307,33 +307,54 @@ func clusterGet(s state.State, r *http.Request) response.Response {
 			return response.SmartError(err)
 		}
 
+		wg := sync.WaitGroup{}
+		wg.Add(len(apiClusterMembers))
+
 		for i, clusterMember := range apiClusterMembers {
-			addr := api.NewURL().Scheme("https").Host(clusterMember.Address.String())
-			d, err := internalClient.New(*addr, s.ServerCert(), clusterCert, false)
-			if err != nil {
-				return response.SmartError(fmt.Errorf("Failed to create HTTPS client for cluster member with address %q: %w", addr.String(), err))
-			}
+			go func(i int, clusterMember types.ClusterMember) {
+				defer wg.Done()
 
-			var (
-				checkCtx context.Context
-				cancel   context.CancelFunc
-			)
-			if deadline, ok := ctx.Deadline(); ok {
-				until := time.Until(deadline)
-				timeout := (until / time.Duration(len(apiClusterMembers))).Truncate(time.Second)
-				timeout = max(time.Second, timeout)
-				checkCtx, cancel = context.WithTimeout(ctx, timeout)
-			} else {
-				checkCtx, cancel = context.WithCancel(ctx)
-			}
+				addr := api.NewURL().Scheme("https").Host(clusterMember.Address.String())
+				d, err := internalClient.New(*addr, s.ServerCert(), clusterCert, false)
+				if err != nil {
+					logger.Errorf("Failed to create HTTPS client for cluster member with address %q: %v", addr.String(), err)
+					return
+				}
 
-			err = d.CheckReady(checkCtx)
-			if err == nil {
-				apiClusterMembers[i].Status = types.MemberOnline
-			} else {
-				logger.Warnf("Failed to get status of cluster member with address %q: %v", addr.String(), err)
-			}
-			cancel()
+				var (
+					checkCtx context.Context
+					cancel   context.CancelFunc
+				)
+				if deadline, ok := ctx.Deadline(); ok {
+					until := time.Until(deadline)
+					timeout := (until / time.Duration(len(apiClusterMembers))).Truncate(time.Second)
+					timeout = max(time.Second, timeout)
+					checkCtx, cancel = context.WithTimeout(ctx, timeout)
+				} else {
+					checkCtx, cancel = context.WithCancel(ctx)
+				}
+
+				err = d.CheckReady(checkCtx)
+				if err == nil {
+					apiClusterMembers[i].Status = types.MemberOnline
+				} else {
+					logger.Warnf("Failed to get status of cluster member with address %q: %v", addr.String(), err)
+				}
+
+				cancel()
+			}(i, clusterMember)
+		}
+
+		waitCh := make(chan struct{})
+		go func() {
+			wg.Wait()
+			close(waitCh)
+		}()
+
+		select {
+		case <-ctx.Done():
+			return response.SmartError(fmt.Errorf("failed while waiting for cluster members to respond: %w", ctx.Err()))
+		case <-waitCh:
 		}
 	}
 

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -302,12 +302,14 @@ func clusterGet(s state.State, r *http.Request) response.Response {
 				return response.SmartError(fmt.Errorf("Failed to create HTTPS client for cluster member with address %q: %w", addr.String(), err))
 			}
 
-			err = d.CheckReady(r.Context())
+			checkCtx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+			err = d.CheckReady(checkCtx)
 			if err == nil {
 				apiClusterMembers[i].Status = types.MemberOnline
 			} else {
 				logger.Warnf("Failed to get status of cluster member with address %q: %v", addr.String(), err)
 			}
+			cancel()
 		}
 	}
 

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -245,11 +245,13 @@ func clusterGet(s state.State, r *http.Request) response.Response {
 
 	ctx := r.Context()
 	var cancel context.CancelFunc
-	if timeoutStr := r.URL.Query().Get("timeout"); timeoutStr != "" {
+	timeoutStr := r.URL.Query().Get("timeout")
+	if timeoutStr != "" {
 		timeout, err := strconv.Atoi(timeoutStr)
 		if err != nil {
 			return response.SmartError(api.StatusErrorf(http.StatusBadRequest, "Invalid timeout value (should be an integer representing timeout in seconds): %v", err))
 		}
+
 		ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
 		defer cancel()
 	}
@@ -325,7 +327,8 @@ func clusterGet(s state.State, r *http.Request) response.Response {
 					checkCtx context.Context
 					cancel   context.CancelFunc
 				)
-				if deadline, ok := ctx.Deadline(); ok {
+				deadline, ok := ctx.Deadline()
+				if ok {
 					until := time.Until(deadline)
 					timeout := (until / time.Duration(len(apiClusterMembers))).Truncate(time.Second)
 					timeout = max(time.Second, timeout)

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"path/filepath"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -242,13 +243,24 @@ func clusterPost(s state.State, r *http.Request) response.Response {
 func clusterGet(s state.State, r *http.Request) response.Response {
 	status := s.Database().Status()
 
+	ctx := r.Context()
+	var cancel context.CancelFunc
+	if timeoutStr := r.URL.Query().Get("timeout"); timeoutStr != "" {
+		timeout, err := strconv.Atoi(timeoutStr)
+		if err != nil {
+			return response.SmartError(api.StatusErrorf(http.StatusBadRequest, "Invalid timeout value (should be an integer representing timeout in seconds): %v", err))
+		}
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+		defer cancel()
+	}
+
 	// If the database is not in a ready or waiting state, we can't be sure it's available for use.
 	if status != types.DatabaseReady && status != types.DatabaseWaiting {
 		return response.SmartError(api.StatusErrorf(http.StatusServiceUnavailable, "%s", string(status)))
 	}
 
 	var apiClusterMembers []types.ClusterMember
-	err := s.Database().Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
+	err := s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
 		var err error
 		var clusterMembers []cluster.CoreClusterMember
 		var awaitingUpgrade map[string]bool
@@ -302,7 +314,19 @@ func clusterGet(s state.State, r *http.Request) response.Response {
 				return response.SmartError(fmt.Errorf("Failed to create HTTPS client for cluster member with address %q: %w", addr.String(), err))
 			}
 
-			checkCtx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+			var (
+				checkCtx context.Context
+				cancel   context.CancelFunc
+			)
+			if deadline, ok := ctx.Deadline(); ok {
+				until := time.Until(deadline)
+				timeout := (until / time.Duration(len(apiClusterMembers))).Truncate(time.Second)
+				timeout = max(time.Second, timeout)
+				checkCtx, cancel = context.WithTimeout(ctx, timeout)
+			} else {
+				checkCtx, cancel = context.WithCancel(ctx)
+			}
+
 			err = d.CheckReady(checkCtx)
 			if err == nil {
 				apiClusterMembers[i].Status = types.MemberOnline


### PR DESCRIPTION
### Overview

This PR tunes the context passed to `CheckReady`.  Consider this scenario: In a 3 node cluster, if 1 node is temporarily unreachable, various things might fail (AFAIK things that rely on a `GetClusterMembers` call), e.g. a heartbeat.
E.g. [here](https://github.com/canonical/microcluster/blob/v2/internal/rest/resources/heartbeat.go#L187) we're [calling `GetClusterMembers`](https://github.com/canonical/microcluster/blob/v2/internal/state/state.go#L174) with a [30 seconds timeout](https://github.com/canonical/microcluster/blob/v2/internal/rest/client/cluster.go#L42-L46). In that call, we're looping over cluster members and sending each one a `CheckReady` with the [request context](https://github.com/canonical/microcluster/blob/v2/internal/rest/resources/cluster.go#L304). This call will have a [30 seconds timeout](https://github.com/canonical/microcluster/blob/v2/internal/rest/client/ready.go#L14-L18) on its own. In an ideal world we should be smart with the timeout of this context (something like `deadline / cluster_members`), but we don't know the deadline with which our clients are calling us (`r.Context().Deadline()` is server side. Timeout is not shipped from the client to the server). But we can at least put a custom timeout on the context used for this call, which this PR aims to do.  

We can also reduce the timeout which is set [here](https://github.com/canonical/microcluster/blob/v2/internal/rest/client/ready.go#L14-L18) instead. I'm open to any suggestions or alternatives.