### PR TITLE
fix: make node join more fault tolerance [backport v2]

### DIFF
--- a/example/test/main.sh
+++ b/example/test/main.sh
@@ -176,17 +176,256 @@ test_recover() {
   shutdown_systems
 }
 
+test_join_token_after_cluster_formed() {
+  # Test node join succeeds when original control plane is down
+  # Token generated AFTER the 3-node cluster is formed
+  # Based on k8s-snap test: test_node_join_succeeds_when_original_control_plane_is_down
+  
+  echo "Starting join test - token generated after 3-node cluster formed"
+  
+  new_systems 4 --heartbeat 2s
+  
+  # Bootstrap initial cluster with c1 as original control plane
+  microctl --state-dir "${test_dir}/c1" init "c1" 127.0.0.1:9001 --bootstrap
+  
+  # Get join tokens for c2 and c3 while c1 is available
+  token_c2=$(microctl --state-dir "${test_dir}/c1" tokens add "c2")
+  token_c3=$(microctl --state-dir "${test_dir}/c1" tokens add "c3")
+  
+  # Join c2 and c3 to form 3-node cluster
+  microctl --state-dir "${test_dir}/c2" init "c2" 127.0.0.1:9002 --token "${token_c2}"
+  microctl --state-dir "${test_dir}/c3" init "c3" 127.0.0.1:9003 --token "${token_c3}"
+  
+  # Wait for cluster to stabilize
+  while [[ -n "$(microctl --state-dir "${test_dir}/c1" cluster list -f yaml | yq '.[] | select(.role == "PENDING")')" ]]; do
+    sleep 2
+  done
+  
+  echo "Initial 3-node cluster formed:"
+  microctl --state-dir "${test_dir}/c1" cluster list
+  
+  # Verify all nodes are voters in the 3-node cluster
+  [[ $(microctl --state-dir "${test_dir}/c1" cluster list -f yaml | yq '.[] | select(.clustermemberlocal.name == "c1").role') == "voter" ]]
+  [[ $(microctl --state-dir "${test_dir}/c1" cluster list -f yaml | yq '.[] | select(.clustermemberlocal.name == "c2").role') == "voter" ]]
+  [[ $(microctl --state-dir "${test_dir}/c1" cluster list -f yaml | yq '.[] | select(.clustermemberlocal.name == "c3").role') == "voter" ]]
+  
+  # Get join token for c4 while c1 is still available
+  token_c4=$(microctl --state-dir "${test_dir}/c1" tokens add "c4")
+  
+  echo "Simulating original control plane (c1) failure..."
+  
+  # Kill c1 to simulate original control plane failure
+  c1_pid=$(jobs -p | head -1)  # Get first background job (should be c1)
+  kill -9 "${c1_pid}" 2>/dev/null || true
+  
+  sleep 2
+  
+  echo "Attempting to join c4 while c1 is down (this tests fault tolerance)..."
+  
+  # This is the critical test: can c4 join while c1 is down?
+  # This should work with proper fault tolerance implementation
+  microctl --state-dir "${test_dir}/c4" init "c4" 127.0.0.1:9004 --token "${token_c4}"
+  
+  echo "Verifying cluster state from surviving nodes..."
+  
+  # Verify cluster from c2's perspective (c1 should be unreachable, c2/c3/c4 should be online)
+  microctl --state-dir "${test_dir}/c2" cluster list
+  
+  # Wait for roles to stabilize after c1 failure and c4 join
+  sleep 5
+  
+  # Count online nodes from c2's perspective
+  online_count=$(microctl --state-dir "${test_dir}/c2" cluster list -f yaml | yq '[.[] | select(.status == "ONLINE")] | length')
+  echo "Online nodes count: ${online_count}"
+  
+  # Should have 3 online nodes (c2, c3, c4) even though c1 is down
+  [[ "${online_count}" -eq 3 ]] || {
+    echo "ERROR: Expected 3 online nodes, got ${online_count}"
+    microctl --state-dir "${test_dir}/c2" cluster list
+    return 1
+  }
+  
+  # Verify c4 successfully joined
+  c4_status=$(microctl --state-dir "${test_dir}/c2" cluster list -f yaml | yq '.[] | select(.clustermemberlocal.name == "c4").status')
+  [[ "${c4_status}" == "ONLINE" ]] || {
+    echo "ERROR: c4 should be ONLINE, got ${c4_status}"
+    return 1
+  }
+  
+  # Verify c4 is a voter, not just PENDING
+  # Add retry logic to wait for role promotion
+  echo "Waiting for c4 to be promoted from PENDING to voter..."
+  retry_count=0
+  max_retries=10
+  while [[ "${retry_count}" -lt "${max_retries}" ]]; do
+    c4_role=$(microctl --state-dir "${test_dir}/c2" cluster list -f yaml | yq '.[] | select(.clustermemberlocal.name == "c4").role')
+    if [[ "${c4_role}" == "voter" ]]; then
+      break
+    fi
+    echo "c4 role is still ${c4_role}, waiting for promotion... (attempt $((retry_count + 1))/${max_retries})"
+    sleep 2
+    retry_count=$((retry_count + 1))
+  done
+  
+  [[ "${c4_role}" == "voter" ]] || {
+    echo "ERROR: c4 should be voter, got ${c4_role} after ${max_retries} attempts"
+    microctl --state-dir "${test_dir}/c2" cluster list
+    return 1
+  }
+
+  # Verify dqlite cluster.yaml shows 4 members (low-level dqlite validation)
+  dqlite_cluster_count=$(yq '. | length' "${test_dir}/c2/database/cluster.yaml")
+  [[ "${dqlite_cluster_count}" -eq 4 ]] || {
+    echo "ERROR: Expected exactly 4 members in dqlite cluster.yaml, got ${dqlite_cluster_count}"
+    echo "Dqlite cluster.yaml contents:"
+    cat "${test_dir}/c2/database/cluster.yaml"
+    return 1
+  }
+
+  echo "SUCCESS: Node c4 successfully joined cluster while original control plane c1 was down"
+  echo "SUCCESS: Node c4 is ONLINE and has voter role"
+  echo "Final cluster state:"
+  microctl --state-dir "${test_dir}/c2" cluster list
+  echo "Dqlite cluster members:"
+  cat "${test_dir}/c2/database/cluster.yaml"
+  
+  shutdown_systems
+}
+
+test_join_token_before_cluster_formed() {
+  # Test node join succeeds when original control plane is down
+  # Token generated BEFORE other nodes join (while c1 is solo)
+  # Based on k8s-snap test: test_node_join_succeeds_when_original_control_plane_is_down
+  
+  echo "Starting join test - token generated before cluster formed"
+  
+  new_systems 4 --heartbeat 2s
+  
+  # Bootstrap initial cluster with c1 as original control plane
+  microctl --state-dir "${test_dir}/c1" init "c1" 127.0.0.1:9001 --bootstrap
+  
+  # Get join tokens for c2 and c3 while c1 is available
+  token_c2=$(microctl --state-dir "${test_dir}/c1" tokens add "c2")
+  token_c3=$(microctl --state-dir "${test_dir}/c1" tokens add "c3")
+  # Get join token for c4 while c1 is the only node up
+  token_c4=$(microctl --state-dir "${test_dir}/c1" tokens add "c4")
+  
+  # Join c2 and c3 to form 3-node cluster
+  microctl --state-dir "${test_dir}/c2" init "c2" 127.0.0.1:9002 --token "${token_c2}"
+  microctl --state-dir "${test_dir}/c3" init "c3" 127.0.0.1:9003 --token "${token_c3}"
+  
+  # Wait for cluster to stabilize
+  while [[ -n "$(microctl --state-dir "${test_dir}/c1" cluster list -f yaml | yq '.[] | select(.role == "PENDING")')" ]]; do
+    sleep 2
+  done
+  
+  echo "Initial 3-node cluster formed:"
+  microctl --state-dir "${test_dir}/c1" cluster list
+  
+  # Verify all nodes are voters in the 3-node cluster
+  [[ $(microctl --state-dir "${test_dir}/c1" cluster list -f yaml | yq '.[] | select(.clustermemberlocal.name == "c1").role') == "voter" ]]
+  [[ $(microctl --state-dir "${test_dir}/c1" cluster list -f yaml | yq '.[] | select(.clustermemberlocal.name == "c2").role') == "voter" ]]
+  [[ $(microctl --state-dir "${test_dir}/c1" cluster list -f yaml | yq '.[] | select(.clustermemberlocal.name == "c3").role') == "voter" ]]
+  
+  echo "Simulating original control plane (c1) failure..."
+  
+  # Kill c1 to simulate original control plane failure
+  c1_pid=$(jobs -p | head -1)  # Get first background job (should be c1)
+  kill -9 "${c1_pid}" 2>/dev/null || true
+  
+  sleep 2
+  
+  echo "Attempting to join c4 while c1 is down (this should fail cleanly)..."
+  
+  # This is the critical test: c4 should FAIL to join when c1 is down
+  # and the token was generated before cluster formation
+  # The join should fail cleanly without creating partial state
+  ! microctl --state-dir "${test_dir}/c4" init "c4" 127.0.0.1:9004 --token "${token_c4}" || {
+    echo "ERROR: c4 join should have failed but succeeded"
+    return 1
+  }
+  
+  echo "c4 join failed as expected. Verifying clean failure..."
+  
+  # Verify cluster from c2's perspective (should only show c1 as unreachable, c2/c3 as online)
+  microctl --state-dir "${test_dir}/c2" cluster list
+  
+  # Wait a bit to see if c4 appears in cluster or fails cleanly
+  sleep 5
+  
+  # Count online nodes from c2's perspective - should only be c2 and c3
+  online_count=$(microctl --state-dir "${test_dir}/c2" cluster list -f yaml | yq '[.[] | select(.status == "ONLINE")] | length')
+  echo "Online nodes count: ${online_count}"
+  
+  # Should have only 2 online nodes (c2, c3) since c1 is down and c4 should fail to join
+  [[ "${online_count}" -eq 2 ]] || {
+    echo "ERROR: Expected 2 online nodes (c2, c3), got ${online_count}"
+    microctl --state-dir "${test_dir}/c2" cluster list
+    return 1
+  }
+  
+  # Verify c4 is NOT in the cluster members table (clean failure)
+  c4_exists=$(microctl --state-dir "${test_dir}/c2" cluster list -f yaml | yq '.[] | select(.clustermemberlocal.name == "c4")' | wc -l)
+  [[ "${c4_exists}" -eq 0 ]] || {
+    echo "ERROR: c4 should not appear in cluster members table (partial join detected)"
+    echo "c4 state in cluster:"
+    microctl --state-dir "${test_dir}/c2" cluster list -f yaml | yq '.[] | select(.clustermemberlocal.name == "c4")'
+    return 1
+  }
+  
+  # Verify that only c1, c2, c3 exist in cluster (no c4)
+  member_count=$(microctl --state-dir "${test_dir}/c2" cluster list -f yaml | yq '. | length')
+  [[ "${member_count}" -eq 3 ]] || {
+    echo "ERROR: Expected exactly 3 cluster members (c1, c2, c3), got ${member_count}"
+    microctl --state-dir "${test_dir}/c2" cluster list
+    return 1
+  }
+  
+  # Verify dqlite cluster.yaml shows only 3 members (low-level dqlite validation)
+  dqlite_cluster_count=$(yq '. | length' "${test_dir}/c2/database/cluster.yaml")
+  [[ "${dqlite_cluster_count}" -eq 3 ]] || {
+    echo "ERROR: Expected exactly 3 members in dqlite cluster.yaml, got ${dqlite_cluster_count}"
+    echo "Dqlite cluster.yaml contents:"
+    cat "${test_dir}/c2/database/cluster.yaml"
+    return 1
+  }
+  
+  # Verify c4 (127.0.0.1:9004) is NOT in dqlite cluster.yaml
+  c4_in_dqlite_yaml=$(yq '.[] | select(.Address == "127.0.0.1:9004")' "${test_dir}/c2/database/cluster.yaml" | wc -l)
+  [[ "${c4_in_dqlite_yaml}" -eq 0 ]] || {
+    echo "ERROR: c4 found in dqlite cluster.yaml (partial join detected at dqlite level)"
+    echo "Dqlite cluster.yaml contents:"
+    cat "${test_dir}/c2/database/cluster.yaml"
+    return 1
+  }
+  
+  echo "SUCCESS: Node c4 failed to join cleanly - no partial join state detected"
+  echo "SUCCESS: Verified at both microcluster API and go-dqlite cluster members"
+  echo "Final cluster state (c4 should not appear):"
+  microctl --state-dir "${test_dir}/c2" cluster list
+  echo "Dqlite cluster members:"
+  cat "${test_dir}/c2/database/cluster.yaml"
+  
+  shutdown_systems
+}
+
 # allow for running a specific set of tests
 if [ "${1:-"all"}" = "all" ] || [ "${1}" = "" ]; then
   test_misc
   test_tokens
   test_recover
