### PR TITLE
internal/state: add ctx deadline exceeded check on membership consistency check

### DIFF
--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -258,7 +258,7 @@ func (s *InternalState) CheckMembershipConsistency(ctx context.Context) error {
 		if err != nil {
 			select {
 			case <-ctx.Done():
-				return fmt.Errorf("Membership consistency check failed after timeout: %w", err)
+				return fmt.Errorf("Membership consistency check failed: %w", err)
 			case <-time.After(200 * time.Millisecond):
 				continue
 			}


### PR DESCRIPTION
# Add ctx deadline exceeded check on membership consistency check

This PR adds a ctx deadline exceeded check in the membership consistency check loop on the v2 branch. 

Nice to know: In v3 we pass the request's context, however, we do not want to make any drastic changes to the LTS branch.
