### PR TITLE
Dqlite: TLS error followup for IPv6

### DIFF
--- a/internal/daemon/logfilter.go
+++ b/internal/daemon/logfilter.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"bytes"
 	"regexp"
+	"strings"
 
 	"github.com/canonical/lxd/shared/logger"
 
@@ -51,7 +52,8 @@ func (l logFilter) stripLog(p []byte) string {
 	var sourceIP string
 	if match != nil {
 		if match[1] != nil {
-			sourceIP = string(match[1])
+			// Trim off potential IPv6 brackets.
+			sourceIP = strings.Trim(string(match[1]), "[]")
 		}
 	}
 

--- a/internal/daemon/logfilter.go
+++ b/internal/daemon/logfilter.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"bytes"
 	"regexp"
 
 	"github.com/canonical/lxd/shared/logger"
@@ -40,6 +41,11 @@ func (l logFilter) Write(p []byte) (int, error) {
 
 // stripLog strips the log message to determine whether or not its unwanted.
 func (l logFilter) stripLog(p []byte) string {
+	// Strip the newline from the end if it exists.
+	p = bytes.TrimRightFunc(p, func(r rune) bool {
+		return r == '\n'
+	})
+
 	// Get the source IP address.
 	match := unwantedLogRegex.FindSubmatch(p)
 	var sourceIP string


### PR DESCRIPTION
Follow up on https://github.com/canonical/microcluster/pull/470 to also account for IPv6 addresses. 

I initially thought this is working for IPv4 and IPv6 but more tests have shown that in case of IPv6 we need to handle a newline and the additional brackets.