### PR TITLE
Restructure (8): Make DB interface public 

### DIFF
--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -45,7 +45,7 @@ type State interface {
 	ClusterCert() *shared.CertInfo
 
 	// Database.
-	Database() db.DB
+	Database() types.DB
 
 	// Local truststore access.
 	Truststore() types.Store
@@ -144,7 +144,7 @@ func (s *InternalState) ClusterCert() *shared.CertInfo {
 }
 
 // Database allows access to the dqlite database.
-func (s *InternalState) Database() db.DB {
+func (s *InternalState) Database() types.DB {
 	return s.InternalDatabase
 }
 

--- a/microcluster/types/db.go
+++ b/microcluster/types/db.go
@@ -1,12 +1,10 @@
-package db
+package types
 
 import (
 	"context"
 	"database/sql"
 
 	dqliteClient "github.com/canonical/go-dqlite/v3/client"
-
-	"github.com/canonical/microcluster/v3/microcluster/types"
 )
 
 // DB exposes the internal database for use with external projects.
@@ -21,7 +19,7 @@ type DB interface {
 	Cluster(ctx context.Context, client *dqliteClient.Client) ([]dqliteClient.NodeInfo, error)
 
 	// Status returns the current status of the database.
-	Status() types.DatabaseStatus
+	Status() DatabaseStatus
 
 	// IsOpen returns nil  only if the DB has been opened and the schema loaded.
 	// Otherwise, it returns an error describing why the database is offline.
@@ -29,5 +27,5 @@ type DB interface {
 	IsOpen(ctx context.Context) error
 
 	// SchemaVersion returns the current internal and external schema version, as well as all API extensions in memory.
-	SchemaVersion() (versionInternal uint64, versionExternal uint64, apiExtensions types.Extensions)
+	SchemaVersion() (versionInternal uint64, versionExternal uint64, apiExtensions Extensions)
 }


### PR DESCRIPTION
Can only be merged after (won't build before):
* https://github.com/canonical/microcluster/pull/607

This is the eigth PR taken from a single commit in https://github.com/canonical/microcluster/pull/534 (even though in this case the actual changes are very different from the original commit).
The final package layout will be different but to allow reviewing the changes in smaller chunks I will split this PR by its commits.

In this PR the DB interface is made public. It's returned by the public `State` interface and should therefore not be located inside the `internal/` package.