### PR TITLE
Don't require LXD's `shared` URL type

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -3,8 +3,8 @@ package client
 import (
 	"context"
 	"net/http"
+	"net/url"
 
-	"github.com/canonical/lxd/shared/api"
 	"github.com/gorilla/websocket"
 
 	"github.com/canonical/microcluster/v3/internal/rest/client"
@@ -23,7 +23,7 @@ func IsNotification(r *http.Request) bool {
 
 // Query is a helper for initiating a request on any endpoints defined external to microcluster. This function should be used for all client
 // methods defined externally from microcluster.
-func (c *Client) Query(ctx context.Context, method string, prefix types.EndpointPrefix, path *api.URL, in any, out any) error {
+func (c *Client) Query(ctx context.Context, method string, prefix types.EndpointPrefix, path *url.URL, in any, out any) error {
 	queryCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -32,7 +32,7 @@ func (c *Client) Query(ctx context.Context, method string, prefix types.Endpoint
 
 // QueryRaw is a helper for initiating a request on any endpoints defined external to microcluster.
 // Unlike Query it returns the raw HTTP response.
-func (c *Client) QueryRaw(ctx context.Context, method string, prefix types.EndpointPrefix, path *api.URL, in any) (*http.Response, error) {
+func (c *Client) QueryRaw(ctx context.Context, method string, prefix types.EndpointPrefix, path *url.URL, in any) (*http.Response, error) {
 	queryCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -41,7 +41,7 @@ func (c *Client) QueryRaw(ctx context.Context, method string, prefix types.Endpo
 
 // Websocket is a helper for upgrading a request to websocket on any endpoints defined external to microcluster.
 // This function should be used for all client methods defined externally from microcluster.
-func (c *Client) Websocket(ctx context.Context, prefix types.EndpointPrefix, path *api.URL) (*websocket.Conn, error) {
+func (c *Client) Websocket(ctx context.Context, prefix types.EndpointPrefix, path *url.URL) (*websocket.Conn, error) {
 	websocketCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 

--- a/example/client/client.go
+++ b/example/client/client.go
@@ -4,9 +4,8 @@ package client
 import (
 	"context"
 	"fmt"
+	"net/url"
 	"time"
-
-	"github.com/canonical/lxd/shared/api"
 
 	"github.com/canonical/microcluster/v3/client"
 	"github.com/canonical/microcluster/v3/example/api/types"
@@ -19,8 +18,12 @@ func ExtendedPostCmd(ctx context.Context, c *client.Client, data *types.Extended
 	queryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
 
+	path := url.URL{
+		Path: "extended",
+	}
+
 	var outStr string
-	err := c.Query(queryCtx, "POST", types.ExtendedPathPrefix, api.NewURL().Path("extended"), data, &outStr)
+	err := c.Query(queryCtx, "POST", types.ExtendedPathPrefix, &path, data, &outStr)
 	if err != nil {
 		clientURL := c.URL()
 		return "", fmt.Errorf("Failed performing action on %q: %w", clientURL.String(), err)

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -340,7 +340,7 @@ func (db *DqliteDB) SendHeartbeat(ctx context.Context, c *internalClient.Client,
 	queryCtx, cancel := context.WithTimeout(ctx, heartbeatTimeout)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, api.NewURL().Path("heartbeat"), hbInfo, nil)
+	return c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, &api.NewURL().Path("heartbeat").URL, hbInfo, nil)
 }
 
 func (db *DqliteDB) heartbeat(leaderInfo dqliteClient.NodeInfo, servers []dqliteClient.NodeInfo) error {

--- a/internal/recover/recover.go
+++ b/internal/recover/recover.go
@@ -123,7 +123,7 @@ func RecoverFromQuorumLoss(ctx context.Context, filesystem *sys.OS, members []cl
 	cancelCtx, cancel := context.WithTimeout(context.Background(), time.Second*10)
 	err = cluster.Query(cancelCtx, true, func(ctx context.Context, client *client.Client) error {
 		var rslt internalTypes.Server
-		err := client.Query(ctx, "GET", internalTypes.PublicEndpoint, api.NewURL(), nil, &rslt)
+		err := client.Query(ctx, "GET", internalTypes.PublicEndpoint, &api.NewURL().URL, nil, &rslt)
 		if err == nil {
 			return fmt.Errorf("Contacted cluster member at %q; please shut down all cluster members", rslt.Name)
 		}

--- a/internal/rest/client/client.go
+++ b/internal/rest/client/client.go
@@ -189,7 +189,7 @@ func IsForwardedRequest(r *http.Request) bool {
 	return r.Header.Get("User-Agent") == UserAgentNotifier
 }
 
-func (c *Client) rawQuery(ctx context.Context, method string, url *api.URL, data any) (*http.Response, error) {
+func (c *Client) rawQuery(ctx context.Context, method string, url *url.URL, data any) (*http.Response, error) {
 	var req *http.Request
 	var err error
 
@@ -266,17 +266,17 @@ func (c *Client) MakeRequest(r *http.Request) (*api.Response, error) {
 	return parsedResponse, nil
 }
 
-func (c *Client) mergeURL(endpointType types.EndpointPrefix, endpoint *api.URL) *api.URL {
-	localURL := api.NewURL()
+func (c *Client) mergeURL(endpointType types.EndpointPrefix, endpoint *url.URL) *url.URL {
+	localURL := &url.URL{}
 	if endpoint != nil {
 		// Get a new local struct to avoid modifying the provided one.
 		newURL := *endpoint
 		localURL = &newURL
 	}
 
-	localURL.URL.Host = c.url.URL.Host
-	localURL.URL.Scheme = c.url.URL.Scheme
-	localURL.URL.Path = filepath.Join("/", string(endpointType), localURL.URL.Path)
+	localURL.Host = c.url.URL.Host
+	localURL.Scheme = c.url.URL.Scheme
+	localURL.Path = filepath.Join("/", string(endpointType), localURL.Path)
 	localURL.RawPath = filepath.Join("/", string(endpointType), localURL.RawPath)
 
 	localQuery := localURL.Query()
@@ -293,7 +293,7 @@ func (c *Client) mergeURL(endpointType types.EndpointPrefix, endpoint *api.URL) 
 // The response gets unpacked into the target struct. POST requests can optionally provide raw data to be sent through.
 //
 // The final URL is that provided as the endpoint combined with the applicable prefix for the endpointType and the scheme and host from the client.
-func (c *Client) QueryStruct(ctx context.Context, method string, endpointType types.EndpointPrefix, endpoint *api.URL, data any, target any) error {
+func (c *Client) QueryStruct(ctx context.Context, method string, endpointType types.EndpointPrefix, endpoint *url.URL, data any, target any) error {
 	resp, err := c.QueryStructRaw(ctx, method, endpointType, endpoint, data)
 	if err != nil {
 		return err
@@ -317,7 +317,7 @@ func (c *Client) QueryStruct(ctx context.Context, method string, endpointType ty
 // The raw response is returned. POST requests can optionally provide raw data to be sent through.
 //
 // The final URL is that provided as the endpoint combined with the applicable prefix for the endpointType and the scheme and host from the client.
-func (c *Client) QueryStructRaw(ctx context.Context, method string, endpointType types.EndpointPrefix, endpoint *api.URL, data any) (*http.Response, error) {
+func (c *Client) QueryStructRaw(ctx context.Context, method string, endpointType types.EndpointPrefix, endpoint *url.URL, data any) (*http.Response, error) {
 	// Merge the provided URL with the one we have for the client.
 	localURL := c.mergeURL(endpointType, endpoint)
 
@@ -333,15 +333,15 @@ func (c *Client) QueryStructRaw(ctx context.Context, method string, endpointType
 // RawWebsocket dials the provided endpoint and tries to upgrade the connection.
 //
 // The final URL is that provided as the endpoint combined with the applicable prefix for the endpointType and the scheme and host from the client.
-func (c *Client) RawWebsocket(ctx context.Context, endpointType types.EndpointPrefix, endpoint *api.URL) (*websocket.Conn, error) {
+func (c *Client) RawWebsocket(ctx context.Context, endpointType types.EndpointPrefix, endpoint *url.URL) (*websocket.Conn, error) {
 	// Merge the provided URL with the one we have for the client.
 	localURL := c.mergeURL(endpointType, endpoint)
 
 	// Pick the right scheme based on the client configuration.
 	if c.url.URL.Scheme == "http" {
-		localURL.URL.Scheme = "ws"
+		localURL.Scheme = "ws"
 	} else {
-		localURL.URL.Scheme = "wss"
+		localURL.Scheme = "wss"
 	}
 
 	// Get the transport configuration from the HTTP client.

--- a/internal/rest/client/cluster.go
+++ b/internal/rest/client/cluster.go
@@ -26,7 +26,7 @@ func AddClusterMember(ctx context.Context, c *Client, args types.ClusterMember) 
 	defer cancel()
 
 	tokenResponse := internalTypes.TokenResponse{}
-	err := c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, api.NewURL().Path("cluster"), args, &tokenResponse)
+	err := c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, &api.NewURL().Path("cluster").URL, args, &tokenResponse)
 	if err != nil {
 		return nil, err
 	}
@@ -44,7 +44,7 @@ func ResetClusterMember(ctx context.Context, c *Client, name string, force bool)
 		endpoint = endpoint.WithQuery("force", "1")
 	}
 
-	return c.QueryStruct(queryCtx, "PUT", internalTypes.InternalEndpoint, endpoint, nil, nil)
+	return c.QueryStruct(queryCtx, "PUT", internalTypes.InternalEndpoint, &endpoint.URL, nil, nil)
 }
 
 // GetClusterMembers returns the database record of cluster members.
@@ -53,7 +53,7 @@ func (c *Client) GetClusterMembers(ctx context.Context) ([]types.ClusterMember, 
 	defer cancel()
 
 	clusterMembers := []types.ClusterMember{}
-	err := c.QueryStruct(queryCtx, "GET", internalTypes.PublicEndpoint, api.NewURL().Path("cluster"), nil, &clusterMembers)
+	err := c.QueryStruct(queryCtx, "GET", internalTypes.PublicEndpoint, &api.NewURL().Path("cluster").URL, nil, &clusterMembers)
 
 	return clusterMembers, err
 }
@@ -68,7 +68,7 @@ func (c *Client) DeleteClusterMember(ctx context.Context, name string, force boo
 		endpoint = endpoint.WithQuery("force", "1")
 	}
 
-	return c.QueryStruct(queryCtx, "DELETE", internalTypes.PublicEndpoint, endpoint, nil, nil)
+	return c.QueryStruct(queryCtx, "DELETE", internalTypes.PublicEndpoint, &endpoint.URL, nil, nil)
 }
 
 // UpdateCertificate sets a new keypair and CA.
@@ -77,5 +77,5 @@ func (c *Client) UpdateCertificate(ctx context.Context, name types.CertificateNa
 	defer cancel()
 
 	endpoint := api.NewURL().Path("cluster", "certificates", string(name))
-	return c.QueryStruct(queryCtx, "PUT", internalTypes.PublicEndpoint, endpoint, args, nil)
+	return c.QueryStruct(queryCtx, "PUT", internalTypes.PublicEndpoint, &endpoint.URL, args, nil)
 }

--- a/internal/rest/client/daemon.go
+++ b/internal/rest/client/daemon.go
@@ -16,5 +16,5 @@ func (c *Client) UpdateServers(ctx context.Context, config map[string]apiTypes.S
 	defer cancel()
 
 	endpoint := api.NewURL().Path("daemon", "servers")
-	return c.QueryStruct(queryCtx, "PUT", types.PublicEndpoint, endpoint, config, nil)
+	return c.QueryStruct(queryCtx, "PUT", types.PublicEndpoint, &endpoint.URL, config, nil)
 }

--- a/internal/rest/client/hooks.go
+++ b/internal/rest/client/hooks.go
@@ -15,7 +15,7 @@ func RunPreRemoveHook(ctx context.Context, c *Client, config internalTypes.HookR
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, api.NewURL().Path("hooks", string(internalTypes.PreRemove)), config, nil)
+	return c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, &api.NewURL().Path("hooks", string(internalTypes.PreRemove)).URL, config, nil)
 }
 
 // RunPostRemoveHook executes the PostRemove hook with the given configuration on the cluster member targeted by this client.
@@ -23,7 +23,7 @@ func RunPostRemoveHook(ctx context.Context, c *Client, config internalTypes.Hook
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, api.NewURL().Path("hooks", string(internalTypes.PostRemove)), config, nil)
+	return c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, &api.NewURL().Path("hooks", string(internalTypes.PostRemove)).URL, config, nil)
 }
 
 // RunNewMemberHook executes the OnNewMember hook with the given configuration on the cluster member targeted by this client.
@@ -31,7 +31,7 @@ func RunNewMemberHook(ctx context.Context, c *Client, config internalTypes.HookN
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, api.NewURL().Path("hooks", string(internalTypes.OnNewMember)), config, nil)
+	return c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, &api.NewURL().Path("hooks", string(internalTypes.OnNewMember)).URL, config, nil)
 }
 
 // RunOnDaemonConfigUpdateHook executes the OnDaemonConfigUpdate hook with the given configuration on the cluster member targeted by this client.
@@ -39,5 +39,5 @@ func RunOnDaemonConfigUpdateHook(ctx context.Context, c *Client, config *types.D
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, api.NewURL().Path("hooks", string(internalTypes.OnDaemonConfigUpdate)), config, nil)
+	return c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, &api.NewURL().Path("hooks", string(internalTypes.OnDaemonConfigUpdate)).URL, config, nil)
 }

--- a/internal/rest/client/ready.go
+++ b/internal/rest/client/ready.go
@@ -14,7 +14,7 @@ func (c *Client) CheckReady(ctx context.Context) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	err := c.QueryStruct(queryCtx, "GET", types.PublicEndpoint, api.NewURL().Path("ready"), nil, nil)
+	err := c.QueryStruct(queryCtx, "GET", types.PublicEndpoint, &api.NewURL().Path("ready").URL, nil, nil)
 
 	return err
 }

--- a/internal/rest/client/shutdown.go
+++ b/internal/rest/client/shutdown.go
@@ -14,5 +14,5 @@ func (c *Client) ShutdownDaemon(ctx context.Context) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "POST", types.ControlEndpoint, api.NewURL().Path("shutdown"), nil, nil)
+	return c.QueryStruct(queryCtx, "POST", types.ControlEndpoint, &api.NewURL().Path("shutdown").URL, nil, nil)
 }

--- a/internal/rest/client/sql.go
+++ b/internal/rest/client/sql.go
@@ -21,7 +21,7 @@ func GetSQL(ctx context.Context, c *Client, schema bool) (*types.SQLDump, error)
 		endpoint.WithQuery("schema", "1")
 	}
 
-	err := c.QueryStruct(reqCtx, "GET", types.InternalEndpoint, endpoint, nil, dump)
+	err := c.QueryStruct(reqCtx, "GET", types.InternalEndpoint, &endpoint.URL, nil, dump)
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +35,7 @@ func PostSQL(ctx context.Context, c *Client, query types.SQLQuery) (*types.SQLBa
 	defer cancel()
 
 	batch := &types.SQLBatch{}
-	err := c.QueryStruct(reqCtx, "POST", types.InternalEndpoint, api.NewURL().Path("sql"), query, batch)
+	err := c.QueryStruct(reqCtx, "POST", types.InternalEndpoint, &api.NewURL().Path("sql").URL, query, batch)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/rest/client/tokens.go
+++ b/internal/rest/client/tokens.go
@@ -16,7 +16,7 @@ func (c *Client) RequestToken(ctx context.Context, name string, expireAfter time
 
 	var token string
 	tokenRecord := types.TokenRequest{Name: name, ExpireAfter: expireAfter}
-	err := c.QueryStruct(queryCtx, "POST", types.ControlEndpoint, api.NewURL().Path("tokens"), tokenRecord, &token)
+	err := c.QueryStruct(queryCtx, "POST", types.ControlEndpoint, &api.NewURL().Path("tokens").URL, tokenRecord, &token)
 
 	return token, err
 }
@@ -26,7 +26,7 @@ func (c *Client) DeleteTokenRecord(ctx context.Context, name string) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	err := c.QueryStruct(queryCtx, "DELETE", types.PublicEndpoint, api.NewURL().Path("tokens", name), nil, nil)
+	err := c.QueryStruct(queryCtx, "DELETE", types.PublicEndpoint, &api.NewURL().Path("tokens", name).URL, nil, nil)
 
 	return err
 }
@@ -37,7 +37,7 @@ func (c *Client) GetTokenRecords(ctx context.Context) ([]types.TokenRecord, erro
 	defer cancel()
 
 	tokenRecords := []types.TokenRecord{}
-	err := c.QueryStruct(queryCtx, "GET", types.ControlEndpoint, api.NewURL().Path("tokens"), nil, &tokenRecords)
+	err := c.QueryStruct(queryCtx, "GET", types.ControlEndpoint, &api.NewURL().Path("tokens").URL, nil, &tokenRecords)
 
 	return tokenRecords, err
 }

--- a/internal/rest/client/truststore.go
+++ b/internal/rest/client/truststore.go
@@ -15,7 +15,7 @@ func AddTrustStoreEntry(ctx context.Context, c *Client, args types.ClusterMember
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, api.NewURL().Path("truststore"), args, nil)
+	return c.QueryStruct(queryCtx, "POST", internalTypes.InternalEndpoint, &api.NewURL().Path("truststore").URL, args, nil)
 }
 
 // DeleteTrustStoreEntry deletes the record corresponding to the given cluster member from the trust store.
@@ -23,5 +23,5 @@ func DeleteTrustStoreEntry(ctx context.Context, c *Client, name string) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	return c.QueryStruct(queryCtx, "DELETE", internalTypes.InternalEndpoint, api.NewURL().Path("truststore", name), nil, nil)
+	return c.QueryStruct(queryCtx, "DELETE", internalTypes.InternalEndpoint, &api.NewURL().Path("truststore", name).URL, nil, nil)
 }


### PR DESCRIPTION
A cosmetic followup on https://github.com/canonical/microcluster/issues/503.

In order to use the exposed client funcs (e.g. `Query` and `Websocket`), the URL required to use LXD's shared `api.URL` type with helpers around the standard `url.URL`. 
As it's in the `shared` package reuse is desired but let's also drop this dependency to be fully decoupled from a users perspective of Microcluster as this single type doesn't justify importing the LXD dep.

To not require any user of Microcluster to import `github.com/canonical/lxd` just to use the query functions, we fallback to the standard `url.URL`.
But this doesn't prevent us internally from using LXD's "extended" struct as we can always pass the underlying struct when requested as it's embedded by `api.URL`.