### PR TITLE
make node join more fault tolerant

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -677,16 +677,17 @@ func (d *Daemon) StartAPI(ctx context.Context, bootstrap bool, initConfig map[st
 			}
 
 			// At this point the joiner is only trusted on the node that was leader at the time,
-			// so find it and have it instruct all dqlite members to trust this system now that it is functional.
-			if !clusterConfirmation {
-				err := internalClient.AddTrustStoreEntry(ctx, &c.Client, localMemberInfo)
-				if err != nil {
-					lastErr = err
-				} else {
-					clusterConfirmation = true
-				}
+			// so propagate trust to all reachable cluster members for fault tolerance.
+			err := internalClient.AddTrustStoreEntry(ctx, &c.Client, localMemberInfo)
+			if err != nil {
+				lastErr = err
+				// Continue trying other nodes even if this one fails
+				return nil
+			} else {
+				clusterConfirmation = true
 			}
 
+			// Continue to propagate trust to all nodes, don't stop after first success
 			return nil
 		})
 		if err != nil {

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -165,35 +165,28 @@ func (s *InternalState) HasExtension(ext string) bool {
 // this one.
 // All requests made by the client will have the UserAgentNotifier header set
 // if isNotification is true.
+// Uses the trust store instead of database for better fault tolerance -
+// trust store is updated on heartbeats and shouldn't contain crashed nodes.
 func (s *InternalState) Cluster(isNotification bool) (client.Cluster, error) {
-	c, err := s.Leader()
+	publicKey, err := s.ClusterCert().PublicKeyX509()
 	if err != nil {
 		return nil, err
 	}
 
-	clusterMembers, err := c.GetClusterMembers(s.Context)
+	// Use trust store instead of database - it's updated on heartbeats
+	// and is more likely to reflect current reachable cluster state
+	remotes := s.Remotes()
+	allClients, err := remotes.Cluster(isNotification, s.ServerCert(), publicKey)
 	if err != nil {
 		return nil, err
 	}
 
-	clients := make(client.Cluster, 0, len(clusterMembers)-1)
-	for _, clusterMember := range clusterMembers {
-		if s.Address().URL.Host == clusterMember.Address.String() {
-			continue
+	// Filter out ourselves from the client list
+	clients := make(client.Cluster, 0, len(allClients))
+	for _, client := range allClients {
+		if s.Address().URL.Host != client.URL().URL.Host {
+			clients = append(clients, client)
 		}
-
-		publicKey, err := s.ClusterCert().PublicKeyX509()
-		if err != nil {
-			return nil, err
-		}
-
-		url := api.NewURL().Scheme("https").Host(clusterMember.Address.String())
-		c, err := internalClient.New(*url, s.ServerCert(), publicKey, isNotification)
-		if err != nil {
-			return nil, err
-		}
-
-		clients = append(clients, client.Client{Client: *c})
 	}
 
 	return clients, nil

--- a/internal/trust/remotes.go
+++ b/internal/trust/remotes.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -225,6 +227,12 @@ func (r *Remotes) Addresses() map[string]types.AddrPort {
 func (r *Remotes) Cluster(isNotification bool, serverCert *shared.CertInfo, publicKey *x509.Certificate) (client.Cluster, error) {
 	cluster := make(client.Cluster, 0, r.Count()-1)
 	for _, addr := range r.Addresses() {
+		// Filter out unreachable nodes with a quick connectivity check
+		if !isReachable(addr) {
+			logger.Debug("Skipping unreachable node", logger.Ctx{"address": addr.String()})
+			continue
+		}
+
 		url := api.NewURL().Scheme("https").Host(addr.String())
 		c, err := internalClient.New(*url, serverCert, publicKey, isNotification)
 		if err != nil {
@@ -310,6 +318,18 @@ func (r *Remotes) RemotesByName() map[string]Remote {
 	}
 
 	return remoteData
+}
+
+// isReachable performs a quick TCP connectivity check to determine if a node is reachable.
+func isReachable(addr types.AddrPort) bool {
+	// Use a short timeout for the connectivity check
+	conn, err := net.DialTimeout("tcp", addr.String(), 2*time.Second)
+	if err != nil {
+		return false
+	}
+
+	conn.Close()
+	return true
 }
 
 // URL returns the parsed URL of the Remote.


### PR DESCRIPTION
## Improve fault tolerance on Microcluster membership operation

While testing node joins in Canonical Kubernetes we stumbled across this error message on node join:

```
sudo k8s join-cluster <token>

Joining the cluster. This may take a few seconds, please wait.
Error: Failed to join the cluster using the provided token.

The error was: failed after potential retry: wait check failed: failed to POST /k8sd/cluster/join: failed to join k8sd cluster as control plane: Failed to confirm new member "blue" on any existing system (3): Post "https://192.168.105.48:6400/core/internal/truststore": Unable to connect to "192.168.105.48:6400": dial tcp 192.168.105.48:6400: connect: no route to host
```

The node joining (192.168.105.52) is the fourth node in a three node cluster where one of the nodes (192.168.105.48) was killed but not removed from the cluster for testing purposes.

A node join should not fail when one of the nodes in the cluster crashes, we should fail over and contact the other nodes in the cluster.

As a consequence our cluster ends up in an inconsistent state:

core_cluster_members: holds original three nodes including the crashed one.
dqlite: has 4 members including our new one as spare.

```
sudo /snap/k8s/current/bin/k8sd sql   --state-dir /var/snap/k8s/common/var/lib/k8sd/state   "SELECT name, role FROM core_cluster_members"
[[green spare] [yellow voter] [red voter]] 

which is 192.168.105.48, 192.168.105.50, 192.168.105.51

sudo cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml
- ID: 3297041220608546238
  Address: 192.168.105.48:6400
  Role: 0
- ID: 2600311347157639893
  Address: 192.168.105.50:6400
  Role: 0
- ID: 17391627959315830676
  Address: 192.168.105.51:6400
  Role: 0
- ID: 4234120578868796636
  Address: 192.168.105.52:6400
  Role: 2
```

## The bug

When we add the node to the truststore in daemon.go we call cluster.Query. This under the hood retrieves the cluster members from core_cluster members which only gets updated on member add/removals but is unaware of a node being in a crashed state. The logic then proceeds to do the call with this list of members. We use the first one in the list (failed node) and make the call to add the node to the truststore, this fails because the node is dead. Instead of trying the other nodes from the list we fail the call which fails the join in a partial state.

I propose to implement the following fix:

1. Use the trust store when getting cluster members, the trust store members get updated on every heartbeat detecting crashed nodes.

2. Make trust propagation fault tolerant -> when we fail to reach one node continue and try the next.

3. Filter out unreachable nodes when building the client list.

