### PR TITLE
make: Pin latest commit on LXD's `stable-5.21` branch (v2)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,7 +48,7 @@ update-gomod:
 	go get -t -v -u ./...
 
 	# Static pins
-	go get github.com/canonical/lxd@stable-5.21 # Stay on v2 dqlite and LXD LTS client
+	go get github.com/canonical/lxd@8079534cf291bbc562aeffc26b671a03c322ae10 # Stay on v2 dqlite and specific LXD LTS client from stable-5.21 branch
 	go get github.com/olekukonko/tablewriter@v0.0.5 # Due to breaking API in later versions
 
 	go mod tidy -go=$(GOMIN)


### PR DESCRIPTION
This ensures breaking changes from the LXD LTS branch (non public API) won't affect Microcluster. All downstream importers of Microcluster can also rely on this commit to ensure operations.

It caused a problem recently which was fixed in https://github.com/canonical/microcluster/pull/413.