### PR TITLE
Proxy: Support Websockets

### DIFF
--- a/example/api/extended.go
+++ b/example/api/extended.go
@@ -35,8 +35,9 @@ var extendedWebsocketCmd = rest.Endpoint{
 	},
 }
 
+// This is the POST handler for the /1.0/extended/simple endpoint.
 // This example shows how to forward a request to other cluster members.
-func cmdPost(state state.State, r *http.Request) response.Response {
+func cmdSimple(state state.State, r *http.Request) response.Response {
 	// Check the user agent header to check if we are the notifying cluster member.
 	if !client.IsNotification(r) {
 		// Get a collection of clients every other cluster member, with the notification user-agent set.
@@ -55,11 +56,11 @@ func cmdPost(state state.State, r *http.Request) response.Response {
 			// Our payload in this case is defined by us as ExtendedType.
 			data := &extendedTypes.ExtendedType{
 				Sender:  addrPort,
-				Message: "Testing 1 2 3...",
+				Message: "Testing ...",
 			}
 
-			// Asynchronously send a POST on /1.0/extended to each other cluster member.
-			outMessage, err := extendedClient.ExtendedPostCmd(ctx, c, data)
+			// Asynchronously send a POST on /1.0/extended/simple to each other cluster member.
+			outMessage, err := extendedClient.ExtendedSimpleCmd(ctx, c, data)
 			if err != nil {
 				clientURL := c.URL()
 				return fmt.Errorf("Failed to POST to cluster member with address %q: %w", clientURL.String(), err)

--- a/example/api/extended.go
+++ b/example/api/extended.go
@@ -3,8 +3,12 @@ package api
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
+	"time"
+
+	"github.com/gorilla/websocket"
 
 	"github.com/canonical/microcluster/v3/client"
 	extendedTypes "github.com/canonical/microcluster/v3/example/api/types"
@@ -94,4 +98,38 @@ func cmdSimple(state state.State, r *http.Request) response.Response {
 	message := fmt.Sprintf("cluster member at address %q received message %q from cluster member at address %q", state.Address().URL.Host, info.Message, info.Sender.String())
 
 	return response.SyncResponse(true, message)
+}
+
+// This is the GET handler for the /1.0/extended/websocket endpoint.
+// This example shows how to use websockets.
+func cmdWebsocket(state state.State, r *http.Request) response.Response {
+	if r.Header.Get("Upgrade") == "websocket" {
+		var upgrader = websocket.Upgrader{
+			ReadBufferSize:  1024,
+			WriteBufferSize: 1024,
+		}
+
+		return response.ManualResponse(func(w http.ResponseWriter) error {
+			conn, err := upgrader.Upgrade(w, r, nil)
+			if err != nil {
+				return err
+			}
+
+			defer conn.Close()
+
+			for i := range 3 {
+				text := fmt.Sprintf("Testing from %q, iteration %d ...", state.Address().URL.Host, i+1)
+				err := conn.WriteMessage(websocket.TextMessage, []byte(text))
+				if err != nil {
+					return err
+				}
+
+				time.Sleep(time.Second)
+			}
+
+			return nil
+		})
+	}
+
+	return response.BadRequest(errors.New("Missing websocket upgrade header"))
 }

--- a/example/api/extended.go
+++ b/example/api/extended.go
@@ -25,7 +25,16 @@ var extendedSimpleCmd = rest.Endpoint{
 	},
 }
 
-// This is the POST handler for the /1.0/extended endpoint.
+// This is an example extended endpoint reachable at /1.0/extended/websocket.
+var extendedWebsocketCmd = rest.Endpoint{
+	Path: "extended/websocket",
+	Get: rest.EndpointAction{
+		Handler:        cmdWebsocket,
+		AllowUntrusted: true,
+		ProxyTarget:    true,
+	},
+}
+
 // This example shows how to forward a request to other cluster members.
 func cmdPost(state state.State, r *http.Request) response.Response {
 	// Check the user agent header to check if we are the notifying cluster member.

--- a/example/api/extended.go
+++ b/example/api/extended.go
@@ -15,10 +15,14 @@ import (
 	"github.com/canonical/microcluster/v3/state"
 )
 
-// This is an example extended endpoint reachable at /1.0/extended.
-var extendedCmd = rest.Endpoint{
-	Path: "extended",
-	Post: rest.EndpointAction{Handler: cmdPost, AllowUntrusted: true},
+// This is an example extended endpoint reachable at /1.0/extended/simple.
+var extendedSimpleCmd = rest.Endpoint{
+	Path: "extended/simple",
+	Post: rest.EndpointAction{
+		Handler:        cmdSimple,
+		AllowUntrusted: true,
+		ProxyTarget:    true,
+	},
 }
 
 // This is the POST handler for the /1.0/extended endpoint.

--- a/example/api/servers.go
+++ b/example/api/servers.go
@@ -17,7 +17,8 @@ var Servers = map[string]rest.Server{
 			{
 				PathPrefix: types.ExtendedPathPrefix,
 				Endpoints: []rest.Endpoint{
-					extendedCmd,
+					extendedSimpleCmd,
+					extendedWebsocketCmd,
 				},
 			},
 		},

--- a/example/client/client.go
+++ b/example/client/client.go
@@ -11,15 +11,15 @@ import (
 	"github.com/canonical/microcluster/v3/example/api/types"
 )
 
-// ExtendedPostCmd is a client function that sets a context timeout and sends a POST to /1.0/extended using the given
+// ExtendedSimpleCmd is a client function that sets a context timeout and sends a POST to /1.0/extended/simple using the given
 // client. This function is expected to be called from an api endpoint handler, which gives us access to the
 // daemon state, from which we can create a client.
-func ExtendedPostCmd(ctx context.Context, c *client.Client, data *types.ExtendedType) (string, error) {
+func ExtendedSimpleCmd(ctx context.Context, c *client.Client, data *types.ExtendedType) (string, error) {
 	queryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
 	defer cancel()
 
 	path := url.URL{
-		Path: "extended",
+		Path: "extended/simple",
 	}
 
 	var outStr string

--- a/example/client/client.go
+++ b/example/client/client.go
@@ -7,6 +7,8 @@ import (
 	"net/url"
 	"time"
 
+	"github.com/gorilla/websocket"
+
 	"github.com/canonical/microcluster/v3/client"
 	"github.com/canonical/microcluster/v3/example/api/types"
 )
@@ -30,4 +32,37 @@ func ExtendedSimpleCmd(ctx context.Context, c *client.Client, data *types.Extend
 	}
 
 	return outStr, nil
+}
+
+// ExtendedWebsocketCmd is a client function that sets a context timeout and sends a GET to /1.0/extended/websocket using the given
+// client. This function is expected to be called from an api endpoint handler, which gives us access to the
+// daemon state, from which we can create a client.
+func ExtendedWebsocketCmd(ctx context.Context, c *client.Client) error {
+	queryCtx, cancel := context.WithTimeout(ctx, time.Second*30)
+	defer cancel()
+
+	path := url.URL{
+		Path: "extended/websocket",
+	}
+
+	conn, err := c.Websocket(queryCtx, types.ExtendedPathPrefix, &path)
+	if err != nil {
+		return fmt.Errorf("Failed to create websocket connection: %w", err)
+	}
+
+	defer conn.Close()
+
+	for {
+		_, message, err := conn.ReadMessage()
+		if err != nil {
+			// If the server closes the connection, exit gracefully.
+			if websocket.IsCloseError(err, websocket.CloseAbnormalClosure) {
+				return nil
+			}
+
+			return fmt.Errorf("Failed to read message from websocket: %w", err)
+		}
+
+		fmt.Println(string(message))
+	}
 }

--- a/example/cmd/microctl/extended_cmd.go
+++ b/example/cmd/microctl/extended_cmd.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 
-	microClient "github.com/canonical/microcluster/v3/client"
 	"github.com/canonical/microcluster/v3/example/client"
 	"github.com/canonical/microcluster/v3/microcluster"
 )
@@ -14,17 +13,51 @@ type cmdExtended struct {
 	common *CmdControl
 }
 
+type cmdExtendedSimple struct {
+	common *CmdControl
+
+	flagTarget string
+}
+
+type cmdExtendedWebsocket struct {
+	common *CmdControl
+
+	flagTarget string
+}
+
 func (c *cmdExtended) command() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "extended <address>",
+		Use:   "extended",
 		Short: "An extended command not part of the default MicroCluster API",
 		RunE:  c.run,
 	}
+
+	var cmdSimple = cmdExtendedSimple{common: c.common}
+	cmd.AddCommand(cmdSimple.command())
+
+	var cmdWebsocket = cmdExtendedWebsocket{common: c.common}
+	cmd.AddCommand(cmdWebsocket.command())
 
 	return cmd
 }
 
 func (c *cmdExtended) run(cmd *cobra.Command, args []string) error {
+	return cmd.Help()
+}
+
+func (c *cmdExtendedSimple) command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "simple",
+		Short: "Send a simple request",
+		RunE:  c.run,
+	}
+
+	cmd.Flags().StringVar(&c.flagTarget, "target", "", "target cluster member for sending the simple request")
+
+	return cmd
+}
+
+func (c *cmdExtendedSimple) run(cmd *cobra.Command, args []string) error {
 	if len(args) > 1 {
 		return cmd.Help()
 	}
@@ -37,23 +70,63 @@ func (c *cmdExtended) run(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	var cli *microClient.Client
-	if len(args) == 1 {
-		cli, err = m.RemoteClient(args[0])
-	} else {
-		cli, err = m.LocalClient()
-	}
-
+	cli, err := m.LocalClient()
 	if err != nil {
 		return err
 	}
 
-	outMsg, err := client.ExtendedPostCmd(cmd.Context(), cli, nil)
+	if c.flagTarget != "" {
+		cli = cli.UseTarget(c.flagTarget)
+	}
+
+	outMsg, err := client.ExtendedSimpleCmd(cmd.Context(), cli, nil)
 	if err != nil {
 		return err
 	}
 
 	fmt.Print(outMsg)
+
+	return nil
+}
+
+func (c *cmdExtendedWebsocket) command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "websocket",
+		Short: "Send a websocket request",
+		RunE:  c.run,
+	}
+
+	cmd.Flags().StringVar(&c.flagTarget, "target", "", "target cluster member for sending the websocket request")
+
+	return cmd
+}
+
+func (c *cmdExtendedWebsocket) run(cmd *cobra.Command, args []string) error {
+	if len(args) > 1 {
+		return cmd.Help()
+	}
+
+	m, err := microcluster.App(microcluster.Args{
+		LogHandler: logHandler,
+		StateDir:   c.common.FlagStateDir,
+	})
+	if err != nil {
+		return err
+	}
+
+	cli, err := m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	if c.flagTarget != "" {
+		cli = cli.UseTarget(c.flagTarget)
+	}
+
+	err = client.ExtendedWebsocketCmd(cmd.Context(), cli)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/example/test/main.sh
+++ b/example/test/main.sh
@@ -403,6 +403,37 @@ test_join_token_before_cluster_formed() {
   shutdown_systems
 }
 
+test_extended_endpoints() {
+  new_systems 4 --heartbeat 2s
+
+  # Bootstrap initial cluster.
+  microctl --state-dir "${test_dir}/c1" init "c1" 127.0.0.1:9001 --bootstrap
+
+  # Get join tokens for the other cluster members.
+  token_c2=$(microctl --state-dir "${test_dir}/c1" tokens add "c2")
+  token_c3=$(microctl --state-dir "${test_dir}/c1" tokens add "c3")
+  token_c4=$(microctl --state-dir "${test_dir}/c1" tokens add "c4")
+
+  # Join the cluster members.
+  microctl --state-dir "${test_dir}/c2" init "c2" 127.0.0.1:9002 --token "${token_c2}"
+  microctl --state-dir "${test_dir}/c3" init "c3" 127.0.0.1:9003 --token "${token_c3}"
+  microctl --state-dir "${test_dir}/c4" init "c4" 127.0.0.1:9004 --token "${token_c4}"
+
+  # Test the extended simple endpoint.
+  microctl --state-dir "${test_dir}/c1" extended simple
+  for i in 1 2 3 4; do
+    microctl --state-dir "${test_dir}/c1" extended simple --target "c${i}"
+  done
+
+  # Test the extended websocket endpoint.
+  microctl --state-dir "${test_dir}/c1" extended websocket
+  for i in 1 2 3 4; do
+    microctl --state-dir "${test_dir}/c1" extended websocket --target "c${i}"
+  done
+
+  shutdown_systems
+}
+
 # allow for running a specific set of tests
 if [ "${1:-"all"}" = "all" ] || [ "${1}" = "" ]; then
   test_misc
@@ -410,6 +441,7 @@ if [ "${1:-"all"}" = "all" ] || [ "${1}" = "" ]; then
   test_recover
   test_join_token_after_cluster_formed
   test_join_token_before_cluster_formed
+  test_extended_endpoints
 elif [ "${1}" = "recover" ]; then
   test_recover
 elif [ "${1}" = "tokens" ]; then
@@ -420,6 +452,8 @@ elif [ "${1}" = "join-after" ]; then
   test_join_token_after_cluster_formed
 elif [ "${1}" = "join-before" ]; then
   test_join_token_before_cluster_formed
+elif [ "${1}" = "extended" ]; then
+  test_extended_endpoints
 else
   echo "Unknown test ${1}"
 fi

--- a/internal/rest/rest.go
+++ b/internal/rest/rest.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 
 	"github.com/canonical/lxd/shared/api"
+	"github.com/canonical/lxd/shared/ws"
 	"github.com/gorilla/mux"
 
 	"github.com/canonical/microcluster/v3/cluster"
@@ -113,7 +114,7 @@ func proxyTarget(action rest.EndpointAction, s state.State, r *http.Request) res
 
 	client, err := client.New(*targetURL, s.ServerCert(), clusterCert, false)
 	if err != nil {
-		return response.InternalError(fmt.Errorf("Failed to get a client for the target %q at address %q: %w", target, targetURL.String(), err))
+		return response.InternalError(fmt.Errorf("Failed to get a client for the target %q at address %q: %w", target, targetURL.URL.Host, err))
 	}
 
 	// Update request URL.
@@ -123,6 +124,37 @@ func proxyTarget(action rest.EndpointAction, s state.State, r *http.Request) res
 	r.Host = targetURL.URL.Host
 
 	logger.Info("Forwarding request to specified target", slog.String("source", s.Name()), slog.String("target", target))
+
+	// Upgrade the connection and setup a websocket proxy if requested by the client.
+	if r.Header.Get("Upgrade") == "websocket" {
+		// Perform the websocket proxy.
+		return response.ManualResponse(func(w http.ResponseWriter) error {
+			connToSource, err := ws.Upgrader.Upgrade(w, r, nil)
+			if err != nil {
+				return fmt.Errorf("Failed to upgrade connection to websocket: %w", err)
+			}
+
+			// Close connection to source when the proxy returns.
+			defer connToSource.Close()
+
+			// Set an empty endpoint prefix to support all target URLs.
+			// In case the client set an endpoint prefix, it's already included in the request URL.
+			// Use the actual request URL to retain query parameters.
+			connToTarget, err := client.RawWebsocket(r.Context(), "", r.URL)
+			if err != nil {
+				return fmt.Errorf("Failed to upgrade connection for the target %q at address %q to websocket: %w", target, targetURL.URL.Host, err)
+			}
+
+			// Close connection to target when the proxy returns.
+			defer connToTarget.Close()
+
+			<-ws.Proxy(connToTarget, connToSource)
+
+			return nil
+		})
+	}
+
+	// Use the actual request URL to retain query parameters.
 	resp, err := client.MakeRequest(r)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Failed to send request to target %q: %w", target, err))


### PR DESCRIPTION
When enabling `ProxyTarget` on an `EndpointAction`, Microcluster should also be able to forward websocket connections. 

This PR enables this in a non breaking approach which allows backporting this to `v2` so that MicroCloud v2 can make use of it when talking to LXD 6.6+ servers that now return operations when creating volumes.
Furthermore a new test suite is added to check the extended endpoints and the proxy functionality for both regular HTTP requests and websockets.

The actual new functionality is the first commit in this PR.
In the other commits I have reworked the example package a bit so that the extended endpoints make use of the proxy and can then be used later on in the new test suite.