### PR TITLE
make: switch dqlite branch to main

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GOMIN=1.24.6
 GOPATH ?= $(shell go env GOPATH)
 DQLITE_PATH=$(GOPATH)/deps/dqlite
-DQLITE_BRANCH=master
+DQLITE_BRANCH=main
 
 .PHONY: default
 default: update-schema


### PR DESCRIPTION
# Switch dqlite branch to main

Dqlite is moving from `master` to `main`. This PR updates the reference branch in the Makefile.