### PR TITLE
internal/rest/resources: Cleanup lost node as best-effort when `--force`d

### DIFF
--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -416,7 +416,7 @@ func clusterMemberDelete(s state.State, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("No remote exists with the given name %q", name))
 	}
 
-	ctx, cancel := context.WithTimeout(r.Context(), time.Second*30)
+	ctx, cancel := context.WithTimeout(r.Context(), time.Second*60)
 	defer cancel()
 
 	leader, err := s.Database().Leader(ctx)

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -613,7 +613,7 @@ func clusterMemberDelete(s state.State, r *http.Request) response.Response {
 	err = s.Database().Transaction(r.Context(), func(ctx context.Context, tx *sql.Tx) error {
 		return cluster.DeleteCoreClusterMember(ctx, tx, remote.Address.String())
 	})
-	if err != nil {
+	if err != nil && !force {
 		return response.SmartError(err)
 	}
 


### PR DESCRIPTION
Removing a lost node from a cluster fails right now because the it tries to run the pre-remove hook on the lost node and eventually times out after 30 seconds.

This fix will try to reach the node that is about to be removed before running the pre-remove hook. If it cannot be reached the removal will either fail or continue without running the `pre-remove` hook if forced.