### PR TITLE
Response: Remove odd response body discard reader

### DIFF
--- a/microcluster/types/response.go
+++ b/microcluster/types/response.go
@@ -5,7 +5,6 @@ import (
 	"database/sql"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"os"
 
@@ -235,10 +234,6 @@ func ParseResponse(resp *http.Response) (*api.Response, error) {
 
 	err := decoder.Decode(&response)
 	if err != nil {
-		if resp.StatusCode != http.StatusOK {
-			return nil, fmt.Errorf("Failed to fetch %q: %q", resp.Request.URL.String(), resp.Status)
-		}
-
 		return nil, err
 	}
 

--- a/microcluster/types/response.go
+++ b/microcluster/types/response.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 
@@ -229,6 +228,8 @@ func IsNotFoundError(err error) bool {
 
 // ParseResponse takes an HTTP response, parses it and returns the extracted result.
 func ParseResponse(resp *http.Response) (*api.Response, error) {
+	defer resp.Body.Close()
+
 	decoder := json.NewDecoder(resp.Body)
 	response := api.Response{}
 
@@ -243,12 +244,6 @@ func ParseResponse(resp *http.Response) (*api.Response, error) {
 
 	if response.Type == api.ErrorResponse {
 		return nil, api.StatusErrorf(resp.StatusCode, "%s", response.Error)
-	}
-
-	defer resp.Body.Close()
-	_, err = io.Copy(io.Discard, resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to read response body: %w", err)
 	}
 
 	return &response, nil


### PR DESCRIPTION
The ParseResponse function always reads from the response which invalidates the purpose of the body discard reader.
It's good Go practice to always read the response and then close the body but not anymore required in this case.

As a neat side effect we remove the logging statement from the client func which is odd anyway as such an error should rather be returned directly and not logged as this func is not only used as part of the daemon (which has an initialized logger) but can also be called by clients directly.