### PR TITLE
Move dqlite roles to core_cluster_member_roles

### DIFF
--- a/doc/status.md
+++ b/doc/status.md
@@ -25,6 +25,8 @@ Database is offline                | Set when the database is explicitly turned 
 
 # Dqlite roles
 
-The current Dqlite role is stored in the `role` column of `core_cluster_members`. It follows typical Dqlite roles (`voter`, `standby`, `spare`) with the addition of `PENDING` for systems that have recently joined the cluster, but have not yet received a heartbeat through the Dqlite roles adjustment hook.
-* At least 1 non-`PENDING` cluster member must be present to remove other members.
-* Once a heartbeat detects that a `PENDING` member exists in Dqlite, it will assign it the correct role.
+The current Dqlite role is stored in the `dqlite_role` column of `core_cluster_member_roles`. It follows typical
+Dqlite roles (`voter`, `standby`, `spare`) with the addition of `PENDING` for systems that have recently joined
+the cluster, but have not yet received a heartbeat through the Dqlite roles adjustment hook. At least 1
+non-`PENDING` cluster member must be present to remove other members. Once a heartbeat detects that a `PENDING`
+member exists in Dqlite, it will assign it the correct role.

--- a/internal/cluster/cluster_members.go
+++ b/internal/cluster/cluster_members.go
@@ -87,10 +87,11 @@ WHERE name IN ('api_extensions');
 	}
 
 	// Fetch all cluster members with a smaller schema version than we expect.
-	stmt = `SELECT id, name, address, certificate, schema_internal, schema_external, %s, heartbeat, role
+	stmt = fmt.Sprintf(`SELECT id, name, address, certificate, schema_internal, schema_external, %s, heartbeat, core_cluster_member_roles.dqlite_role
   FROM %s
+  JOIN core_cluster_member_roles ON core_cluster_member_roles.member_id = %s.id
   ORDER BY name
-	`
+	`, "%s", tableName, tableName)
 
 	// If API extensions are supported, ensure the list for each cluster member also matches what we expect,
 	// and only return cluster members for whom it does not.
@@ -99,7 +100,7 @@ WHERE name IN ('api_extensions');
 		apiField = "api_extensions"
 	}
 
