### PR TITLE
V2.2.1 fault tolerance

### DIFF
--- a/example/test/main.sh
+++ b/example/test/main.sh
@@ -357,9 +357,30 @@ test_join_token_before_cluster_formed() {
     return 1
   }
   
+  # Verify dqlite cluster.yaml shows only 3 members (low-level dqlite validation)
+  dqlite_cluster_count=$(yq '. | length' "${test_dir}/c2/database/cluster.yaml")
+  [[ "${dqlite_cluster_count}" -eq 3 ]] || {
+    echo "ERROR: Expected exactly 3 members in dqlite cluster.yaml, got ${dqlite_cluster_count}"
+    echo "Dqlite cluster.yaml contents:"
+    cat "${test_dir}/c2/database/cluster.yaml"
+    return 1
+  }
+  
+  # Verify c4 (127.0.0.1:9004) is NOT in dqlite cluster.yaml
+  c4_in_dqlite_yaml=$(yq '.[] | select(.Address == "127.0.0.1:9004")' "${test_dir}/c2/database/cluster.yaml" | wc -l)
+  [[ "${c4_in_dqlite_yaml}" -eq 0 ]] || {
+    echo "ERROR: c4 found in dqlite cluster.yaml (partial join detected at dqlite level)"
+    echo "Dqlite cluster.yaml contents:"
+    cat "${test_dir}/c2/database/cluster.yaml"
+    return 1
+  }
+  
   echo "SUCCESS: Node c4 failed to join cleanly - no partial join state detected"
+  echo "SUCCESS: Verified at both microcluster API and go-dqlite cluster members"
   echo "Final cluster state (c4 should not appear):"
   microctl --state-dir "${test_dir}/c2" cluster list
+  echo "Dqlite cluster members:"
+  cat "${test_dir}/c2/database/cluster.yaml"
   
   shutdown_systems
 }

--- a/example/test/main.sh
+++ b/example/test/main.sh
@@ -176,17 +176,211 @@ test_recover() {
   shutdown_systems
 }
 
