### PR TITLE
golangci: Fix issues with latest linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,8 @@ linters:
             arguments: # The arguments here are quite odd looking. See the rule description.
               - [ ]
               - [ ]
-              - [ { "upperCaseConst": true } ]
+              - - upperCaseConst: true
+                  skipPackageNameCollisionWithGoStd: true
 
           # https://github.com/mgechev/revive/blob/2a1701aadbedfcc175cb92836a51407bec382652/RULES_DESCRIPTIONS.md#early-return
           - name: early-return


### PR DESCRIPTION
Do the same as in LXD and skip the check.
See https://github.com/canonical/lxd/pull/17623