### PR TITLE
internal/endpoints: removed dependency from LXD FancyTLSListener

### DIFF
--- a/internal/endpoints/mutable_tls_listener.go
+++ b/internal/endpoints/mutable_tls_listener.go
@@ -1,0 +1,61 @@
+package endpoints
+
+import (
+	"crypto/tls"
+	"net"
+	"sync"
+
+	"github.com/canonical/lxd/lxd/util"
+	"github.com/canonical/lxd/shared"
+)
+
+// mutableTLSListener is a variation of the standard tls.Listener that supports
+// atomically swapping the underlying TLS configuration.
+// Requests served before the swap will continue using the old configuration.
+// This implementation matches LXD's FancyTLSListener but excludes:
+//   - trustedProxy []net.IP field (proxy protocol support not needed)
+//   - TrustedProxy() method for setting proxy IPs
+//   - isProxy() function and proxy protocol wrapping logic
+//   - proxyproto.NewConn() calls in Accept()
+type mutableTLSListener struct {
+	net.Listener
+	mu     sync.RWMutex
+	config *tls.Config
+}
+
+// newMutableTLSListener creates a new mutableTLSListener.
+func newMutableTLSListener(inner net.Listener, cert *shared.CertInfo) *mutableTLSListener {
+	listener := &mutableTLSListener{
+		Listener: inner,
+	}
+
+	listener.Config(cert)
+	return listener
+}
+
+// Accept waits for and returns the next incoming TLS connection then use the
+// current TLS configuration to handle it.
+// EXCLUDED from LXD: proxy protocol check and wrapping:
+//   - if isProxy(c.RemoteAddr().String(), l.trustedProxy) { c = proxyproto.NewConn(c, 0) }
+func (l *mutableTLSListener) Accept() (net.Conn, error) {
+	c, err := l.Listener.Accept()
+	if err != nil {
+		return nil, err
+	}
+
+	l.mu.RLock()
+	defer l.mu.RUnlock()
+	config := l.config
+
+	return tls.Server(c, config), nil
+}
+
+// Config safely swaps the underlying TLS configuration.
+func (l *mutableTLSListener) Config(cert *shared.CertInfo) {
+	config := util.ServerTLSConfig(cert)
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.config = config
+}

--- a/internal/endpoints/mutable_tls_listener_test.go
+++ b/internal/endpoints/mutable_tls_listener_test.go
@@ -1,0 +1,25 @@
+package endpoints
+
+import (
+	"testing"
+
+	"github.com/canonical/lxd/shared"
+	"github.com/stretchr/testify/require"
+)
+
+// Test_mutableTLSListener tests immutability and concurrent access.
+func Test_mutableTLSListener(t *testing.T) {
+	listener := &mutableTLSListener{}
+	cert1 := shared.TestingKeyPair()
+	cert2 := shared.TestingAltKeyPair()
+
+	// Test immutability: different certs create different config objects
+	listener.Config(cert1)
+	config1 := listener.config
+	require.NotNil(t, config1)
+
+	listener.Config(cert2)
+	config2 := listener.config
+	require.NotNil(t, config2)
+	require.NotSame(t, config1, config2, "Different certs should create different config objects")
+}

--- a/internal/endpoints/network.go
+++ b/internal/endpoints/network.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/canonical/lxd/lxd/endpoints/listeners"
 	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -74,14 +73,15 @@ func (n *Network) Listen() error {
 		return fmt.Errorf("Failed to listen on https socket: %w", err)
 	}
 
-	n.listener = listeners.NewFancyTLSListener(listener, n.cert)
+	// Use the mutableTLSListener that wraps connections at Accept time
+	n.listener = newMutableTLSListener(listener, n.cert)
 
 	return nil
 }
 
 // UpdateTLS updates the TLS configuration of the network listener.
 func (n *Network) UpdateTLS(cert *shared.CertInfo) {
-	l, ok := n.listener.(*listeners.FancyTLSListener)
+	l, ok := n.listener.(*mutableTLSListener)
 	if ok {
 		n.certMu.Lock()
 		n.cert = cert


### PR DESCRIPTION
Refers to https://github.com/canonical/microcluster/issues/503
LXD-3654