### PR TITLE
backport: v2 add consistency checks across core_cluster_members, truststore, and dqlite (#515)

### DIFF
--- a/example/test/main.sh
+++ b/example/test/main.sh
@@ -409,6 +409,140 @@ test_join_token_before_cluster_formed() {
   shutdown_systems
 }
 
+test_membership_consistency() {
+  echo "Testing membership consistency checks"
+  
+  new_systems 4 --heartbeat 2s
+  
+  # Bootstrap first member (daemon already running from new_systems)
+  microctl --state-dir "${test_dir}/c1" init "c1" 127.0.0.1:9001 --bootstrap
+  
+  # Join second member (daemon already running)
+  token_c2=$(microctl --state-dir "${test_dir}/c1" tokens add "c2")
+  microctl --state-dir "${test_dir}/c2" init "c2" 127.0.0.1:9002 --token "${token_c2}"
+
+  # Start third member and join cluster
+  token_c3=$(microctl --state-dir "${test_dir}/c1" tokens add "c3")
+  microctl --state-dir "${test_dir}/c3" init "c3" 127.0.0.1:9003 --token "${token_c3}"
+  
+  # Fetch join token for c4
+  token_c4=$(microctl --state-dir "${test_dir}/c1" tokens add "c4")
+
+  # Wait for cluster to stabilize
+  echo "  -> Waiting for cluster members to exit PENDING state"
+  
+  # Wait for all members to be promoted from PENDING
+  retry_count=0
+  max_retries=10
+  while [[ -n "$(microctl --state-dir "${test_dir}/c1" cluster list -f yaml | yq '.[] | select(.role == "PENDING")')" ]] && [[ ${retry_count} -lt ${max_retries} ]]; do
+    echo "  -> Still waiting for members to exit PENDING state..."
+    sleep 2
+    retry_count=$((retry_count + 1))
+  done
+  
+  echo "  -> Cluster established successfully"
+  
+  # Verify cluster is healthy
+  cluster_size=$(microctl --state-dir "${test_dir}/c1" cluster list -f yaml | yq '. | length')
+  if [ "${cluster_size}" != "3" ]; then
+    echo "ERROR: Expected cluster size 3, got ${cluster_size}"
+    exit 1
+  fi
+  
+  # Simulate inconsistent state by directly manipulating the database
+  # while keeping dqlite/truststore intact
+  echo "  -> Simulating inconsistent membership state"
+
+  # Remove c2's membership from core_cluster_members (simulating partial remove failure)
+  microctl --state-dir "${test_dir}/c1" sql "DELETE FROM core_cluster_members WHERE name = 'c2'"
+  
+  echo "  -> Created inconsistent state (c2 removed from database but still in truststore until heartbeat timeout)"
+
+  # Test member removal with inconsistent state
+  echo "  -> Testing member removal with inconsistent state"
+  if microctl --state-dir "${test_dir}/c1" cluster remove c2 2>/tmp/remove_error; then
+    echo "ERROR: Member removal should have failed due to inconsistent state"
+    cat /tmp/remove_error
+    exit 1
+  else
+    echo "  -> Member removal correctly blocked due to membership inconsistency"
+    cat /tmp/remove_error
+  fi
+  
+  # Try to join a new member - this should fail due to inconsistency
+  echo "  -> Testing join of new member c4 with inconsistent state"
+  if microctl --state-dir "${test_dir}/c4" init "c4" 127.0.0.1:9004 --token "${token_c4}" 2>/tmp/join_error; then
+    echo "ERROR: Member c4 should not have been able to join due to inconsistent state"
+    cat /tmp/join_error
+    exit 1
+  else
+    echo "  -> Membership inconsistency correctly detected, c4 join blocked"
+    cat /tmp/join_error
+  fi
+  
+  # Attempt to generate token should fail
+  echo "  -> Testing token generation with inconsistent state"
+  if microctl --state-dir "${test_dir}/c1" tokens add c5 2>/tmp/token_error; then
+    echo "ERROR: Token generation should have failed due to inconsistent state"
+    cat /tmp/token_error
+    exit 1
+  else
+    echo "  -> Token generation correctly blocked due to membership inconsistency"
+    cat /tmp/token_error
+  fi
+
+  echo "  -> Membership consistency checks working as expected"
+  
+  shutdown_systems
+}
+
+test_parallel_joins() {
+  echo "Testing parallel joins"
+
+  new_systems 4 --heartbeat 2s
+
+  # Bootstrap first member
+  microctl --state-dir "${test_dir}/c1" init "c1" 127.0.0.1:9001 --bootstrap
+
+  # Prepare tokens for remaining members
+  token_c2=$(microctl --state-dir "${test_dir}/c1" tokens add "c2")
+  token_c3=$(microctl --state-dir "${test_dir}/c1" tokens add "c3")
+  token_c4=$(microctl --state-dir "${test_dir}/c1" tokens add "c4")
+
+  # Kick off joins in parallel and collect PIDs
+  microctl --state-dir "${test_dir}/c2" init "c2" 127.0.0.1:9002 --token "${token_c2}" &
+  pids=($!)
+  microctl --state-dir "${test_dir}/c3" init "c3" 127.0.0.1:9003 --token "${token_c3}" &
+  pids+=($!)
+  microctl --state-dir "${test_dir}/c4" init "c4" 127.0.0.1:9004 --token "${token_c4}" &
+  pids+=($!)
+
+  for pid in "${pids[@]}"; do
+    if ! wait "${pid}"; then
+      echo "ERROR: parallel join failed (pid ${pid})"
+      return 1
+    fi
+  done
+
+  # Wait for cluster to stabilize
+  retry_count=0
+  max_retries=10
+  while [[ -n "$(microctl --state-dir "${test_dir}/c1" cluster list -f yaml | yq '.[] | select(.role == "PENDING")')" ]] && [[ ${retry_count} -lt ${max_retries} ]]; do
+    sleep 2
+    retry_count=$((retry_count + 1))
+  done
+
+  cluster_size=$(microctl --state-dir "${test_dir}/c1" cluster list -f yaml | yq '. | length')
+  if [ "${cluster_size}" != "4" ]; then
+    echo "ERROR: Expected cluster size 4 after parallel joins, got ${cluster_size}"
+    return 1
+  fi
+
+  echo "SUCCESS: parallel joins completed without failures"
+
+  shutdown_systems
+}
+
 test_extended_endpoints() {
   new_systems 4 --heartbeat 2s
 
@@ -448,6 +582,8 @@ if [ "${1:-"all"}" = "all" ] || [ "${1}" = "" ]; then
   test_join_token_after_cluster_formed
   test_join_token_before_cluster_formed
   test_extended_endpoints
+  test_membership_consistency
+  test_parallel_joins
 elif [ "${1}" = "recover" ]; then
   test_recover
 elif [ "${1}" = "tokens" ]; then
@@ -460,6 +596,10 @@ elif [ "${1}" = "join-before" ]; then
   test_join_token_before_cluster_formed
 elif [ "${1}" = "extended" ]; then
   test_extended_endpoints
+elif [ "${1}" = "membership" ]; then
+  test_membership_consistency
+elif [ "${1}" = "parallel-join" ]; then
+  test_parallel_joins
 else
   echo "Unknown test ${1}"
 fi

--- a/example/test/main.sh
+++ b/example/test/main.sh
@@ -74,7 +74,10 @@ shutdown_systems() {
 
   # The cluster doesn't always shut down right away; we've given it a chance
   for job_pid in $(jobs -p); do
-    kill -9 "${job_pid}"
+    # Check if process still exists before trying to kill it
+    if kill -0 "${job_pid}" 2>/dev/null; then
+      kill -9 "${job_pid}" 2>/dev/null || true
+    fi
   done
 }
 

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -101,6 +101,18 @@ func clusterPost(s state.State, r *http.Request) response.Response {
 		return response.SmartError(fmt.Errorf("Remote with address %q exists", req.Address.String()))
 	}
 
+	// Check cluster membership consistency before allowing joins
+	// This ensures core_cluster_members, truststore, and dqlite are all in sync
+	intState, err := internalState.ToInternal(s)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	err = intState.CheckMembershipConsistency(ctx)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
 	// Forward request to leader.
 	if leaderInfo.Address != s.Address().URL.Host {
 		client, err := s.Leader()
@@ -114,11 +126,6 @@ func clusterPost(s state.State, r *http.Request) response.Response {
 		}
 
 		return response.SyncResponse(true, tokenResponse)
-	}
-
-	intState, err := internalState.ToInternal(s)
-	if err != nil {
-		return response.SmartError(err)
 	}
 
 	// Check if the joining node's extensions are compatible with the leader's.
@@ -416,6 +423,20 @@ func clusterMemberDelete(s state.State, r *http.Request) response.Response {
 
 	ctx, cancel := context.WithTimeout(r.Context(), time.Second*60)
 	defer cancel()
+
+	// Check cluster membership consistency before allowing removals (unless forced)
+	// This ensures core_cluster_members, truststore, and dqlite are all in sync
+	if !force {
+		intState, err := internalState.ToInternal(s)
+		if err != nil {
+			return response.SmartError(err)
+		}
+
+		err = intState.CheckMembershipConsistency(ctx)
+		if err != nil {
+			return response.SmartError(err)
+		}
+	}
 
 	leader, err := s.Database().Leader(ctx)
 	if err != nil {

--- a/internal/rest/resources/tokens.go
+++ b/internal/rest/resources/tokens.go
@@ -16,11 +16,12 @@ import (
 
 	"github.com/canonical/microcluster/v2/cluster"
 	internalTypes "github.com/canonical/microcluster/v2/internal/rest/types"
-	"github.com/canonical/microcluster/v2/internal/state"
+	internalState "github.com/canonical/microcluster/v2/internal/state"
 	"github.com/canonical/microcluster/v2/internal/utils"
 	"github.com/canonical/microcluster/v2/rest"
 	"github.com/canonical/microcluster/v2/rest/access"
 	"github.com/canonical/microcluster/v2/rest/types"
+	"github.com/canonical/microcluster/v2/state"
 )
 
 var tokensCmd = rest.Endpoint{
@@ -48,6 +49,18 @@ func tokensPost(state state.State, r *http.Request) response.Response {
 	err = utils.ValidateFQDN(req.Name)
 	if err != nil {
 		return response.SmartError(fmt.Errorf("Token name %q is not a valid FQDN: %w", req.Name, err))
+	}
+
+	// Check cluster membership consistency before allowing token creation
+	// This ensures core_cluster_members, truststore, and dqlite are all in sync
+	intState, err := internalState.ToInternal(state)
+	if err != nil {
+		return response.SmartError(err)
+	}
+
+	err = intState.CheckMembershipConsistency(r.Context())
+	if err != nil {
+		return response.SmartError(err)
 	}
 
 	// Generate join token for new member. This will be stored alongside the join

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -2,13 +2,18 @@ package state
 
 import (
 	"context"
+	"database/sql"
 	"fmt"
+	"slices"
+	"sort"
 	"time"
 
+	dqliteClient "github.com/canonical/go-dqlite/v2/client"
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
 
 	"github.com/canonical/microcluster/v2/client"
+	"github.com/canonical/microcluster/v2/cluster"
 	internalConfig "github.com/canonical/microcluster/v2/internal/config"
 	"github.com/canonical/microcluster/v2/internal/db"
 	"github.com/canonical/microcluster/v2/internal/endpoints"
@@ -229,4 +234,99 @@ func ToInternal(s State) (*InternalState, error) {
 	}
 
 	return nil, fmt.Errorf("Underlying State is not an InternalState")
+}
+
+// CheckMembershipConsistency verifies that core_cluster_members, truststore, and dqlite
+// all have consistent membership information. This should be called before any member
+// add/remove operations or join token generation to ensure the cluster is in a healthy state.
+func (s *InternalState) CheckMembershipConsistency(ctx context.Context) error {
+	// Assign a context timeout if we don't already have one.
+	_, ok := ctx.Deadline()
+	if !ok {
+		timeoutCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+		ctx = timeoutCtx
+		defer cancel()
+	}
+
+	for {
+		coreClusterMembers, truststoreRemotes, dqliteNodes, err := s.getMembershipData(ctx)
+		if err != nil {
+			return fmt.Errorf("Failed to gather membership data for consistency check: %w", err)
+		}
+
+		err = s.checkMembershipConsistency(coreClusterMembers, truststoreRemotes, dqliteNodes)
+		if err != nil {
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("Membership consistency check failed after timeout: %w", err)
+			case <-time.After(200 * time.Millisecond):
+				continue
+			}
+		}
+
+		return nil
+	}
+}
+
+// getMembershipData retrieves membership information from all sources.
+func (s *InternalState) getMembershipData(ctx context.Context) ([]cluster.CoreClusterMember, map[string]trust.Remote, []dqliteClient.NodeInfo, error) {
+	// Get database core cluster members
+	var coreClusterMembers []cluster.CoreClusterMember
+	err := s.Database().Transaction(ctx, func(ctx context.Context, tx *sql.Tx) error {
+		var err error
+		coreClusterMembers, err = cluster.GetCoreClusterMembers(ctx, tx)
+		return err
+	})
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("Failed to get core cluster members from database: %w", err)
+	}
+
+	// Get truststore remotes
+	truststoreRemotes := s.Remotes().RemotesByName()
+
+	// Get dqlite cluster info
+	leaderClient, err := s.Database().Leader(ctx)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("Failed to get dqlite leader: %w", err)
+	}
+
+	// Get dqlite cluster members
+	dqliteNodes, err := s.Database().Cluster(ctx, leaderClient)
+	if err != nil {
+		return nil, nil, nil, fmt.Errorf("Failed to get dqlite cluster info: %w", err)
+	}
+
+	return coreClusterMembers, truststoreRemotes, dqliteNodes, nil
+}
+
+// checkMembershipConsistency checks consistency across all three membership sources using addresses.
+func (s *InternalState) checkMembershipConsistency(coreClusterMembers []cluster.CoreClusterMember, truststoreRemotes map[string]trust.Remote, dqliteNodes []dqliteClient.NodeInfo) error {
+	// Collect addresses from each source into sorted slices
+	var coreClusterAddresses []string
+	for _, member := range coreClusterMembers {
+		coreClusterAddresses = append(coreClusterAddresses, member.Address)
+	}
+
+	sort.Strings(coreClusterAddresses)
+
+	var trustAddresses []string
+	for _, remote := range truststoreRemotes {
+		trustAddresses = append(trustAddresses, remote.Address.String())
+	}
+
+	sort.Strings(trustAddresses)
+
+	var dqliteAddresses []string
+	for _, node := range dqliteNodes {
+		dqliteAddresses = append(dqliteAddresses, node.Address)
+	}
+
+	sort.Strings(dqliteAddresses)
+
+	// Check if all three slices are equal
+	if !slices.Equal(coreClusterAddresses, trustAddresses) || !slices.Equal(coreClusterAddresses, dqliteAddresses) {
+		return fmt.Errorf("Microcluster node membership is inconsistent across core_cluster_members (%v), truststore (%v) and dqlite (%v)", coreClusterAddresses, trustAddresses, dqliteAddresses)
+	}
+
+	return nil
 }


### PR DESCRIPTION
# Backport

This PR backports https://github.com/canonical/microcluster/pull/515