### PR TITLE
Removes Cluster() returning error on single node cluster.

### DIFF
--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -261,7 +261,7 @@ func (s *InternalState) RandomMember(isNotification bool) (types.Client, error) 
 	switch clusterClientNum {
 	case 0:
 		// Returns an error if the cluster is uninitialized (not bootstrapped, not joined).
-		return nil, fmt.Errorf("Cluster is uninitialized or has no members")
+		return nil, fmt.Errorf("Cluster is uninitialized or has no other members")
 	case 1:
 		// Returns the only available client if cluster size is 1.
 		return clusterClients[0], nil

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -196,11 +196,6 @@ func (s *InternalState) Cluster(isNotification bool) (types.Clients, error) {
 		}
 	}
 
-	// Return error if no other cluster members exist.
-	if len(clients) == 0 {
-		return nil, fmt.Errorf("No other cluster members available.")
-	}
-
 	return clients, nil
 }
 


### PR DESCRIPTION
With a single node cluster the heartbeat code fails, which causes the heartbeat round to fail. This can be solved by reverting the changes done to Cluster() to allow it to return an empty list on a single node.