### PR TITLE
Restructure (7): Make extensions package public

### DIFF
--- a/internal/cluster/cluster_members.go
+++ b/internal/cluster/cluster_members.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/canonical/microcluster/v3/internal/db/update"
-	"github.com/canonical/microcluster/v3/internal/extensions"
 	"github.com/canonical/microcluster/v3/microcluster/types"
 )
 
@@ -25,7 +24,7 @@ type CoreClusterMember struct {
 	Certificate    string
 	SchemaInternal uint64
 	SchemaExternal uint64
-	APIExtensions  extensions.Extensions
+	APIExtensions  types.Extensions
 	Heartbeat      time.Time
 	Role           Role
 }
@@ -67,7 +66,7 @@ func (c CoreClusterMember) ToAPI() (*types.ClusterMember, error) {
 // GetUpgradingClusterMembers returns the list of all cluster members during an upgrade, as well as a map of members who we consider to be in a waiting state.
 // This function can be used immediately after dqlite is ready, before we have loaded any prepared statements.
 // A cluster member will be in a waiting state if a different cluster member still exists with a smaller API extension count or schema version.
-func GetUpgradingClusterMembers(ctx context.Context, tx *sql.Tx, schemaInternal uint64, schemaExternal uint64, apiExtensions extensions.Extensions) (allMembers []CoreClusterMember, awaitingMembers map[string]bool, err error) {
+func GetUpgradingClusterMembers(ctx context.Context, tx *sql.Tx, schemaInternal uint64, schemaExternal uint64, apiExtensions types.Extensions) (allMembers []CoreClusterMember, awaitingMembers map[string]bool, err error) {
 	tableName, err := update.PrepareUpdateV1(ctx, tx)
 	if err != nil {
 		return nil, nil, err

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -27,7 +27,6 @@ import (
 	internalConfig "github.com/canonical/microcluster/v3/internal/config"
 	"github.com/canonical/microcluster/v3/internal/db"
 	"github.com/canonical/microcluster/v3/internal/endpoints"
-	"github.com/canonical/microcluster/v3/internal/extensions"
 	internalLog "github.com/canonical/microcluster/v3/internal/log"
 	"github.com/canonical/microcluster/v3/internal/recover"
 	internalREST "github.com/canonical/microcluster/v3/internal/rest"
@@ -105,7 +104,7 @@ type Daemon struct {
 	shutdownDoneCh chan error         // Receives the result of state.Stop() when exit() is called and tells the daemon to end.
 	shutdownCancel context.CancelFunc // Cancels the shutdownCtx to indicate shutdown starting.
 
-	Extensions extensions.Extensions // Extensions supported at runtime by the daemon.
+	Extensions types.Extensions // Extensions supported at runtime by the daemon.
 
 	// stop is a sync.Once which wraps the daemon's stop sequence. Each call will block until the first one completes.
 	stop func() error
@@ -272,7 +271,7 @@ func (d *Daemon) init(listenAddress string, socketGroup string, heartbeatInterva
 	d.config.SetName(name)
 
 	// Initialize the extensions registry with the internal extensions.
-	d.Extensions, err = extensions.NewExtensionRegistry(true)
+	d.Extensions, err = types.NewExtensionRegistry(true)
 	if err != nil {
 		return err
 	}

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/canonical/microcluster/v3/internal/db/query"
 	"github.com/canonical/microcluster/v3/internal/db/update"
-	"github.com/canonical/microcluster/v3/internal/extensions"
 	"github.com/canonical/microcluster/v3/internal/sys"
 	clusterDB "github.com/canonical/microcluster/v3/microcluster/db"
 	"github.com/canonical/microcluster/v3/microcluster/types"
@@ -26,7 +25,7 @@ import (
 
 // Open opens the dqlite database and loads the schema.
 // Returns true if we need to wait for other nodes to catch up to our version.
-func (db *DqliteDB) Open(ext extensions.Extensions, bootstrap bool) error {
+func (db *DqliteDB) Open(ext types.Extensions, bootstrap bool) error {
 	// Allow dqlite up to 2 minutes to become ready when starting up.
 	// This is to allow for unready/dead nodes to time out.
 	ctx, cancel := context.WithTimeout(db.ctx, 120*time.Second)
@@ -88,7 +87,7 @@ func (db *DqliteDB) Open(ext extensions.Extensions, bootstrap bool) error {
 // waitUpgrade compares the version information of all cluster members in the database to the local version.
 // If this node's version is ahead of others, then it will block on the `db.upgradeCh` or up to a minute.
 // If this node's version is behind others, then it returns an error.
-func (db *DqliteDB) waitUpgrade(bootstrap bool, ext extensions.Extensions) error {
+func (db *DqliteDB) waitUpgrade(bootstrap bool, ext types.Extensions) error {
 	checkSchemaVersion := func(schemaVersion uint64, clusterMemberVersions []uint64) (otherNodesBehind bool, err error) {
 		nodeIsBehind := false
 		for _, version := range clusterMemberVersions {
@@ -116,7 +115,7 @@ func (db *DqliteDB) waitUpgrade(bootstrap bool, ext extensions.Extensions) error
 		return nodeIsBehind, nil
 	}
 
-	checkAPIExtensions := func(currentAPIExtensions extensions.Extensions, clusterMemberAPIExtensions []extensions.Extensions) (otherNodesBehind bool, err error) {
+	checkAPIExtensions := func(currentAPIExtensions types.Extensions, clusterMemberAPIExtensions []types.Extensions) (otherNodesBehind bool, err error) {
 		db.log().Debug(fmt.Sprintf("Local API extensions: %v, cluster members API extensions: %v", currentAPIExtensions, clusterMemberAPIExtensions))
 
 		nodeIsBehind := false

--- a/internal/db/db_test.go
+++ b/internal/db/db_test.go
@@ -14,10 +14,10 @@ import (
 
 	"github.com/canonical/microcluster/v3/internal/cluster"
 	"github.com/canonical/microcluster/v3/internal/db/update"
-	"github.com/canonical/microcluster/v3/internal/extensions"
 	"github.com/canonical/microcluster/v3/internal/log"
 	"github.com/canonical/microcluster/v3/internal/sys"
 	clusterDB "github.com/canonical/microcluster/v3/microcluster/db"
+	"github.com/canonical/microcluster/v3/microcluster/types"
 )
 
 type dbSuite struct {
@@ -165,7 +165,7 @@ func (s *dbSuite) Test_waitUpgradeSchema() {
 		tx, err := db.db.BeginTx(db.ctx, nil)
 		s.NoError(err)
 
-		apiExtensions, err := extensions.NewExtensionRegistry(true)
+		apiExtensions, err := types.NewExtensionRegistry(true)
 		s.NoError(err)
 
 		// Generate a cluster member for the local node.
@@ -289,47 +289,47 @@ func (s *dbSuite) Test_waitUpgradeSchema() {
 func (s *dbSuite) Test_waitUpgradeAPI() {
 	tests := []struct {
 		name                       string
-		upgradedLocalAPIExtensions extensions.Extensions
-		clusterMembersExtensions   []extensions.Extensions
+		upgradedLocalAPIExtensions types.Extensions
+		clusterMembersExtensions   []types.Extensions
 		expectErr                  error
 		expectWait                 bool
 	}{
 		{
 			name:                       "No upgrade, no other nodes",
-			upgradedLocalAPIExtensions: extensions.Extensions{},
+			upgradedLocalAPIExtensions: types.Extensions{},
 		},
 		{
 			name:                       "API upgrade, no other nodes",
-			upgradedLocalAPIExtensions: extensions.Extensions{"internal:a", "ext"},
+			upgradedLocalAPIExtensions: types.Extensions{"internal:a", "ext"},
 		},
 		{
 			name:                       "All other nodes ahead",
-			upgradedLocalAPIExtensions: extensions.Extensions{"internal:a", "ext"},
-			clusterMembersExtensions:   []extensions.Extensions{{"internal:a", "ext", "ext2"}, {"internal:a", "ext", "ext2"}},
+			upgradedLocalAPIExtensions: types.Extensions{"internal:a", "ext"},
+			clusterMembersExtensions:   []types.Extensions{{"internal:a", "ext", "ext2"}, {"internal:a", "ext", "ext2"}},
 			expectErr:                  fmt.Errorf("This node's API extensions are behind, please upgrade"),
 		},
 		{
 			name:                       "Some other nodes ahead",
-			upgradedLocalAPIExtensions: extensions.Extensions{"internal:a", "ext"},
-			clusterMembersExtensions:   []extensions.Extensions{{"internal:a", "ext"}, {"internal:a", "ext", "ext2"}},
+			upgradedLocalAPIExtensions: types.Extensions{"internal:a", "ext"},
+			clusterMembersExtensions:   []types.Extensions{{"internal:a", "ext"}, {"internal:a", "ext", "ext2"}},
 			expectErr:                  fmt.Errorf("This node's API extensions are behind, please upgrade"),
 		},
 		{
 			name:                       "All other nodes behind",
-			upgradedLocalAPIExtensions: extensions.Extensions{"internal:a", "ext", "ext2"},
-			clusterMembersExtensions:   []extensions.Extensions{{"internal:a", "ext"}, {"internal:a", "ext"}},
+			upgradedLocalAPIExtensions: types.Extensions{"internal:a", "ext", "ext2"},
+			clusterMembersExtensions:   []types.Extensions{{"internal:a", "ext"}, {"internal:a", "ext"}},
 			expectWait:                 true,
 		},
 		{
 			name:                       "Some other nodes behind",
-			upgradedLocalAPIExtensions: extensions.Extensions{"internal:a", "ext", "ext2"},
-			clusterMembersExtensions:   []extensions.Extensions{{"internal:a", "ext", "ext2"}, {"internal:a", "ext"}},
+			upgradedLocalAPIExtensions: types.Extensions{"internal:a", "ext", "ext2"},
+			clusterMembersExtensions:   []types.Extensions{{"internal:a", "ext", "ext2"}, {"internal:a", "ext"}},
 			expectWait:                 true,
 		},
 		{
 			name:                       "Some nodes behind, others ahead",
-			upgradedLocalAPIExtensions: extensions.Extensions{"internal:a", "ext", "ext2"},
-			clusterMembersExtensions:   []extensions.Extensions{{"internal:a", "ext"}, {"internal:a", "ext", "ext2", "ext3"}},
+			upgradedLocalAPIExtensions: types.Extensions{"internal:a", "ext", "ext2"},
+			clusterMembersExtensions:   []types.Extensions{{"internal:a", "ext"}, {"internal:a", "ext", "ext2", "ext3"}},
 			expectErr:                  fmt.Errorf("This node's API extensions are behind, please upgrade"),
 		},
 	}
@@ -417,9 +417,9 @@ func (s *dbSuite) Test_waitUpgradeAPI() {
 
 		res, err := clusterDB.SelectStrings(ctx, tx, "SELECT api_extensions FROM core_cluster_members ORDER BY id")
 		s.NoError(err)
-		allExtensions := make([]extensions.Extensions, 0)
+		allExtensions := make([]types.Extensions, 0)
 		for _, r := range res {
-			e := extensions.Extensions{}
+			e := types.Extensions{}
 			err = json.Unmarshal([]byte(r), &e)
 			s.NoError(err)
 			allExtensions = append(allExtensions, e)
@@ -442,7 +442,7 @@ func (s *dbSuite) Test_waitUpgradeSchemaAndAPI() {
 	type versionsWithExtensions struct {
 		schemaInt uint64
 		schemaExt uint64
-		ext       extensions.Extensions
+		ext       types.Extensions
 	}
 
 	tests := []struct {
@@ -457,7 +457,7 @@ func (s *dbSuite) Test_waitUpgradeSchemaAndAPI() {
 			upgradedLocalInfo: versionsWithExtensions{
 				schemaInt: 0,
 				schemaExt: 0,
-				ext:       extensions.Extensions{"internal:a"},
+				ext:       types.Extensions{"internal:a"},
 			},
 		},
 		{
@@ -465,11 +465,11 @@ func (s *dbSuite) Test_waitUpgradeSchemaAndAPI() {
 			upgradedLocalInfo: versionsWithExtensions{
 				schemaInt: 0,
 				schemaExt: 0,
-				ext:       extensions.Extensions{"internal:a"},
+				ext:       types.Extensions{"internal:a"},
 			},
 			clusterMembers: []versionsWithExtensions{
-				{schemaInt: 1, schemaExt: 1, ext: extensions.Extensions{"internal:a"}},
-				{schemaInt: 1, schemaExt: 1, ext: extensions.Extensions{"internal:a"}},
+				{schemaInt: 1, schemaExt: 1, ext: types.Extensions{"internal:a"}},
+				{schemaInt: 1, schemaExt: 1, ext: types.Extensions{"internal:a"}},
 			},
 			expectErr: fmt.Errorf("This node's version is behind, please upgrade"),
 		},
@@ -478,11 +478,11 @@ func (s *dbSuite) Test_waitUpgradeSchemaAndAPI() {
 			upgradedLocalInfo: versionsWithExtensions{
 				schemaInt: 2,
 				schemaExt: 2,
-				ext:       extensions.Extensions{"internal:a", "b", "c"},
+				ext:       types.Extensions{"internal:a", "b", "c"},
 			},
 			clusterMembers: []versionsWithExtensions{
-				{schemaInt: 1, schemaExt: 1, ext: extensions.Extensions{"internal:a", "b", "c"}},
-				{schemaInt: 1, schemaExt: 1, ext: extensions.Extensions{"internal:a", "b", "c"}},
+				{schemaInt: 1, schemaExt: 1, ext: types.Extensions{"internal:a", "b", "c"}},
+				{schemaInt: 1, schemaExt: 1, ext: types.Extensions{"internal:a", "b", "c"}},
 			},
 			expectWait: true,
 		},
@@ -491,11 +491,11 @@ func (s *dbSuite) Test_waitUpgradeSchemaAndAPI() {
 			upgradedLocalInfo: versionsWithExtensions{
 				schemaInt: 1,
 				schemaExt: 1,
-				ext:       extensions.Extensions{"internal:a", "b"},
+				ext:       types.Extensions{"internal:a", "b"},
 			},
 			clusterMembers: []versionsWithExtensions{
-				{schemaInt: 2, schemaExt: 2, ext: extensions.Extensions{"internal:a", "b"}},
-				{schemaInt: 0, schemaExt: 0, ext: extensions.Extensions{"internal:a", "b"}},
+				{schemaInt: 2, schemaExt: 2, ext: types.Extensions{"internal:a", "b"}},
+				{schemaInt: 0, schemaExt: 0, ext: types.Extensions{"internal:a", "b"}},
 			},
 			expectErr: fmt.Errorf("This node's version is behind, please upgrade"),
 		},
@@ -518,7 +518,7 @@ func (s *dbSuite) Test_waitUpgradeSchemaAndAPI() {
 			Certificate:    fmt.Sprintf("test-cert-%d", 0),
 			SchemaInternal: 0,
 			SchemaExternal: 0,
-			APIExtensions:  extensions.Extensions{},
+			APIExtensions:  types.Extensions{},
 			Heartbeat:      time.Time{},
 			Role:           "voter",
 		})
@@ -599,9 +599,9 @@ func (s *dbSuite) Test_waitUpgradeSchemaAndAPI() {
 
 		res, err := clusterDB.SelectStrings(ctx, tx, "SELECT api_extensions FROM core_cluster_members ORDER BY id")
 		s.NoError(err)
-		allExtensions := make([]extensions.Extensions, 0)
+		allExtensions := make([]types.Extensions, 0)
 		for _, r := range res {
-			e := extensions.Extensions{}
+			e := types.Extensions{}
 			err = json.Unmarshal([]byte(r), &e)
 			s.NoError(err)
 			allExtensions = append(allExtensions, e)

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -26,7 +26,6 @@ import (
 
 	"github.com/canonical/microcluster/v3/internal/cluster"
 	"github.com/canonical/microcluster/v3/internal/db/update"
-	"github.com/canonical/microcluster/v3/internal/extensions"
 	"github.com/canonical/microcluster/v3/internal/log"
 	internalClient "github.com/canonical/microcluster/v3/internal/rest/client"
 	"github.com/canonical/microcluster/v3/internal/sys"
@@ -114,7 +113,7 @@ func (db *DqliteDB) log() *slog.Logger {
 }
 
 // SetSchema sets schema and API extensions on the DB.
-func (db *DqliteDB) SetSchema(schemaExtensions []clusterDB.Update, apiExtensions extensions.Extensions) {
+func (db *DqliteDB) SetSchema(schemaExtensions []clusterDB.Update, apiExtensions types.Extensions) {
 	s := update.NewSchema()
 	s.AppendSchema(schemaExtensions, apiExtensions)
 	db.schema = s.Schema()
@@ -126,7 +125,7 @@ func (db *DqliteDB) Schema() *update.SchemaUpdate {
 }
 
 // SchemaVersion returns the current internal and external schema version, as well as all API extensions in memory.
-func (db *DqliteDB) SchemaVersion() (versionInternal uint64, versionExternal uint64, apiExtensions extensions.Extensions) {
+func (db *DqliteDB) SchemaVersion() (versionInternal uint64, versionExternal uint64, apiExtensions types.Extensions) {
 	return db.schema.Version()
 }
 
@@ -146,7 +145,7 @@ func (db *DqliteDB) isInitialized() (bool, error) {
 }
 
 // Bootstrap dqlite.
-func (db *DqliteDB) Bootstrap(extensions extensions.Extensions, addr *url.URL, clusterRecord cluster.CoreClusterMember) error {
+func (db *DqliteDB) Bootstrap(extensions types.Extensions, addr *url.URL, clusterRecord cluster.CoreClusterMember) error {
 	var err error
 	db.listenAddr = addr
 	db.dqlite, err = dqlite.New(db.os.DatabaseDir(),
@@ -196,7 +195,7 @@ func (db *DqliteDB) Bootstrap(extensions extensions.Extensions, addr *url.URL, c
 }
 
 // Join a dqlite cluster with the address of a member.
-func (db *DqliteDB) Join(extensions extensions.Extensions, addr *url.URL, joinAddresses ...string) error {
+func (db *DqliteDB) Join(extensions types.Extensions, addr *url.URL, joinAddresses ...string) error {
 	var err error
 	db.listenAddr = addr
 	db.dqlite, err = dqlite.New(db.os.DatabaseDir(),
@@ -248,7 +247,7 @@ func (db *DqliteDB) Join(extensions extensions.Extensions, addr *url.URL, joinAd
 }
 
 // StartWithCluster starts up dqlite and joins the cluster.
-func (db *DqliteDB) StartWithCluster(extensions extensions.Extensions, addr *url.URL, clusterMembers map[string]types.AddrPort) error {
+func (db *DqliteDB) StartWithCluster(extensions types.Extensions, addr *url.URL, clusterMembers map[string]types.AddrPort) error {
 	allClusterAddrs := []string{}
 	for _, clusterMemberAddrs := range clusterMembers {
 		allClusterAddrs = append(allClusterAddrs, clusterMemberAddrs.String())

--- a/internal/db/interface.go
+++ b/internal/db/interface.go
@@ -6,7 +6,6 @@ import (
 
 	dqliteClient "github.com/canonical/go-dqlite/v3/client"
 
-	"github.com/canonical/microcluster/v3/internal/extensions"
 	"github.com/canonical/microcluster/v3/microcluster/types"
 )
 
@@ -30,5 +29,5 @@ type DB interface {
 	IsOpen(ctx context.Context) error
 
 	// SchemaVersion returns the current internal and external schema version, as well as all API extensions in memory.
-	SchemaVersion() (versionInternal uint64, versionExternal uint64, apiExtensions extensions.Extensions)
+	SchemaVersion() (versionInternal uint64, versionExternal uint64, apiExtensions types.Extensions)
 }

--- a/internal/db/update/cluster.go
+++ b/internal/db/update/cluster.go
@@ -6,9 +6,9 @@ import (
 	"fmt"
 	"log/slog"
 
-	"github.com/canonical/microcluster/v3/internal/extensions"
 	"github.com/canonical/microcluster/v3/internal/log"
 	clusterDB "github.com/canonical/microcluster/v3/microcluster/db"
+	"github.com/canonical/microcluster/v3/microcluster/types"
 )
 
 // PrepareUpdateV1 creates the temporary table `internal_cluster_members_new` if we have not yet run `updateFromV1`.
@@ -144,7 +144,7 @@ func GetClusterMemberSchemaVersions(ctx context.Context, tx *sql.Tx) (internalSc
 
 // UpdateClusterMemberAPIExtensions sets the API extensions for the cluster member with the given address.
 // This helper is non-generated to work before generated statements are loaded, as we update the API extensions.
-func UpdateClusterMemberAPIExtensions(ctx context.Context, tx *sql.Tx, apiExtensions extensions.Extensions, memberName string) error {
+func UpdateClusterMemberAPIExtensions(ctx context.Context, tx *sql.Tx, apiExtensions types.Extensions, memberName string) error {
 	table, err := getClusterTableName(ctx, tx)
 	if err != nil {
 		return err
@@ -193,7 +193,7 @@ WHERE name IN ('api_extensions');
 
 // GetClusterMemberAPIExtensions returns the API extensions from all cluster members that are not pending.
 // This helper is non-generated to work before generated statements are loaded, as we update the API extensions.
-func GetClusterMemberAPIExtensions(ctx context.Context, tx *sql.Tx) ([]extensions.Extensions, error) {
+func GetClusterMemberAPIExtensions(ctx context.Context, tx *sql.Tx) ([]types.Extensions, error) {
 	table, err := getClusterTableName(ctx, tx)
 	if err != nil {
 		return nil, err
@@ -216,9 +216,9 @@ func GetClusterMemberAPIExtensions(ctx context.Context, tx *sql.Tx) ([]extension
 		}
 	}()
 
-	var results []extensions.Extensions
+	var results []types.Extensions
 	for rows.Next() {
-		var ext extensions.Extensions
+		var ext types.Extensions
 		err := rows.Scan(&ext)
 		if err != nil {
 			return nil, err

--- a/internal/db/update/schema.go
+++ b/internal/db/update/schema.go
@@ -11,8 +11,8 @@ import (
 
 	"github.com/canonical/microcluster/v3/internal/db/query"
 	"github.com/canonical/microcluster/v3/internal/db/schema"
-	"github.com/canonical/microcluster/v3/internal/extensions"
 	clusterDB "github.com/canonical/microcluster/v3/microcluster/db"
+	"github.com/canonical/microcluster/v3/microcluster/types"
 )
 
 // updateType represents whether the update is an internal or external schema update.
@@ -29,7 +29,7 @@ const (
 // SchemaUpdate holds the configuration for executing schema updates.
 type SchemaUpdate struct {
 	updates       map[updateType][]clusterDB.Update // Ordered series of internal and external updates making up the schema
-	apiExtensions extensions.Extensions
+	apiExtensions types.Extensions
 	hook          schema.Hook  // Optional hook to execute whenever a update gets applied
 	fresh         string       // Optional SQL statement used to create schema from scratch
 	check         schema.Check // Optional callback invoked before doing any update
@@ -58,7 +58,7 @@ func (s *SchemaUpdate) Check(check schema.Check) {
 }
 
 // Version returns the internal and external schema update versions, corresponding to the number of updates that have occurred.
-func (s *SchemaUpdate) Version() (internalVersion uint64, externalVersion uint64, apiExtensions extensions.Extensions) {
+func (s *SchemaUpdate) Version() (internalVersion uint64, externalVersion uint64, apiExtensions types.Extensions) {
 	return uint64(len(s.updates[updateInternal])), uint64(len(s.updates[updateExternal])), s.apiExtensions
 }
 

--- a/internal/db/update/update.go
+++ b/internal/db/update/update.go
@@ -5,8 +5,8 @@ import (
 	"database/sql"
 	"fmt"
 
-	"github.com/canonical/microcluster/v3/internal/extensions"
 	clusterDB "github.com/canonical/microcluster/v3/microcluster/db"
+	"github.com/canonical/microcluster/v3/microcluster/types"
 )
 
 // CreateSchema is the default schema applied when bootstrapping the database.
@@ -23,7 +23,7 @@ CREATE TABLE schemas (
 type SchemaUpdateManager struct {
 	updates map[updateType][]clusterDB.Update
 
-	apiExtensions extensions.Extensions
+	apiExtensions types.Extensions
 }
 
 // NewSchema returns a new SchemaUpdateManager containing microcluster schema updates.
@@ -69,7 +69,7 @@ func (s *SchemaUpdateManager) Schema() *SchemaUpdate {
 }
 
 // AppendSchema sets the given schema and API updates as the list of external extensions on the update manager.
-func (s *SchemaUpdateManager) AppendSchema(schemaExtensions []clusterDB.Update, apiExtensions extensions.Extensions) {
+func (s *SchemaUpdateManager) AppendSchema(schemaExtensions []clusterDB.Update, apiExtensions types.Extensions) {
 	s.updates[updateExternal] = schemaExtensions
 	s.apiExtensions = apiExtensions
 }

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -19,7 +19,6 @@ import (
 	internalConfig "github.com/canonical/microcluster/v3/internal/config"
 	"github.com/canonical/microcluster/v3/internal/db"
 	"github.com/canonical/microcluster/v3/internal/endpoints"
-	"github.com/canonical/microcluster/v3/internal/extensions"
 	internalClient "github.com/canonical/microcluster/v3/internal/rest/client"
 	"github.com/canonical/microcluster/v3/internal/trust"
 	"github.com/canonical/microcluster/v3/microcluster/types"
@@ -97,7 +96,7 @@ type InternalState struct {
 	Stop func() (exit func(), stopErr error)
 
 	// Runtime extensions.
-	Extensions extensions.Extensions
+	Extensions types.Extensions
 
 	// Hooks contain external implementations that are triggered by specific cluster actions.
 	Hooks *Hooks

--- a/microcluster/types/cluster.go
+++ b/microcluster/types/cluster.go
@@ -2,20 +2,18 @@ package types
 
 import (
 	"time"
-
-	"github.com/canonical/microcluster/v3/internal/extensions"
 )
 
 // ClusterMember represents information about a dqlite cluster member.
 type ClusterMember struct {
 	ClusterMemberLocal
-	Role                  string                `json:"role" yaml:"role"`
-	SchemaInternalVersion uint64                `json:"schema_internal_version" yaml:"schema_internal_version"`
-	SchemaExternalVersion uint64                `json:"schema_external_version" yaml:"schema_external_version"`
-	LastHeartbeat         time.Time             `json:"last_heartbeat" yaml:"last_heartbeat"`
-	Status                MemberStatus          `json:"status" yaml:"status"`
-	Extensions            extensions.Extensions `json:"extensions" yaml:"extensions"`
-	Secret                string                `json:"secret" yaml:"secret"`
+	Role                  string       `json:"role" yaml:"role"`
+	SchemaInternalVersion uint64       `json:"schema_internal_version" yaml:"schema_internal_version"`
+	SchemaExternalVersion uint64       `json:"schema_external_version" yaml:"schema_external_version"`
+	LastHeartbeat         time.Time    `json:"last_heartbeat" yaml:"last_heartbeat"`
+	Status                MemberStatus `json:"status" yaml:"status"`
+	Extensions            Extensions   `json:"extensions" yaml:"extensions"`
+	Secret                string       `json:"secret" yaml:"secret"`
 }
 
 // ClusterMemberLocal represents local information about a new cluster member.

--- a/microcluster/types/extensions.go
+++ b/microcluster/types/extensions.go
@@ -1,4 +1,4 @@
-package extensions
+package types
 
 import (
 	"database/sql/driver"

--- a/microcluster/types/extensions_test.go
+++ b/microcluster/types/extensions_test.go
@@ -1,4 +1,4 @@
-package extensions
+package types
 
 import (
 	"database/sql"

--- a/microcluster/types/server.go
+++ b/microcluster/types/server.go
@@ -1,7 +1,5 @@
 package types
 
-import "github.com/canonical/microcluster/v3/internal/extensions"
-
 const (
 	// PublicEndpoint - Internally managed APIs.
 	PublicEndpoint EndpointPrefix = "core/1.0"
@@ -22,9 +20,9 @@ type ServerConfig struct {
 
 // Server represents server status information.
 type Server struct {
-	Name       string                `json:"name"    yaml:"name"`
-	Address    AddrPort              `json:"address" yaml:"address"`
-	Version    string                `json:"version" yaml:"version"`
-	Ready      bool                  `json:"ready"   yaml:"ready"`
-	Extensions extensions.Extensions `json:"extensions" yaml:"extensions"`
+	Name       string     `json:"name"    yaml:"name"`
+	Address    AddrPort   `json:"address" yaml:"address"`
+	Version    string     `json:"version" yaml:"version"`
+	Ready      bool       `json:"ready"   yaml:"ready"`
+	Extensions Extensions `json:"extensions" yaml:"extensions"`
 }


### PR DESCRIPTION
This is the seventh PR taken from a single commit in https://github.com/canonical/microcluster/pull/534 (even though in this case the actual changes are very different from the original commit).
The final package layout will be different but to allow reviewing the changes in smaller chunks I will split this PR by its commits.

In this PR the extensions package is made public so that the actual types can be accessed by importers of Microcluster.