### PR TITLE
Dqlite: Fix TLS handshake errors

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -498,6 +499,7 @@ func (d *Daemon) initServer(resources ...rest.Resources) *http.Server {
 	return &http.Server{
 		Handler:     mux,
 		ConnContext: request.SaveConnectionInContext,
+		ErrorLog:    log.New(newLogFilter(state.Remotes().Addresses), "", 0),
 	}
 }
 

--- a/internal/daemon/logfilter.go
+++ b/internal/daemon/logfilter.go
@@ -1,0 +1,65 @@
+package daemon
+
+import (
+	"regexp"
+
+	"github.com/canonical/lxd/shared/logger"
+
+	"github.com/canonical/microcluster/v3/rest/types"
+)
+
+// logFilter represents a filter for log messages caused by known addresses.
+type logFilter struct {
+	knownAddresses func() map[string]types.AddrPort
+}
+
+// newLogFilter returns a new instances of the log filter.
+// It expects a slice of known addresses for which log messages will get filtered.
+func newLogFilter(knownAddresses func() map[string]types.AddrPort) *logFilter {
+	return &logFilter{
+		knownAddresses: knownAddresses,
+	}
+}
+
+// unwantedLogRegex represents log texts whose presence will cause log messages to be filtered out.
+var unwantedLogRegex = regexp.MustCompile(`^http: TLS handshake error from (.*):[0-9]+: EOF$`)
+
+// Write filters the given log message p and checks whether or not it contains any
+// of the unwanted log messages.
+// If there is a match, a debug message is logged with the unwanted log message
+// In all other cases the message is logged using the actual logger.
+func (l logFilter) Write(p []byte) (int, error) {
+	strippedLog := l.stripLog(p)
+	if strippedLog == "" {
+		return 0, nil
+	}
+
+	logger.Info(strippedLog)
+	return len(p), nil
+}
+
+// stripLog strips the log message to determine whether or not its unwanted.
+func (l logFilter) stripLog(p []byte) string {
+	// Get the source IP address.
+	match := unwantedLogRegex.FindSubmatch(p)
+	var sourceIP string
+	if match != nil {
+		if match[1] != nil {
+			sourceIP = string(match[1])
+		}
+	}
+
+	logStr := string(p)
+
+	// Discard the log if the source is in our list of known addresses.
+	if sourceIP != "" {
+		for _, knownAddress := range l.knownAddresses() {
+			if knownAddress.Addr().String() == sourceIP {
+				logger.Debug("Filtered out unwanted log text", logger.Ctx{"text": logStr})
+				return ""
+			}
+		}
+	}
+
+	return logStr
+}

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -417,9 +417,7 @@ func dqliteNetworkDial(ctx context.Context, addr string, db *DqliteDB) (net.Conn
 	revert := revert.New()
 	defer revert.Fail()
 
-	deadline, _ := ctx.Deadline()
-	dialer := &net.Dialer{Timeout: time.Until(deadline)}
-	tlsDialer := tls.Dialer{NetDialer: dialer, Config: config}
+	tlsDialer := tls.Dialer{Config: config}
 	conn, err := tlsDialer.DialContext(ctx, "tcp", addr)
 	if err != nil {
 		return nil, fmt.Errorf("Failed connecting to HTTP endpoint %q: %w", addr, err)

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -430,7 +430,7 @@ func dqliteNetworkDial(ctx context.Context, addr string, db *DqliteDB) (net.Conn
 		}
 	})
 	logCtx := logger.AddContext(logger.Ctx{"local": conn.LocalAddr().String(), "remote": conn.RemoteAddr().String()})
-	logCtx.Debug("Dqlite connected outbound")
+	logCtx.Debug("Successfully established outbound dqlite connection")
 
 	// Set outbound timeouts.
 	remoteTCP, err := tcp.ExtractConn(conn)


### PR DESCRIPTION
See https://github.com/canonical/go-dqlite/issues/398 for reference.
Closes https://github.com/canonical/go-dqlite/issues/398.

Microcluster's custom dial function passed into `go-dqlite` might cause TLS handshake errors on the target members in case the context passed into the dial function is cancelled early on. That might be the case when a leader was already found, so all the other parallel connection attempts to the other members are cancelled.
Whilst this is not a functional issue we should have extra handling to prevent seeing those error messages in the Microcluster daemon logs.

Furthermore the passed context's deadline is now used properly. Setting it whilst using the same context the deadline is coming from doesn't bring much value.
In addition a potential leak of the request's response body is fixed.