### PR TITLE
internal/db: keep dqlite app alive across Open retries

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -39,19 +39,6 @@ func (db *DqliteDB) Open(ext extensions.Extensions, bootstrap bool) error {
 	reverter := revert.New()
 	defer reverter.Fail()
 
-	reverter.Add(func() {
-		db.statusLock.Lock()
-		db.status = types.DatabaseOffline
-		db.statusLock.Unlock()
-		// close the db if any of the following steps fail
-		closeErr := db.dqlite.Close()
-		if closeErr != nil {
-			db.log().Error("Failed to close database", slog.String("address", db.listenAddr.String()), slog.String("error", closeErr.Error()))
-		}
-
-		db.db = nil
-	})
-
 	err := db.dqlite.Ready(ctx)
 	if err != nil {
 		return fmt.Errorf("Ready dqlite: %w", err)
@@ -62,6 +49,19 @@ func (db *DqliteDB) Open(ext extensions.Extensions, bootstrap bool) error {
 		if err != nil {
 			return fmt.Errorf("Open dqlite: %w", err)
 		}
+
+		// Add reverter only after successfully opening db.db
+		reverter.Add(func() {
+			db.statusLock.Lock()
+			db.status = types.DatabaseOffline
+			db.statusLock.Unlock()
+			closeErr := db.db.Close()
+			if closeErr != nil {
+				db.log().Error("Failed to close database", slog.String("address", db.listenAddr.String()), slog.String("error", closeErr.Error()))
+			}
+
+			db.db = nil
+		})
 	}
 
 	err = db.waitUpgrade(bootstrap, ext)

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -161,6 +161,21 @@ func (db *DqliteDB) Bootstrap(extensions extensions.Extensions, addr api.URL, cl
 		return fmt.Errorf("Failed to bootstrap dqlite: %w", err)
 	}
 
+	// Only close the dqlite app if the entire Bootstrap process fails or exits.
+	// dqlite.Close() immediately tears down all Raft connections and removes this node from the dqlite cluster.
+	reverter := revert.New()
+	defer reverter.Fail()
+	reverter.Add(func() {
+		if db.dqlite != nil {
+			closeErr := db.dqlite.Close()
+			if closeErr != nil {
+				db.log().Error("Failed to close dqlite app", slog.String("address", db.listenAddr.String()), slog.String("error", closeErr.Error()))
+			}
+
+			db.dqlite = nil
+		}
+	})
+
 	err = db.Open(extensions, true)
 	if err != nil {
 		return err
@@ -177,6 +192,7 @@ func (db *DqliteDB) Bootstrap(extensions extensions.Extensions, addr api.URL, cl
 		return err
 	}
 
+	reverter.Success()
 	return nil
 }
 
@@ -196,6 +212,22 @@ func (db *DqliteDB) Join(extensions extensions.Extensions, addr api.URL, joinAdd
 		return fmt.Errorf("Failed to join dqlite cluster %w", err)
 	}
 
+	// Only close the dqlite app if the entire Join process fails or exits.
+	// This ensures dqlite.Close() is not called on every Open() retry, but only if we fully give up joining.
+	// dqlite.Close() immediately tears down all Raft connections and removes this node from the dqlite cluster.
+	reverter := revert.New()
+	defer reverter.Fail()
+	reverter.Add(func() {
+		if db.dqlite != nil {
+			closeErr := db.dqlite.Close()
+			if closeErr != nil {
+				db.log().Error("Failed to close dqlite app", slog.String("address", db.listenAddr.String()), slog.String("error", closeErr.Error()))
+			}
+
+			db.dqlite = nil
+		}
+	})
+
 	for {
 		err := db.Open(extensions, false)
 		if err == nil {
@@ -212,6 +244,7 @@ func (db *DqliteDB) Join(extensions extensions.Extensions, addr api.URL, joinAdd
 		return err
 	}
 
+	reverter.Success()
 	return nil
 }
 


### PR DESCRIPTION
# fix(db/join): keep dqlite app alive across Open retries

- Fix panic during schema upgrade wait by keeping the dqlite app alive across Open() retries.
- Open(): add reverter only after successfully opening [db.db](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), and close only [db.db](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) on failure.
- Join(): add reverter to close [dqlite](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) only if the entire join process exits/fails.
- Clarifies lifecycle ownership (Join owns [dqlite](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html), Open owns sql.DB) and prevents bind-address connection panic.

Related: #544 (regression from #487).