### PR TITLE
Replace `utils` package from LXD

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/canonical/go-dqlite/v3/driver"
-	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/revert"
@@ -280,7 +279,7 @@ func (d *Daemon) init(listenAddress string, socketGroup string, heartbeatInterva
 		return err
 	}
 
-	d.serverCert, err = util.LoadServerCert(d.os.StateDir)
+	d.serverCert, err = d.os.ServerCert()
 	if err != nil {
 		return err
 	}

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -6,7 +6,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/stretchr/testify/require"
@@ -15,6 +14,7 @@ import (
 	"github.com/canonical/microcluster/v3/internal/config"
 	"github.com/canonical/microcluster/v3/internal/endpoints"
 	"github.com/canonical/microcluster/v3/internal/log"
+	"github.com/canonical/microcluster/v3/internal/rest/client"
 	"github.com/canonical/microcluster/v3/internal/sys"
 	"github.com/canonical/microcluster/v3/internal/trust"
 	"github.com/canonical/microcluster/v3/rest"
@@ -228,19 +228,34 @@ func (t *daemonsSuite) Test_UpdateServers() {
 
 		// Check if servers are up.
 		for _, addr := range test.listeningOn {
-			client, err := util.HTTPClient(string(daemon.ClusterCert().PublicKey()), nil)
+			url := api.NewURL().Scheme("https").Host(addr.String())
+
+			// The remote server uses the cluster certificate.
+			remoteCert, err := daemon.ClusterCert().PublicKeyX509()
 			require.NoError(t.T(), err)
 
-			_, err = client.Get(api.NewURL().Scheme("https").Host(addr.String()).String())
+			// We also use the cluster certificate as a client certificate for this test.
+			client, err := client.New(*url, daemon.ClusterCert(), remoteCert, false)
+			require.NoError(t.T(), err)
+
+			// Use embedded Get from Go's HTTP client.
+			// It requires providing the URL a second time as it's detached from Microcluster's client struct.
+			// But we can rely on both client and server certificate being setup properly.
+			_, err = client.Get(url.String())
 			require.NoError(t.T(), err)
 		}
 
 		// Check if servers are down.
 		for _, addr := range test.notListeningOn {
-			client, err := util.HTTPClient(string(daemon.ClusterCert().PublicKey()), nil)
+			url := api.NewURL().Scheme("https").Host(addr.String())
+
+			remoteCert, err := daemon.ClusterCert().PublicKeyX509()
 			require.NoError(t.T(), err)
 
-			_, err = client.Get(api.NewURL().Scheme("https").Host(addr.String()).String())
+			client, err := client.New(*url, daemon.ClusterCert(), remoteCert, false)
+			require.NoError(t.T(), err)
+
+			_, err = client.Get(url.String())
 			require.Error(t.T(), err)
 		}
 

--- a/internal/endpoints/mutable_tls_listener.go
+++ b/internal/endpoints/mutable_tls_listener.go
@@ -2,10 +2,10 @@ package endpoints
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"net"
 	"sync"
 
-	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
 )
 
@@ -50,9 +50,25 @@ func (l *mutableTLSListener) Accept() (net.Conn, error) {
 	return tls.Server(c, config), nil
 }
 
+// serverTLSConfig returns a new server-side tls.Config generated from the given certificate info.
+func (l *mutableTLSListener) serverTLSConfig(cert *shared.CertInfo) *tls.Config {
+	config := shared.InitTLSConfig()
+	config.ClientAuth = tls.RequestClientCert
+	config.Certificates = []tls.Certificate{cert.KeyPair()}
+
+	if cert.CA() != nil {
+		pool := x509.NewCertPool()
+		pool.AddCert(cert.CA())
+		config.RootCAs = pool
+		config.ClientCAs = pool
+	}
+
+	return config
+}
+
 // Config safely swaps the underlying TLS configuration.
 func (l *mutableTLSListener) Config(cert *shared.CertInfo) {
-	config := util.ServerTLSConfig(cert)
+	config := l.serverTLSConfig(cert)
 
 	l.mu.Lock()
 	defer l.mu.Unlock()

--- a/internal/endpoints/network.go
+++ b/internal/endpoints/network.go
@@ -11,7 +11,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 
@@ -64,7 +63,7 @@ func (n *Network) Type() EndpointType {
 
 // Listen on the given address.
 func (n *Network) Listen() error {
-	listenAddress := util.CanonicalNetworkAddress(n.address.URL.Host, shared.HTTPSDefaultPort)
+	listenAddress := canonicalNetworkAddress(n.address.URL.Host, shared.HTTPSDefaultPort)
 	protocol := "tcp"
 
 	if strings.HasPrefix(listenAddress, "0.0.0.0") {

--- a/internal/endpoints/util.go
+++ b/internal/endpoints/util.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"strconv"
 	"time"
 
 	"github.com/canonical/microcluster/v3/internal/log"
@@ -47,4 +48,28 @@ func shutdownServer(ctx context.Context, server *http.Server, timeout time.Durat
 	}
 
 	return nil
+}
+
+// canonicalNetworkAddress parses the given network address and returns a string of the form "host:port",
+// possibly filling it with the default port if it's missing. It will also wrap a bare IPv6 address with square
+// brackets if needed.
+func canonicalNetworkAddress(address string, defaultPort int64) string {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		ip := net.ParseIP(address)
+		if ip != nil {
+			// If the input address is a bare IP address, then convert it to a proper listen address
+			// using the canonical IP with default port and wrap IPv6 addresses in square brackets.
+			address = net.JoinHostPort(ip.String(), strconv.FormatInt(defaultPort, 10))
+		} else {
+			// Otherwise assume this is either a host name or a partial address (e.g `[::]`) without
+			// a port number, so append the default port.
+			address = address + ":" + strconv.FormatInt(defaultPort, 10)
+		}
+	} else if port == "" && address[len(address)-1] == ':' {
+		// An address that ends with a trailing colon will be parsed as having an empty port.
+		address = net.JoinHostPort(host, strconv.FormatInt(defaultPort, 10))
+	}
+
+	return address
 }

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -10,7 +10,6 @@ import (
 	"path/filepath"
 	"slices"
 
-	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 	"github.com/canonical/lxd/shared/revert"
@@ -270,9 +269,31 @@ func joinWithToken(state state.State, r *http.Request, req *internalTypes.Contro
 	return joinInfo, &localClusterMember, nil
 }
 
+// writeCert writes the given material to the appropriate certificate files in the given state directory.
+func writeCert(dir, prefix string, cert, key, ca []byte) error {
+	err := os.WriteFile(filepath.Join(dir, prefix+".crt"), cert, 0644)
+	if err != nil {
+		return err
+	}
+
+	err = os.WriteFile(filepath.Join(dir, prefix+".key"), key, 0600)
+	if err != nil {
+		return err
+	}
+
+	if ca != nil {
+		err = os.WriteFile(filepath.Join(dir, prefix+".ca"), ca, 0644)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
 func setupLocalMember(state state.State, localClusterMember *trust.Remote, joinInfo *internalTypes.TokenResponse) ([]string, error) {
 	// Set up cluster certificate.
-	err := util.WriteCert(state.FileSystem().StateDir, string(types.ClusterCertificateName), []byte(joinInfo.ClusterCert.String()), []byte(joinInfo.ClusterKey), nil)
+	err := writeCert(state.FileSystem().StateDir, string(types.ClusterCertificateName), []byte(joinInfo.ClusterCert.String()), []byte(joinInfo.ClusterKey), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -285,7 +306,7 @@ func setupLocalMember(state state.State, localClusterMember *trust.Remote, joinI
 			ca = []byte(cert.CA)
 		}
 
-		err := util.WriteCert(state.FileSystem().CertificatesDir, name, []byte(cert.Cert), []byte(cert.Key), ca)
+		err := writeCert(state.FileSystem().CertificatesDir, name, []byte(cert.Cert), []byte(cert.Key), ca)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/sys/os.go
+++ b/internal/sys/os.go
@@ -117,7 +117,7 @@ func (s *OS) DatabasePath() string {
 
 // ServerCert gets the local server certificate from the state directory.
 func (s *OS) ServerCert() (*shared.CertInfo, error) {
-	cert, err := shared.KeyPairAndCA(s.StateDir, "server", shared.CertServer, shared.CertOptions{})
+	cert, err := shared.KeyPairAndCA(s.StateDir, string(types.ServerCertificateName), shared.CertServer, shared.CertOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("Failed to load TLS certificate: %w", err)
 	}

--- a/internal/sys/os.go
+++ b/internal/sys/os.go
@@ -117,10 +117,6 @@ func (s *OS) DatabasePath() string {
 
 // ServerCert gets the local server certificate from the state directory.
 func (s *OS) ServerCert() (*shared.CertInfo, error) {
-	if !shared.PathExists(filepath.Join(s.StateDir, "server.crt")) {
-		return nil, fmt.Errorf("Failed to get server.crt from directory %q", s.StateDir)
-	}
-
 	cert, err := shared.KeyPairAndCA(s.StateDir, "server", shared.CertServer, shared.CertOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("Failed to load TLS certificate: %w", err)
@@ -131,10 +127,6 @@ func (s *OS) ServerCert() (*shared.CertInfo, error) {
 
 // ClusterCert gets the local cluster certificate from the state directory.
 func (s *OS) ClusterCert() (*shared.CertInfo, error) {
-	if !shared.PathExists(filepath.Join(s.StateDir, fmt.Sprintf("%s.crt", types.ClusterCertificateName))) {
-		return nil, fmt.Errorf("Failed to get %s.crt from directory %q", types.ClusterCertificateName, s.StateDir)
-	}
-
 	cert, err := shared.KeyPairAndCA(s.StateDir, string(types.ClusterCertificateName), shared.CertServer, shared.CertOptions{})
 	if err != nil {
 		return nil, fmt.Errorf("Failed to load TLS certificate: %w", err)

--- a/rest/access/handlers.go
+++ b/rest/access/handlers.go
@@ -1,12 +1,15 @@
 package access
 
 import (
+	"context"
+	"crypto/subtle"
 	"crypto/x509"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"time"
 
-	"github.com/canonical/lxd/lxd/util"
+	"github.com/canonical/lxd/shared/api"
 
 	"github.com/canonical/microcluster/v3/internal/endpoints"
 	"github.com/canonical/microcluster/v3/internal/log"
@@ -48,6 +51,46 @@ func AllowAuthenticated(state state.State, r *http.Request) (bool, response.Resp
 	return true, nil
 }
 
+// certificateInDate returns an error if the current time is before the certificates "not before", or after the
+// certificates "not after".
+func certificateInDate(cert x509.Certificate) error {
+	now := time.Now()
+	if now.Before(cert.NotBefore) {
+		return api.StatusErrorf(http.StatusUnauthorized, "Certificate is not yet valid")
+	}
+
+	if now.After(cert.NotAfter) {
+		return api.StatusErrorf(http.StatusUnauthorized, "Certificate has expired")
+	}
+
+	return nil
+}
+
+// checkMutualTLS checks whether the given certificate is valid and is present in the given trustedCerts map.
+// Returns true if the certificate is trusted, and the fingerprint of the certificate.
+func checkMutualTLS(ctx context.Context, cert x509.Certificate, trustedCerts map[string]x509.Certificate) (bool, string) {
+	err := certificateInDate(cert)
+	if err != nil {
+		return false, ""
+	}
+
+	logger, err := log.LoggerFromContext(ctx)
+	if err != nil {
+		// We failed to get the logger so we can't log the error.
+		return false, ""
+	}
+
+	// Check whether client certificate is in the map of trusted certs.
+	for fingerprint, v := range trustedCerts {
+		if subtle.ConstantTimeCompare(cert.Raw, v.Raw) == 1 {
+			logger.Debug("Matched trusted cert", slog.String("fingerprint", fingerprint), slog.String("subject", v.Subject.String()))
+			return true, fingerprint
+		}
+	}
+
+	return false, ""
+}
+
 // Authenticate ensures the request certificates are trusted against the given set of trusted certificates.
 // - Requests over the unix socket are always allowed.
 // - HTTP requests require the TLS Peer certificate to match an entry in the supplied map of certificates.
@@ -87,7 +130,7 @@ func Authenticate(state state.State, r *http.Request, hostAddress string, truste
 	case hostAddrPort.WithZone("").String():
 		if r.TLS != nil {
 			for _, cert := range r.TLS.PeerCertificates {
-				trusted, fingerprint := util.CheckMutualTLS(*cert, trustedCerts)
+				trusted, fingerprint := checkMutualTLS(r.Context(), *cert, trustedCerts)
 				if trusted {
 					logger.Debug("Authenticated request", slog.String("origin", r.RemoteAddr), slog.String("destination", r.URL.String()), slog.String("fingerprint", fingerprint))
 					return trusted, nil

--- a/rest/response/response.go
+++ b/rest/response/response.go
@@ -8,7 +8,6 @@ import (
 	"log/slog"
 	"net/http"
 
-	"github.com/canonical/lxd/lxd/util"
 	"github.com/canonical/lxd/shared/api"
 
 	"github.com/canonical/microcluster/v3/internal/log"
@@ -70,7 +69,9 @@ func (r *syncResponse) Render(w http.ResponseWriter, req *http.Request) error {
 		Metadata:   r.metadata,
 	}
 
-	return util.WriteJSON(w, resp, nil)
+	enc := json.NewEncoder(w)
+	enc.SetEscapeHTML(false)
+	return enc.Encode(resp)
 }
 
 func (r *syncResponse) String() string {


### PR DESCRIPTION
Fixes https://github.com/canonical/microcluster/issues/503

Last one to resolve the remaining dependencies on non-"shared" deps from the LXD repo. 

Where possible we use the std library. 
Otherwise we import the code from LXD.