-	stmt = fmt.Sprintf(stmt, apiField, tableName)
+	stmt = fmt.Sprintf(stmt, apiField)
 	allMembers, err = getCoreClusterMembersRaw(ctx, tx, stmt)
 	if err != nil {
 		return nil, nil, err

--- a/internal/cluster/cluster_members.mapper.go
+++ b/internal/cluster/cluster_members.mapper.go
@@ -16,21 +16,24 @@ import (
 var _ = api.ServerEnvironment{}
 
 var coreClusterMemberObjects = clusterDB.RegisterStmt(`
-SELECT core_cluster_members.id, core_cluster_members.name, core_cluster_members.address, core_cluster_members.certificate, core_cluster_members.schema_internal, core_cluster_members.schema_external, core_cluster_members.api_extensions, core_cluster_members.heartbeat, core_cluster_members.role
+SELECT core_cluster_members.id, core_cluster_members.name, core_cluster_members.address, core_cluster_members.certificate, core_cluster_members.schema_internal, core_cluster_members.schema_external, core_cluster_members.api_extensions, core_cluster_members.heartbeat, core_cluster_member_roles.dqlite_role
   FROM core_cluster_members
+  JOIN core_cluster_member_roles ON core_cluster_member_roles.member_id = core_cluster_members.id
   ORDER BY core_cluster_members.name
 `)
 
 var coreClusterMemberObjectsByAddress = clusterDB.RegisterStmt(`
-SELECT core_cluster_members.id, core_cluster_members.name, core_cluster_members.address, core_cluster_members.certificate, core_cluster_members.schema_internal, core_cluster_members.schema_external, core_cluster_members.api_extensions, core_cluster_members.heartbeat, core_cluster_members.role
+SELECT core_cluster_members.id, core_cluster_members.name, core_cluster_members.address, core_cluster_members.certificate, core_cluster_members.schema_internal, core_cluster_members.schema_external, core_cluster_members.api_extensions, core_cluster_members.heartbeat, core_cluster_member_roles.dqlite_role
   FROM core_cluster_members
+  JOIN core_cluster_member_roles ON core_cluster_member_roles.member_id = core_cluster_members.id
   WHERE ( core_cluster_members.address = ? )
   ORDER BY core_cluster_members.name
 `)
 
 var coreClusterMemberObjectsByName = clusterDB.RegisterStmt(`
-SELECT core_cluster_members.id, core_cluster_members.name, core_cluster_members.address, core_cluster_members.certificate, core_cluster_members.schema_internal, core_cluster_members.schema_external, core_cluster_members.api_extensions, core_cluster_members.heartbeat, core_cluster_members.role
+SELECT core_cluster_members.id, core_cluster_members.name, core_cluster_members.address, core_cluster_members.certificate, core_cluster_members.schema_internal, core_cluster_members.schema_external, core_cluster_members.api_extensions, core_cluster_members.heartbeat, core_cluster_member_roles.dqlite_role
   FROM core_cluster_members
+  JOIN core_cluster_member_roles ON core_cluster_member_roles.member_id = core_cluster_members.id
   WHERE ( core_cluster_members.name = ? )
   ORDER BY core_cluster_members.name
 `)
@@ -41,8 +44,13 @@ SELECT core_cluster_members.id FROM core_cluster_members
 `)
 
 var coreClusterMemberCreate = clusterDB.RegisterStmt(`
-INSERT INTO core_cluster_members (name, address, certificate, schema_internal, schema_external, api_extensions, heartbeat, role)
-  VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+INSERT INTO core_cluster_members (name, address, certificate, schema_internal, schema_external, api_extensions, heartbeat)
+  VALUES (?, ?, ?, ?, ?, ?, ?)
+`)
+
+var coreClusterMemberRoleCreate = clusterDB.RegisterStmt(`
+INSERT INTO core_cluster_member_roles (member_id, control_plane, dqlite_role)
+  VALUES (?, ?, ?)
 `)
 
 var coreClusterMemberDeleteByAddress = clusterDB.RegisterStmt(`
@@ -51,8 +59,14 @@ DELETE FROM core_cluster_members WHERE address = ?
 
 var coreClusterMemberUpdate = clusterDB.RegisterStmt(`
 UPDATE core_cluster_members
-  SET name = ?, address = ?, certificate = ?, schema_internal = ?, schema_external = ?, api_extensions = ?, heartbeat = ?, role = ?
+  SET name = ?, address = ?, certificate = ?, schema_internal = ?, schema_external = ?, api_extensions = ?, heartbeat = ?
  WHERE id = ?
+`)
+
+var coreClusterMemberRoleUpdate = clusterDB.RegisterStmt(`
+UPDATE core_cluster_member_roles
+  SET dqlite_role = ?
+ WHERE member_id = ?
 `)
 
 // getCoreClusterMembers can be used to run handwritten sql.Stmts to return a slice of objects.
@@ -260,7 +274,7 @@ func CreateCoreClusterMember(ctx context.Context, tx *sql.Tx, object CoreCluster
 		return -1, api.StatusErrorf(http.StatusConflict, "This \"core_cluster_members\" entry already exists")
 	}
 
-	args := make([]any, 8)
+	args := make([]any, 7)
 
 	// Populate the statement arguments.
 	args[0] = object.Name
@@ -270,7 +284,6 @@ func CreateCoreClusterMember(ctx context.Context, tx *sql.Tx, object CoreCluster
 	args[4] = object.SchemaExternal
 	args[5] = object.APIExtensions
 	args[6] = object.Heartbeat
-	args[7] = object.Role
 
 	// Prepared statement to use.
 	stmt, err := clusterDB.Stmt(tx, coreClusterMemberCreate)
@@ -287,6 +300,16 @@ func CreateCoreClusterMember(ctx context.Context, tx *sql.Tx, object CoreCluster
 	id, err := result.LastInsertId()
 	if err != nil {
 		return -1, fmt.Errorf("Failed to fetch \"core_cluster_members\" entry ID: %w", err)
+	}
+
+	stmt, err = clusterDB.Stmt(tx, coreClusterMemberRoleCreate)
+	if err != nil {
+		return -1, fmt.Errorf("Failed to get \"coreClusterMemberRoleCreate\" prepared statement: %w", err)
+	}
+
+	_, err = stmt.Exec(id, 0, object.Role)
+	if err != nil {
+		return -1, fmt.Errorf("Failed to create \"core_cluster_member_roles\" entry: %w", err)
 	}
 
 	return id, nil
@@ -330,12 +353,31 @@ func UpdateCoreClusterMember(ctx context.Context, tx *sql.Tx, name string, objec
 		return fmt.Errorf("Failed to get \"coreClusterMemberUpdate\" prepared statement: %w", err)
 	}
 
-	result, err := stmt.Exec(object.Name, object.Address, object.Certificate, object.SchemaInternal, object.SchemaExternal, object.APIExtensions, object.Heartbeat, object.Role, id)
+	result, err := stmt.Exec(object.Name, object.Address, object.Certificate, object.SchemaInternal, object.SchemaExternal, object.APIExtensions, object.Heartbeat, id)
 	if err != nil {
 		return fmt.Errorf("Update \"core_cluster_members\" entry failed: %w", err)
 	}
 
 	n, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("Fetch affected rows: %w", err)
+	}
+
+	if n != 1 {
+		return fmt.Errorf("Query updated %d rows instead of 1", n)
+	}
+
+	stmt, err = clusterDB.Stmt(tx, coreClusterMemberRoleUpdate)
+	if err != nil {
+		return fmt.Errorf("Failed to get \"coreClusterMemberRoleUpdate\" prepared statement: %w", err)
+	}
+
+	result, err = stmt.Exec(object.Role, id)
+	if err != nil {
+		return fmt.Errorf("Update \"core_cluster_member_roles\" entry failed: %w", err)
+	}
+
+	n, err = result.RowsAffected()
 	if err != nil {
 		return fmt.Errorf("Fetch affected rows: %w", err)
 	}

--- a/internal/db/update/cluster.go
+++ b/internal/db/update/cluster.go
@@ -117,7 +117,7 @@ func GetClusterMemberSchemaVersions(ctx context.Context, tx *sql.Tx) (internalSc
 		return nil, nil, err
 	}
 
-	sql := fmt.Sprintf("SELECT schema_internal,schema_external FROM %s WHERE NOT role='pending'", tableName)
+	sql := fmt.Sprintf("SELECT %s.schema_internal,%s.schema_external FROM %s JOIN core_cluster_member_roles ON core_cluster_member_roles.member_id = %s.id WHERE NOT core_cluster_member_roles.dqlite_role='pending'", tableName, tableName, tableName, tableName)
 
 	internalSchema = []uint64{}
 	externalSchema = []uint64{}
@@ -199,7 +199,7 @@ func GetClusterMemberAPIExtensions(ctx context.Context, tx *sql.Tx) ([]extension
 		return nil, err
 	}
 
-	query := fmt.Sprintf("SELECT api_extensions FROM %s WHERE NOT role='pending'", table)
+	query := fmt.Sprintf("SELECT %s.api_extensions FROM %s JOIN core_cluster_member_roles ON core_cluster_member_roles.member_id = %s.id WHERE NOT core_cluster_member_roles.dqlite_role='pending'", table, table, table)
 	rows, err := tx.QueryContext(ctx, query)
 	if err != nil {
 		return nil, err

--- a/internal/db/update/cluster.go
+++ b/internal/db/update/cluster.go
@@ -117,7 +117,12 @@ func GetClusterMemberSchemaVersions(ctx context.Context, tx *sql.Tx) (internalSc
 		return nil, nil, err
 	}
 
-	sql := fmt.Sprintf("SELECT %s.schema_internal,%s.schema_external FROM %s JOIN core_cluster_member_roles ON core_cluster_member_roles.member_id = %s.id WHERE NOT core_cluster_member_roles.dqlite_role='pending'", tableName, tableName, tableName, tableName)
+	roleClause, roleField, err := roleSelectClause(ctx, tx, tableName)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	sql := fmt.Sprintf("SELECT %s.schema_internal,%s.schema_external FROM %s %s WHERE NOT %s='pending'", tableName, tableName, tableName, roleClause, roleField)
 
 	internalSchema = []uint64{}
 	externalSchema = []uint64{}
@@ -199,7 +204,12 @@ func GetClusterMemberAPIExtensions(ctx context.Context, tx *sql.Tx) ([]extension
 		return nil, err
 	}
 
-	query := fmt.Sprintf("SELECT %s.api_extensions FROM %s JOIN core_cluster_member_roles ON core_cluster_member_roles.member_id = %s.id WHERE NOT core_cluster_member_roles.dqlite_role='pending'", table, table, table)
+	roleClause, roleField, err := roleSelectClause(ctx, tx, table)
+	if err != nil {
+		return nil, err
+	}
+
+	query := fmt.Sprintf("SELECT %s.api_extensions FROM %s %s WHERE NOT %s='pending'", table, table, roleClause, roleField)
 	rows, err := tx.QueryContext(ctx, query)
 	if err != nil {
 		return nil, err
@@ -250,4 +260,29 @@ func getClusterTableName(ctx context.Context, tx *sql.Tx) (string, error) {
 	}
 
 	return tables[0], nil
+}
+
+func roleSelectClause(ctx context.Context, tx *sql.Tx, tableName string) (clause string, roleField string, err error) {
+	stmt := fmt.Sprintf("SELECT count(name) FROM pragma_table_info('%s') WHERE name IN ('role');", tableName)
+	var count int
+	err = tx.QueryRowContext(ctx, stmt).Scan(&count)
+	if err != nil {
+		return "", "", err
+	}
+
+	if count == 1 {
+		return "", "role", nil
+	}
+
+	stmt = "SELECT count(name) FROM sqlite_master WHERE type = 'table' AND name = 'core_cluster_member_roles'"
+	err = tx.QueryRowContext(ctx, stmt).Scan(&count)
+	if err != nil {
+		return "", "", err
+	}
+
+	if count != 1 {
+		return "", "", fmt.Errorf("No cluster member roles table found")
+	}
+
+	return fmt.Sprintf("JOIN core_cluster_member_roles ON core_cluster_member_roles.member_id = %s.id", tableName), "core_cluster_member_roles.dqlite_role", nil
 }

--- a/internal/db/update/update.go
+++ b/internal/db/update/update.go
@@ -37,6 +37,7 @@ func NewSchema() *SchemaUpdateManager {
 			mgr.updateFromV3,
 			updateFromV4,
 			updateFromV5,
+			updateFromV6,
 		},
 	}
 
@@ -92,6 +93,55 @@ ALTER TABLE core_token_records_new RENAME TO core_token_records;
 
 	_, err := tx.ExecContext(ctx, stmt)
 
+	return err
+}
+
+// updateFromV6 moves cluster member roles into a dedicated table.
+func updateFromV6(ctx context.Context, tx *sql.Tx) error {
+	stmt := `
+CREATE TABLE core_cluster_member_roles_new (
+  member_id     INTEGER  NOT NULL,
+  control_plane INTEGER  NOT NULL DEFAULT 0,
+  dqlite_role   TEXT     NOT NULL,
+  PRIMARY KEY (member_id)
+);
+
+INSERT INTO core_cluster_member_roles_new (member_id, control_plane, dqlite_role)
+SELECT id, 0, role FROM core_cluster_members;
+
+CREATE TABLE core_cluster_members_new (
+  id                   INTEGER   PRIMARY  KEY    AUTOINCREMENT  NOT  NULL,
+  name                 TEXT      NOT      NULL,
+  address              TEXT      NOT      NULL,
+  certificate          TEXT      NOT      NULL,
+  schema_internal      INTEGER   NOT      NULL,
+  schema_external      INTEGER   NOT      NULL,
+  api_extensions       TEXT      NOT      NULL DEFAULT '[]',
+  heartbeat            DATETIME  NOT      NULL,
+  UNIQUE(name),
+  UNIQUE(certificate)
+);
+
+INSERT INTO core_cluster_members_new (id, name, address, certificate, schema_internal, schema_external, api_extensions, heartbeat)
+SELECT id, name, address, certificate, schema_internal, schema_external, api_extensions, heartbeat FROM core_cluster_members;
+
+DROP TABLE core_cluster_members;
+ALTER TABLE core_cluster_members_new RENAME TO core_cluster_members;
+
+CREATE TABLE core_cluster_member_roles (
+  member_id     INTEGER  NOT NULL REFERENCES core_cluster_members(id) ON DELETE CASCADE,
+  control_plane INTEGER  NOT NULL DEFAULT 0,
+  dqlite_role   TEXT     NOT NULL,
+  PRIMARY KEY (member_id)
+);
+
+INSERT INTO core_cluster_member_roles (member_id, control_plane, dqlite_role)
+SELECT member_id, control_plane, dqlite_role FROM core_cluster_member_roles_new;
+
+DROP TABLE core_cluster_member_roles_new;
+`
+
+	_, err := tx.ExecContext(ctx, stmt)
 	return err
 }
 

--- a/internal/db/update/update_test.go
+++ b/internal/db/update/update_test.go
@@ -93,6 +93,50 @@ func (s *updateSuite) Test_updateFromV1ClusterMembers() {
 	s.NoError(db.Close())
 }
 
+// Ensures updateFromV6 moves roles to core_cluster_member_roles and drops the role column.
+func (s *updateSuite) Test_updateFromV6ClusterMemberRoles() {
+	db, err := sql.Open("sqlite3", ":memory:")
+	s.NoError(err)
+
+	ctx := context.Background()
+	mgr := NewSchema()
+	mgr.SetInternalUpdates([]clusterDB.Update{
+		updateFromV0,
+		updateFromV1,
+		updateFromV2,
+		mgr.updateFromV3,
+		updateFromV4,
+		updateFromV5,
+	})
+	mgr.SetExternalUpdates([]clusterDB.Update{})
+
+	_, err = mgr.Schema().Ensure(ctx, db)
+	s.NoError(err)
+
+	_, err = db.Exec(`INSERT INTO core_cluster_members (name, address, certificate, schema_internal, schema_external, api_extensions, heartbeat, role)
+VALUES (?, ?, ?, ?, ?, ?, ?, ?)`, "member-1", "10.0.0.1:8443", "cert-1", 1, 1, "[]", time.Time{}, "voter")
+	s.NoError(err)
+
+	tx, err := db.BeginTx(ctx, nil)
+	s.NoError(err)
+	s.NoError(updateFromV6(ctx, tx))
+	s.NoError(tx.Commit())
+
+	var count int
+	err = db.QueryRow("SELECT count(name) FROM pragma_table_info('core_cluster_members') WHERE name = 'role'").Scan(&count)
+	s.NoError(err)
+	s.Equal(0, count)
+
+	var role string
+	var controlPlane int
+	err = db.QueryRow("SELECT control_plane, dqlite_role FROM core_cluster_member_roles").Scan(&controlPlane, &role)
+	s.NoError(err)
+	s.Equal(0, controlPlane)
+	s.Equal("voter", role)
+
+	s.NoError(db.Close())
+}
+
 // Ensures the schema is properly split by the updateFromV1 function from various update patterns.
 func (s *updateSuite) Test_updateFromV1() {
 	dummyUpdate := func(ctx context.Context, tx *sql.Tx) error { return nil }


### PR DESCRIPTION
Introduces a dedicated `core_cluster_member_roles` table and migrates dqlite role storage out of `core_cluster_members`. Updates runtime queries and upgrade helpers to read/write roles from the new table, adds a migration test for update V6, and updates docs to reflect the new storage location.

Associated spec: https://docs.google.com/document/d/1qt5OPBW0NDGENWLKg5T3VYOhct1UCS6FUJ9RZ3kKPxg/edit?usp=sharing.
