### PR TITLE
Sys: Fix missing hosts in server certificate

### DIFF
--- a/internal/sys/os.go
+++ b/internal/sys/os.go
@@ -118,7 +118,8 @@ func (s *OS) DatabasePath() string {
 
 // ServerCert gets the local server certificate from the state directory.
 func (s *OS) ServerCert() (*shared.CertInfo, error) {
-	cert, err := shared.KeyPairAndCA(s.stateDir, string(types.ServerCertificateName), shared.CertServer, shared.CertOptions{})
+	// Make sure to populate the certificates SAN.
+	cert, err := shared.KeyPairAndCA(s.stateDir, string(types.ServerCertificateName), shared.CertServer, shared.CertOptions{AddHosts: true})
 	if err != nil {
 		return nil, fmt.Errorf("Failed to load TLS certificate: %w", err)
 	}


### PR DESCRIPTION
A regression was introduced in https://github.com/canonical/microcluster/pull/526/commits/fd2bc7656d079f127d5572f031806f84a1677643 when trying to remove dependencies to LXD's util package.

The original util.LoadServerCert func also calls shared.KeyPairAndCA but with CertOptions{AddHosts:true}. This was missed when running shared.KeyPairAndCA directly which causes the Microcluster server certificate not being populated with the respective SAN.

This only affects Microcluster v3/edge as it was never backported and was identified when testing MicroCloud v3 using latest Microcluster.