+test_join_token_after_cluster_formed() {
+  # Test node join succeeds when original control plane is down
+  # Token generated AFTER the 3-node cluster is formed
+  # Based on k8s-snap test: test_node_join_succeeds_when_original_control_plane_is_down
+  
+  echo "Starting join test - token generated after 3-node cluster formed"
+  
+  new_systems 4 --heartbeat 2s
+  
+  # Bootstrap initial cluster with c1 as original control plane
+  microctl --state-dir "${test_dir}/c1" init "c1" 127.0.0.1:9001 --bootstrap
+  
+  # Get join tokens for c2 and c3 while c1 is available
+  token_c2=$(microctl --state-dir "${test_dir}/c1" tokens add "c2")
+  token_c3=$(microctl --state-dir "${test_dir}/c1" tokens add "c3")
+  
+  # Join c2 and c3 to form 3-node cluster
+  microctl --state-dir "${test_dir}/c2" init "c2" 127.0.0.1:9002 --token "${token_c2}"
+  microctl --state-dir "${test_dir}/c3" init "c3" 127.0.0.1:9003 --token "${token_c3}"
+  
+  # Wait for cluster to stabilize
+  while [[ -n "$(microctl --state-dir "${test_dir}/c1" cluster list -f yaml | yq '.[] | select(.role == "PENDING")')" ]]; do
+    sleep 2
+  done
+  
+  echo "Initial 3-node cluster formed:"
+  microctl --state-dir "${test_dir}/c1" cluster list
+  
+  # Verify all nodes are voters in the 3-node cluster
+  [[ $(microctl --state-dir "${test_dir}/c1" cluster list -f yaml | yq '.[] | select(.clustermemberlocal.name == "c1").role') == "voter" ]]
+  [[ $(microctl --state-dir "${test_dir}/c1" cluster list -f yaml | yq '.[] | select(.clustermemberlocal.name == "c2").role') == "voter" ]]
+  [[ $(microctl --state-dir "${test_dir}/c1" cluster list -f yaml | yq '.[] | select(.clustermemberlocal.name == "c3").role') == "voter" ]]
+  
+  # Get join token for c4 while c1 is still available
+  token_c4=$(microctl --state-dir "${test_dir}/c1" tokens add "c4")
+  
+  echo "Simulating original control plane (c1) failure..."
+  
+  # Kill c1 to simulate original control plane failure
+  c1_pid=$(jobs -p | head -1)  # Get first background job (should be c1)
+  kill -9 "${c1_pid}" 2>/dev/null || true
+  
+  sleep 2
+  
+  echo "Attempting to join c4 while c1 is down (this tests fault tolerance)..."
+  
+  # This is the critical test: can c4 join while c1 is down?
+  # This should work with proper fault tolerance implementation
+  microctl --state-dir "${test_dir}/c4" init "c4" 127.0.0.1:9004 --token "${token_c4}"
+  
+  echo "Verifying cluster state from surviving nodes..."
+  
+  # Verify cluster from c2's perspective (c1 should be unreachable, c2/c3/c4 should be online)
+  microctl --state-dir "${test_dir}/c2" cluster list
+  
+  # Wait for roles to stabilize after c1 failure and c4 join
+  sleep 5
+  
+  # Count online nodes from c2's perspective
+  online_count=$(microctl --state-dir "${test_dir}/c2" cluster list -f yaml | yq '[.[] | select(.status == "ONLINE")] | length')
+  echo "Online nodes count: ${online_count}"
+  
+  # Should have 3 online nodes (c2, c3, c4) even though c1 is down
+  [[ "${online_count}" -eq 3 ]] || {
+    echo "ERROR: Expected 3 online nodes, got ${online_count}"
+    microctl --state-dir "${test_dir}/c2" cluster list
+    return 1
+  }
+  
+  # Verify c4 successfully joined
+  c4_status=$(microctl --state-dir "${test_dir}/c2" cluster list -f yaml | yq '.[] | select(.clustermemberlocal.name == "c4").status')
+  [[ "${c4_status}" == "ONLINE" ]] || {
+    echo "ERROR: c4 should be ONLINE, got ${c4_status}"
+    return 1
+  }
+  
+  # Verify c4 is a voter, not just PENDING
+  c4_role=$(microctl --state-dir "${test_dir}/c2" cluster list -f yaml | yq '.[] | select(.clustermemberlocal.name == "c4").role')
+  [[ "${c4_role}" == "voter" ]] || {
+    echo "ERROR: c4 should be voter, got ${c4_role}"
+    microctl --state-dir "${test_dir}/c2" cluster list
+    return 1
+  }
+  
+  echo "SUCCESS: Node c4 successfully joined cluster while original control plane c1 was down"
+  echo "SUCCESS: Node c4 is ONLINE and has voter role"
+  echo "Final cluster state:"
+  microctl --state-dir "${test_dir}/c2" cluster list
+  
+  shutdown_systems
+}
+
+test_join_token_before_cluster_formed() {
+  # Test node join succeeds when original control plane is down
+  # Token generated BEFORE other nodes join (while c1 is solo)
+  # Based on k8s-snap test: test_node_join_succeeds_when_original_control_plane_is_down
+  
+  echo "Starting join test - token generated before cluster formed"
+  
+  new_systems 4 --heartbeat 2s
+  
+  # Bootstrap initial cluster with c1 as original control plane
+  microctl --state-dir "${test_dir}/c1" init "c1" 127.0.0.1:9001 --bootstrap
+  
+  # Get join tokens for c2 and c3 while c1 is available
+  token_c2=$(microctl --state-dir "${test_dir}/c1" tokens add "c2")
+  token_c3=$(microctl --state-dir "${test_dir}/c1" tokens add "c3")
+  # Get join token for c4 while c1 is the only node up
+  token_c4=$(microctl --state-dir "${test_dir}/c1" tokens add "c4")
+  
+  # Join c2 and c3 to form 3-node cluster
+  microctl --state-dir "${test_dir}/c2" init "c2" 127.0.0.1:9002 --token "${token_c2}"
+  microctl --state-dir "${test_dir}/c3" init "c3" 127.0.0.1:9003 --token "${token_c3}"
+  
+  # Wait for cluster to stabilize
+  while [[ -n "$(microctl --state-dir "${test_dir}/c1" cluster list -f yaml | yq '.[] | select(.role == "PENDING")')" ]]; do
+    sleep 2
+  done
+  
+  echo "Initial 3-node cluster formed:"
+  microctl --state-dir "${test_dir}/c1" cluster list
+  
+  # Verify all nodes are voters in the 3-node cluster
+  [[ $(microctl --state-dir "${test_dir}/c1" cluster list -f yaml | yq '.[] | select(.clustermemberlocal.name == "c1").role') == "voter" ]]
+  [[ $(microctl --state-dir "${test_dir}/c1" cluster list -f yaml | yq '.[] | select(.clustermemberlocal.name == "c2").role') == "voter" ]]
+  [[ $(microctl --state-dir "${test_dir}/c1" cluster list -f yaml | yq '.[] | select(.clustermemberlocal.name == "c3").role') == "voter" ]]
+  
+  echo "Simulating original control plane (c1) failure..."
+  
+  # Kill c1 to simulate original control plane failure
+  c1_pid=$(jobs -p | head -1)  # Get first background job (should be c1)
+  kill -9 "${c1_pid}" 2>/dev/null || true
+  
+  sleep 2
+  
+  echo "Attempting to join c4 while c1 is down (this should fail cleanly)..."
+  
+  # This is the critical test: c4 should FAIL to join when c1 is down
+  # and the token was generated before cluster formation
+  # The join should fail cleanly without creating partial state
+  ! microctl --state-dir "${test_dir}/c4" init "c4" 127.0.0.1:9004 --token "${token_c4}" || {
+    echo "ERROR: c4 join should have failed but succeeded"
+    return 1
+  }
+  
+  echo "c4 join failed as expected. Verifying clean failure..."
+  
+  # Verify cluster from c2's perspective (should only show c1 as unreachable, c2/c3 as online)
+  microctl --state-dir "${test_dir}/c2" cluster list
+  
+  # Wait a bit to see if c4 appears in cluster or fails cleanly
+  sleep 5
+  
+  # Count online nodes from c2's perspective - should only be c2 and c3
+  online_count=$(microctl --state-dir "${test_dir}/c2" cluster list -f yaml | yq '[.[] | select(.status == "ONLINE")] | length')
+  echo "Online nodes count: ${online_count}"
+  
+  # Should have only 2 online nodes (c2, c3) since c1 is down and c4 should fail to join
+  [[ "${online_count}" -eq 2 ]] || {
+    echo "ERROR: Expected 2 online nodes (c2, c3), got ${online_count}"
+    microctl --state-dir "${test_dir}/c2" cluster list
+    return 1
+  }
+  
+  # Verify c4 is NOT in the cluster members table (clean failure)
+  c4_exists=$(microctl --state-dir "${test_dir}/c2" cluster list -f yaml | yq '.[] | select(.clustermemberlocal.name == "c4")' | wc -l)
+  [[ "${c4_exists}" -eq 0 ]] || {
+    echo "ERROR: c4 should not appear in cluster members table (partial join detected)"
+    echo "c4 state in cluster:"
+    microctl --state-dir "${test_dir}/c2" cluster list -f yaml | yq '.[] | select(.clustermemberlocal.name == "c4")'
+    return 1
+  }
+  
+  # Verify that only c1, c2, c3 exist in cluster (no c4)
+  member_count=$(microctl --state-dir "${test_dir}/c2" cluster list -f yaml | yq '. | length')
+  [[ "${member_count}" -eq 3 ]] || {
+    echo "ERROR: Expected exactly 3 cluster members (c1, c2, c3), got ${member_count}"
+    microctl --state-dir "${test_dir}/c2" cluster list
+    return 1
+  }
+  
+  echo "SUCCESS: Node c4 failed to join cleanly - no partial join state detected"
+  echo "Final cluster state (c4 should not appear):"
+  microctl --state-dir "${test_dir}/c2" cluster list
+  
+  shutdown_systems
+}
+
 # allow for running a specific set of tests
 if [ "${1:-"all"}" = "all" ] || [ "${1}" = "" ]; then
   test_misc
   test_tokens
   test_recover
