### PR TITLE
Fix SelectRandom panic on empty clusters (v3 Breaking Change)

### DIFF
--- a/client/cluster.go
+++ b/client/cluster.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"sync"
 )
@@ -10,8 +11,18 @@ import (
 type Cluster []Client
 
 // SelectRandom returns a randomly selected client.
-func (c Cluster) SelectRandom() Client {
-	return c[rand.Intn(len(c))]
+func (c Cluster) SelectRandom() (*Client, error) {
+	switch len(c) {
+	case 0:
+		// Returns an error if the cluster is uninitialized (not bootstrapped, not joined).
+		return nil, fmt.Errorf("Cluster is uninitialized or has no members")
+	case 1:
+		// Returns the only available client if cluster size is 1.
+		return &c[0], nil
+	default:
+		// Returns a randomly selected client for clusters with multiple members.
+		return &c[rand.Intn(len(c))], nil
+	}
 }
 
 // Query executes the given hook across all members of the cluster.

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -188,6 +188,11 @@ func (s *InternalState) Cluster(isNotification bool) (client.Cluster, error) {
 		}
 	}
 
+	// Return error if no other cluster members exist.
+	if len(clients) == 0 {
+		return nil, fmt.Errorf("No other cluster members available.")
+	}
+
 	return clients, nil
 }
 


### PR DESCRIPTION
## Problem

The existing SelectRandom() function panics when called on empty clusters due to rand.Intn(0) being invoked ([as mentioned in](https://github.com/canonical/microcluster/issues/432)). This occurs in three distinct cluster states:

    Fresh/uninitialized cluster (not bootstrapped, not joined) - len(c) == 0

    Single-node cluster - len(c) == 1 (works but unnecessary randomization)

    Multi-node cluster - len(c) > 1 (works as intended)

## Root Cause
SelectRandom() doesn't differentiate between cluster states and attempts random selection even when no clients are available, causing a runtime panic.
 
## Solution
Solution - v3 Breaking Change Approach
Fixes #432

This PR introduces a breaking change by modifying the SelectRandom() function signature to handle all cluster states gracefully with proper error handling:

**Updated Function Signature**
```
// Before (v2):
func (c Cluster) SelectRandom() Client

// After (v3):
func (c Cluster) SelectRandom() (*Client, error)
```
**Behavior Changes**
-Empty cluster: Returns (nil, error) with descriptive message instead of panicking
-Single-node cluster: Returns [(&client, nil)](vscode-file://vscode-app/snap/code/215/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) directly (optimized - no randomization needed)
-Multi-node cluster: Returns (&randomClient, nil) 

## Changes Made

-Modified SelectRandom() signature to return (*Client, error)
-Added proper error handling for uninitialized clusters
-Implemented state-aware logic with switch statement for optimal handling

## Migration Required
```
// Old v2 code:
client := cluster.SelectRandom() // Could panic

// New v3 code:
client, err := cluster.SelectRandom()
if err != nil {
    log.Printf("Failed to select client: %v", err)
    return err
}
// Use client safely...

```

## Next Steps
v2 compatible version: A separate PR will be created for v2 that maintains backward compatibility using the SelectRandomClient() approach. Which is [here](https://github.com/canonical/microcluster/pull/579)