+  test_join_token_after_cluster_formed
+  test_join_token_before_cluster_formed
 elif [ "${1}" = "recover" ]; then
   test_recover
 elif [ "${1}" = "tokens" ]; then
   test_tokens
 elif [ "${1}" = "misc" ]; then
   test_misc
+elif [ "${1}" = "join-after" ]; then
+  test_join_token_after_cluster_formed
+elif [ "${1}" = "join-before" ]; then
+  test_join_token_before_cluster_formed
 else
   echo "Unknown test ${1}"
 fi

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -678,17 +678,17 @@ func (d *Daemon) StartAPI(ctx context.Context, bootstrap bool, initConfig map[st
 				return nil
 			}
 
-			// At this point the joiner is only trusted on the node that was leader at the time,
-			// so find it and have it instruct all dqlite members to trust this system now that it is functional.
-			if !clusterConfirmation {
-				err := internalClient.AddTrustStoreEntry(ctx, &c.Client, localMemberInfo)
-				if err != nil {
-					lastErr = err
-				} else {
-					clusterConfirmation = true
-				}
+			// Propagate trust to all reachable cluster members for fault tolerance.
+			err := internalClient.AddTrustStoreEntry(ctx, &c.Client, localMemberInfo)
+			if err != nil {
+				lastErr = err
+				// Continue trying other nodes even if this one fails
+				return nil
 			}
 
+			clusterConfirmation = true
+
+			// Continue to propagate trust to all nodes, don't stop after first success
 			return nil
 		})
 		if err != nil {
@@ -702,6 +702,14 @@ func (d *Daemon) StartAPI(ctx context.Context, bootstrap bool, initConfig map[st
 
 	// Tell the other nodes that this system is up.
 	remotes := d.trustStore.Remotes()
+
+	// Send a notification to all reachable cluster members.
+	// We don't fail the entire operation if some nodes are unreachable.
+	// This is important in case we are joining a cluster with some offline members.
+	// The heartbeat mechanism will take care of notifying those members later on.
+	var successCount, attemptCount int32
+	var counterMu sync.Mutex
+
 	err = cluster.Query(d.shutdownCtx, true, func(ctx context.Context, c *client.Client) error {
 		c.SetClusterNotification()
 
@@ -709,6 +717,10 @@ func (d *Daemon) StartAPI(ctx context.Context, bootstrap bool, initConfig map[st
 		if d.Address().URL.Host == c.URL().URL.Host {
 			return nil
 		}
+
+		counterMu.Lock()
+		attemptCount++
+		counterMu.Unlock()
 
 		// Send notification about this node's dqlite version to all other cluster members.
 		err = d.sendUpgradeNotification(ctx, c)
@@ -731,14 +743,24 @@ func (d *Daemon) StartAPI(ctx context.Context, bootstrap bool, initConfig map[st
 			// Run the OnNewMember hook, and skip errors on any nodes that are still in the process of joining.
 			err = internalClient.RunNewMemberHook(ctx, c.Client.UseTarget(remote.Name), internalTypes.HookNewMemberOptions{NewMember: localMemberInfo})
 			if err != nil && !api.StatusErrorCheck(err, http.StatusServiceUnavailable) {
-				return err
+				// log error but continue with other nodes
+				logger.Warn("Failed running OnNewMember hook on node", logger.Ctx{"node": c.URL().URL.Host, "error": err})
+				return nil
 			}
 		}
 
+		counterMu.Lock()
+		successCount++
+		counterMu.Unlock()
 		return nil
 	})
 	if err != nil {
 		return err
+	}
+
+	// Only fail if we attempted to notify other nodes but all failed
+	if attemptCount > 0 && successCount == 0 {
+		return fmt.Errorf("Failed to notify any existing cluster member at %q", strings.Join(joinAddresses, ", "))
 	}
 
 	if len(joinAddresses) > 0 {

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -27,7 +27,9 @@ import (
 // Open opens the dqlite database and loads the schema.
 // Returns true if we need to wait for other nodes to catch up to our version.
 func (db *DqliteDB) Open(ext extensions.Extensions, bootstrap bool) error {
-	ctx, cancel := context.WithTimeout(db.ctx, 30*time.Second)
+	// Allow dqlite up to 2 minutes to become ready when starting up.
+	// This is to allow for unready/dead nodes to time out.
+	ctx, cancel := context.WithTimeout(db.ctx, 120*time.Second)
 	defer cancel()
 
 	db.statusLock.Lock()
@@ -41,6 +43,13 @@ func (db *DqliteDB) Open(ext extensions.Extensions, bootstrap bool) error {
 		db.statusLock.Lock()
 		db.status = types.DatabaseOffline
 		db.statusLock.Unlock()
+		// close the db if any of the following steps fail
+		closeErr := db.dqlite.Close()
+		if closeErr != nil {
+			logger.Error("Failed to close database", logger.Ctx{"address": db.listenAddr.String(), "error": closeErr})
+		}
+
+		db.db = nil
 	})
 
 	err := db.dqlite.Ready(ctx)
@@ -59,16 +68,6 @@ func (db *DqliteDB) Open(ext extensions.Extensions, bootstrap bool) error {
 	if err != nil {
 		return err
 	}
-
-	// If we receive an error after this point, close the database.
-	reverter.Add(func() {
-		closeErr := db.db.Close()
-		if closeErr != nil {
-			logger.Error("Failed to close database", logger.Ctx{"address": db.listenAddr.String(), "error": closeErr})
-		}
-
-		db.db = nil
-	})
 
 	err = cluster.PrepareStmts(db.db, "", false)
 	if err != nil {

--- a/internal/rest/resources/truststore.go
+++ b/internal/rest/resources/truststore.go
@@ -6,9 +6,11 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sync"
 	"time"
 
 	"github.com/canonical/lxd/lxd/response"
+	"github.com/canonical/lxd/shared/logger"
 	"github.com/gorilla/mux"
 
 	"github.com/canonical/microcluster/v2/client"
@@ -57,16 +59,41 @@ func trustPost(s state.State, r *http.Request) response.Response {
 			return response.SmartError(err)
 		}
 
+		successCount := 0
+		attemptCount := 0
+		var counterMu sync.Mutex
+
+		// Try to add the truststore entry to all other nodes in the cluster.
+		// We don't fail the entire operation if some nodes are unreachable.
 		err = cluster.Query(ctx, true, func(ctx context.Context, c *client.Client) error {
 			// No need to send a request to ourselves, or to the node we are adding.
 			if s.Address().URL.Host == c.URL().URL.Host || req.Address.String() == c.URL().URL.Host {
 				return nil
 			}
 
-			return internalClient.AddTrustStoreEntry(ctx, &c.Client, req)
+			counterMu.Lock()
+			attemptCount++
+			counterMu.Unlock()
+
+			err := internalClient.AddTrustStoreEntry(ctx, &c.Client, req)
+			if err != nil {
+				// log error but continue with other nodes
+				logger.Warn("Failed adding truststore entry to node", logger.Ctx{"node": c.URL().URL.Host, "error": err})
+				return nil
+			}
+
+			counterMu.Lock()
+			successCount++
+			counterMu.Unlock()
+			return nil
 		})
 		if err != nil {
 			return response.SmartError(err)
+		}
+
+		// Only fail if we attempted to propagate to other nodes but all failed
+		if attemptCount > 0 && successCount == 0 {
+			return response.SmartError(fmt.Errorf("Failed adding truststore entry to any cluster node"))
 		}
 	}
 


### PR DESCRIPTION
# Make node join more fault tolerant
This PR improves the fault tolerance of node joins in microcluster, allowing nodes to successfully join even when the original control plane leader is down or unreachable.

## Key Changes

Trust Propagation: Modified daemon startup to propagate trust only to reachable members, ensuring joins succeed even if some existing cluster members are unavailable.

Join Token Validation: Enhanced node endpoints to validate that join token addresses are reachable before proceeding with cluster operations. If all token join addresses are unreachable we fail the join operation early. 

Database Resilience: Improved dqlite timeout handling and cleanup for unreachable nodes during partial join scenarios.

Test Coverage: Added comprehensive test cases covering both join-before and join-after failure scenarios with retry mechanisms.

## Behavior

- Node joins now succeed when original leader is down (similar to k8s-snap behavior)
- Failed connections to unreachable members no longer block the entire join process
- Trust propagation continues to all reachable nodes instead of failing on first unreachable member
- Improved error handling for connection refused and network timeout scenarios

## Context: bug discovery in the k8s-snap

While testing node joins in Canonical Kubernetes I encountered this error message on node join:

```
sudo k8s join-cluster <token>

Joining the cluster. This may take a few seconds, please wait.
Error: Failed to join the cluster using the provided token.

The error was: failed after potential retry: wait check failed: failed to POST /k8sd/cluster/join: failed to join k8sd cluster as control plane: Failed to confirm new member "blue" on any existing system (3): Post "https://192.168.105.48:6400/core/internal/truststore": Unable to connect to "192.168.105.48:6400": dial tcp 192.168.105.48:6400: connect: no route to host
```

The node joining (192.168.105.52) is the fourth node in a three node cluster where one of the nodes (192.168.105.48) was killed but not removed from the cluster for testing purposes.

A node join should not fail when one of the nodes in the cluster crashes, we should fail over and contact the other nodes in the cluster.

As a consequence our cluster ends up in an inconsistent state:

core_cluster_members: holds original three nodes including the crashed one.
dqlite: has 4 members including our new one as spare.

```
sudo /snap/k8s/current/bin/k8sd sql   --state-dir /var/snap/k8s/common/var/lib/k8sd/state   "SELECT name, role FROM core_cluster_members"
[[green spare] [yellow voter] [red voter]] 

which is 192.168.105.48, 192.168.105.50, 192.168.105.51

sudo cat /var/snap/k8s/common/var/lib/k8sd/state/database/cluster.yaml
- ID: 3297041220608546238
  Address: 192.168.105.48:6400
  Role: 0
- ID: 2600311347157639893
  Address: 192.168.105.50:6400
  Role: 0
- ID: 17391627959315830676
  Address: 192.168.105.51:6400
  Role: 0
- ID: 4234120578868796636
  Address: 192.168.105.52:6400
  Role: 2
```