+  test_join_token_after_cluster_formed
+  test_join_token_before_cluster_formed
 elif [ "${1}" = "recover" ]; then
   test_recover
 elif [ "${1}" = "tokens" ]; then
   test_tokens
 elif [ "${1}" = "misc" ]; then
   test_misc
+elif [ "${1}" = "join-after" ]; then
+  test_join_token_after_cluster_formed
+elif [ "${1}" = "join-before" ]; then
+  test_join_token_before_cluster_formed
 else
   echo "Unknown test ${1}"
 fi

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -677,16 +677,17 @@ func (d *Daemon) StartAPI(ctx context.Context, bootstrap bool, initConfig map[st
 			}
 
 			// At this point the joiner is only trusted on the node that was leader at the time,
-			// so find it and have it instruct all dqlite members to trust this system now that it is functional.
-			if !clusterConfirmation {
-				err := internalClient.AddTrustStoreEntry(ctx, &c.Client, localMemberInfo)
-				if err != nil {
-					lastErr = err
-				} else {
-					clusterConfirmation = true
-				}
+			// so propagate trust to all reachable cluster members for fault tolerance.
+			err := internalClient.AddTrustStoreEntry(ctx, &c.Client, localMemberInfo)
+			if err != nil {
+				lastErr = err
+				// Continue trying other nodes even if this one fails
+				return nil
+			} else {
+				clusterConfirmation = true
 			}
 
+			// Continue to propagate trust to all nodes, don't stop after first success
 			return nil
 		})
 		if err != nil {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -683,9 +683,8 @@ func (d *Daemon) StartAPI(ctx context.Context, bootstrap bool, initConfig map[st
 				lastErr = err
 				// Continue trying other nodes even if this one fails
 				return nil
-			} else {
-				clusterConfirmation = true
 			}
+			clusterConfirmation = true
 
 			// Continue to propagate trust to all nodes, don't stop after first success
 			return nil

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -27,7 +27,9 @@ import (
 // Open opens the dqlite database and loads the schema.
 // Returns true if we need to wait for other nodes to catch up to our version.
 func (db *DqliteDB) Open(ext extensions.Extensions, bootstrap bool) error {
-	ctx, cancel := context.WithTimeout(db.ctx, 30*time.Second)
+	// Allow dqlite up to 2 minutes to become ready when starting up.
+	// This is to allow for unready/dead nodes to time out.
+	ctx, cancel := context.WithTimeout(db.ctx, 120*time.Second)
 	defer cancel()
 
 	db.statusLock.Lock()
@@ -41,6 +43,13 @@ func (db *DqliteDB) Open(ext extensions.Extensions, bootstrap bool) error {
 		db.statusLock.Lock()
 		db.status = types.DatabaseOffline
 		db.statusLock.Unlock()
+		// close the db if any of the following steps fail
+		closeErr := db.dqlite.Close()
+		if closeErr != nil {
+			logger.Error("Failed to close database", logger.Ctx{"address": db.listenAddr.String(), "error": closeErr})
+		}
+
+		db.db = nil
 	})
 
 	err := db.dqlite.Ready(ctx)
@@ -59,16 +68,6 @@ func (db *DqliteDB) Open(ext extensions.Extensions, bootstrap bool) error {
 	if err != nil {
 		return err
 	}
-
-	// If we receive an error after this point, close the database.
-	reverter.Add(func() {
-		closeErr := db.db.Close()
-		if closeErr != nil {
-			logger.Error("Failed to close database", logger.Ctx{"address": db.listenAddr.String(), "error": closeErr})
-		}
-
-		db.db = nil
-	})
 
 	err = cluster.PrepareStmts(db.db, "", false)
 	if err != nil {

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
 	"slices"
+	"time"
 
 	"github.com/canonical/lxd/lxd/response"
 	"github.com/canonical/lxd/lxd/util"
@@ -288,7 +290,10 @@ func setupLocalMember(state state.State, localClusterMember *trust.Remote, joinI
 			Certificate: clusterMember.Certificate,
 		}
 
-		joinAddrs = append(joinAddrs, clusterMember.Address)
+		// Only add reachable addresses to the join list
+		if isReachable(clusterMember.Address) {
+			joinAddrs = append(joinAddrs, clusterMember.Address)
+		}
 		clusterMembers = append(clusterMembers, remote)
 	}
 
@@ -299,4 +304,16 @@ func setupLocalMember(state state.State, localClusterMember *trust.Remote, joinI
 	}
 
 	return joinAddrs.Strings(), nil
+}
+
+// isReachable performs a quick TCP connectivity check to determine if a node is reachable.
+func isReachable(addr types.AddrPort) bool {
+	// Use a short timeout for the connectivity check
+	conn, err := net.DialTimeout("tcp", addr.String(), 2*time.Second)
+	if err != nil {
+		return false
+	}
+
+	conn.Close()
+	return true
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -165,35 +165,28 @@ func (s *InternalState) HasExtension(ext string) bool {
 // this one.
 // All requests made by the client will have the UserAgentNotifier header set
 // if isNotification is true.
+// Uses the trust store instead of database for better fault tolerance -
+// trust store is updated on heartbeats and shouldn't contain crashed nodes.
 func (s *InternalState) Cluster(isNotification bool) (client.Cluster, error) {
-	c, err := s.Leader()
+	publicKey, err := s.ClusterCert().PublicKeyX509()
 	if err != nil {
 		return nil, err
 	}
 
-	clusterMembers, err := c.GetClusterMembers(s.Context)
+	// Use trust store instead of database - it's updated on heartbeats
+	// and is more likely to reflect current reachable cluster state
+	remotes := s.Remotes()
+	allClients, err := remotes.Cluster(isNotification, s.ServerCert(), publicKey)
 	if err != nil {
 		return nil, err
 	}
 
-	clients := make(client.Cluster, 0, len(clusterMembers)-1)
-	for _, clusterMember := range clusterMembers {
-		if s.Address().URL.Host == clusterMember.Address.String() {
-			continue
+	// Filter out ourselves from the client list
+	clients := make(client.Cluster, 0, len(allClients))
+	for _, client := range allClients {
+		if s.Address().URL.Host != client.URL().URL.Host {
+			clients = append(clients, client)
 		}
-
-		publicKey, err := s.ClusterCert().PublicKeyX509()
-		if err != nil {
-			return nil, err
-		}
-
-		url := api.NewURL().Scheme("https").Host(clusterMember.Address.String())
-		c, err := internalClient.New(*url, s.ServerCert(), publicKey, isNotification)
-		if err != nil {
-			return nil, err
-		}
-
-		clients = append(clients, client.Client{Client: *c})
 	}
 
 	return clients, nil

--- a/internal/trust/remotes.go
+++ b/internal/trust/remotes.go
@@ -5,10 +5,12 @@ import (
 	"errors"
 	"fmt"
 	"math/rand"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -225,6 +227,12 @@ func (r *Remotes) Addresses() map[string]types.AddrPort {
 func (r *Remotes) Cluster(isNotification bool, serverCert *shared.CertInfo, publicKey *x509.Certificate) (client.Cluster, error) {
 	cluster := make(client.Cluster, 0, r.Count()-1)
 	for _, addr := range r.Addresses() {
+		// Filter out unreachable nodes with a quick connectivity check
+		if !isReachable(addr) {
+			logger.Debug("Skipping unreachable node", logger.Ctx{"address": addr.String()})
+			continue
+		}
+
 		url := api.NewURL().Scheme("https").Host(addr.String())
 		c, err := internalClient.New(*url, serverCert, publicKey, isNotification)
 		if err != nil {
@@ -310,6 +318,18 @@ func (r *Remotes) RemotesByName() map[string]Remote {
 	}
 
 	return remoteData
+}
+
+// isReachable performs a quick TCP connectivity check to determine if a node is reachable.
+func isReachable(addr types.AddrPort) bool {
+	// Use a short timeout for the connectivity check
+	conn, err := net.DialTimeout("tcp", addr.String(), 2*time.Second)
+	if err != nil {
+		return false
+	}
+
+	conn.Close()
+	return true
 }
 
 // URL returns the parsed URL of the Remote.


### PR DESCRIPTION
## Improve fault tolerance on Microcluster membership operation

While testing node joins in Canonical Kubernetes we stumbled across this error message on node join:

```
sudo k8s join-cluster <token>

Joining the cluster. This may take a few seconds, please wait.
Error: Failed to join the cluster using the provided token.

The error was: failed after potential retry: wait check failed: failed to POST /k8sd/cluster/join: failed to join k8sd cluster as control plane: Failed to confirm new member "blue" on any existing system (3): Post "https://192.168.105.48:6400/core/internal/truststore": Unable to connect to "192.168.105.48:6400": dial tcp 192.168.105.48:6400: connect: no route to host
```

The node joining (192.168.105.52) is the fourth node in a three node cluster where one of the nodes (192.168.105.48) was killed but not removed from the cluster for testing purposes.

A node join should not fail when one of the nodes in the cluster crashes, we should fail over and contact the other nodes in the cluster.

As a consequence our cluster ends up in an inconsistent state:

core_cluster_members: holds original three nodes including the crashed one.
dqlite: has 4 members including our new one as spare.

```
sudo /snap/k8s/current/bin/k8sd sql   --state-dir /var/snap/k8s/common/var/lib/k8sd/state   "SELECT name, role FROM core_cluster_members"
[[green spare] [yellow voter] [red voter]] 

which is 192.168.105.48, 192.168.105.50, 192.168.105.51

sudo cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml
- ID: 3297041220608546238
  Address: 192.168.105.48:6400
  Role: 0
- ID: 2600311347157639893
  Address: 192.168.105.50:6400
  Role: 0
- ID: 17391627959315830676
  Address: 192.168.105.51:6400
  Role: 0
- ID: 4234120578868796636
  Address: 192.168.105.52:6400
  Role: 2
```

## First failure

When we add the node to the truststore in daemon.go we call cluster.Query. This under the hood retrieves the cluster members from core_cluster members which only gets updated on member add/removals but is unaware of a node being in a crashed state. The logic then proceeds to do the call with this list of members. We use the first one in the list (failed node) and make the call to add the node to the truststore, this fails because the node is dead. Instead of trying the other nodes from the list we fail the call which fails the join in a partial state.

I propose to implement the following fix:

1. Use the trust store when getting cluster members, the trust store members get updated on every heartbeat detecting crashed nodes.

2. Make trust propagation fault tolerant -> when we fail to reach one node continue and try the next.

3. Filter out unreachable nodes when building the client list.

snap: 4297 channel: latest/edge/louise-microcluster

## Second failure

After fixing the above I notice the same problem on the joincluster call:

```
ubuntu@blue:~$ sudo k8s join-cluster <toke>
Joining the cluster. This may take a few seconds, please wait.
Error: Failed to join the cluster using the provided token.

The error was: failed after potential retry: wait check failed: failed to POST /k8sd/cluster/join: failed to join k8sd cluster as control plane: 1 join attempts were unsuccessful. Last error: Get "https://192.168.105.48:6400": Unable to connect to: 192.168.105.48:6400 ([dial tcp 192.168.105.48:6400: i/o timeout])
```

To resolve this I filter the join addresses based on whether they are reachable or not in control.go.

## Manual test case (k8s-snap custom build)

Using a join token that only has the dead node as a join address:
```
ubuntu@blue:~$ sudo snap install k8s --channel=latest/edge/louise-mc  --classic
k8s (edge/louise-mc) v1.34.1 from Canonical✓ installed
ubuntu@blue:~$ sudo k8s join-cluster eyJzZWNyZXQiOiIwYmIzMjcxNzE1ZDJiMGViOGUzNzA5YTZkODhmNTNiY2I2OWMxZGMxMzI5YTA2NDhjMzg5ZDk1NWE0YjMyNjM0IiwiZmluZ2VycHJpbnQiOiI0YzIyMTBlNGFmZGQ0ZDlhZDA3YjBmMTM5Njk2YzYxZmVlNmQ1NjkyYjZjOGMzNWFjMGFkNDNlNjU3MjEyZjU0Iiwiam9pbl9hZGRyZXNzZXMiOlsiMTkyLjE2OC4xMDUuNTc6NjQwMCJdfQ==
Joining the cluster. This may take a few seconds, please wait.
Error: Failed to join the cluster using the provided token.

The error was: failed after potential retry: wait check failed: failed to POST /k8sd/cluster/join: failed to join k8sd cluster as control plane: 1 join attempts were unsuccessful. Last error: Get "https://192.168.105.57:6400": Unable to connect to: 192.168.105.57:6400 ([dial tcp 192.168.105.57:6400: connect: no route to host])
```

Clean failure:
```
ubuntu@yellow:~$ sudo etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt --cert /etc/kubernetes/pki/etcd/server.crt --key /etc/kubernetes/pki/etcd/server.key --endpoints https://192.168.105.60:2379 member list
64f152801cac56a7, started, green, https://192.168.105.57:2380, https://192.168.105.57:2379, false
c93518ab3fc84d28, started, red, https://192.168.105.59:2380, https://192.168.105.59:2379, false
f90893b74e7723eb, started, yellow, https://192.168.105.60:2380, https://192.168.105.60:2379, false
ubuntu@yellow:~$ sudo cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml
- ID: 3297041220608546238
  Address: 192.168.105.57:6400
  Role: 0
- ID: 5296972827529738307
  Address: 192.168.105.59:6400
  Role: 0
- ID: 8304496435411849788
  Address: 192.168.105.60:6400
  Role: 0
ubuntu@yellow:~$ sudo /snap/k8s/current/bin/k8sd sql   --state-dir /var/snap/k8s/common/var/lib/k8sd/state   "SELECT name, role FROM core_cluster_members"
[[green voter] [red voter] [yellow voter]]
```

But retrying with a new token that also contains the join token renders a context deadline exceeded:
```
ubuntu@blue:~$ sudo k8s join-cluster eyJzZWNyZXQiOiI1MjE4OTk2NzBmMzZhNGMxMmExNzE1N2I1NmY5M2ZlYzMyNDU5N2ZlOGRmNDBlNWU4ZTNjNzA5OGQ3MzA4MTYzIiwiZmluZ2VycHJpbnQiOiJiODU4ZGU1ZTY0OTg1Y2IwMzJmNDVjOTRkNDY3NGM2NTgyZjFiNmQyNWQ2OWQ3ZmZlYTczNjljZTdkY2YxYWU1Iiwiam9pbl9hZGRyZXNzZXMiOlsiMTkyLjE2OC4xMDUuNTc6NjQwMCIsIjE5Mi4xNjguMTA1LjU5OjY0MDAiLCIxOTIuMTY4LjEwNS42MDo2NDAwIl19
Joining the cluster. This may take a few seconds, please wait.
Error: Failed to join the cluster using the provided token.
```
The error was: failed after potential retry: wait check failed: failed to POST /k8sd/cluster/join: failed to join k8sd cluster as control plane: Failed to join cluster: Ready dqlite: context deadline exceeded
```
ubuntu@yellow:~$ sudo /snap/k8s/current/bin/k8sd sql   --state-dir /var/snap/k8s/common/var/lib/k8sd/state   "SELECT name, role FROM core_cluster_members"
[[green spare] [red voter] [yellow voter]]
ubuntu@yellow:~$ sudo etcdctl --cacert /etc/kubernetes/pki/etcd/ca.crt --cert /etc/kubernetes/pki/etcd/server.crt --key /etc/kubernetes/pki/etcd/server.key --endpoints https://192.168.105.60:2379 member list
64f152801cac56a7, started, green, https://192.168.105.57:2380, https://192.168.105.57:2379, false
a1a98182af3a2db9, started, yellow, https://192.168.105.60:2380, https://192.168.105.60:2379, false
c41b506d7a4eda42, started, red, https://192.168.105.59:2380, https://192.168.105.59:2379, false
ubuntu@yellow:~$ sudo cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml
- ID: 3297041220608546238
  Address: 192.168.105.57:6400
  Role: 2
- ID: 7398126509822647372
  Address: 192.168.105.59:6400
  Role: 0
- ID: 14562585269713805766
  Address: 192.168.105.60:6400
  Role: 0
- ID: 14357816174711914492
  Address: 192.168.105.58:6400
  Role: 0
```
Now the node partially joined in mc’s dqlite.

