### PR TITLE
Restructure (11): Reorganize endpoints

### DIFF
--- a/internal/rest/client/sql.go
+++ b/internal/rest/client/sql.go
@@ -21,7 +21,7 @@ func GetSQL(ctx context.Context, c types.Client, schema bool) (*types.SQLDump, e
 		endpoint.WithQuery("schema", "1")
 	}
 
-	err := c.Query(reqCtx, "GET", types.InternalEndpoint, &endpoint.URL, nil, dump)
+	err := c.Query(reqCtx, "GET", types.ControlEndpoint, &endpoint.URL, nil, dump)
 	if err != nil {
 		return nil, err
 	}
@@ -35,7 +35,7 @@ func PostSQL(ctx context.Context, c types.Client, query types.SQLQuery) (*types.
 	defer cancel()
 
 	batch := &types.SQLBatch{}
-	err := c.Query(reqCtx, "POST", types.InternalEndpoint, &api.NewURL().Path("sql").URL, query, batch)
+	err := c.Query(reqCtx, "POST", types.ControlEndpoint, &api.NewURL().Path("sql").URL, query, batch)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/rest/client/tokens.go
+++ b/internal/rest/client/tokens.go
@@ -26,7 +26,7 @@ func DeleteTokenRecord(ctx context.Context, c types.Client, name string) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	err := c.Query(queryCtx, "DELETE", types.PublicEndpoint, &api.NewURL().Path("tokens", name).URL, nil, nil)
+	err := c.Query(queryCtx, "DELETE", types.ControlEndpoint, &api.NewURL().Path("tokens", name).URL, nil, nil)
 
 	return err
 }

--- a/internal/rest/resources/certificates.go
+++ b/internal/rest/resources/certificates.go
@@ -22,6 +22,7 @@ import (
 )
 
 var clusterCertificatesCmd = types.Endpoint{
+	// Allow modification of the certificate before joining the cluster.
 	AllowedBeforeInit: true,
 	Path:              "cluster/certificates/{name}",
 

--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -33,15 +33,13 @@ import (
 )
 
 var clusterCmd = types.Endpoint{
-	Path:              "cluster",
-	AllowedBeforeInit: true,
+	Path: "cluster",
 
 	Get: types.EndpointAction{Handler: clusterGet, AccessHandler: access.AllowAuthenticated},
 }
 
 var clusterInternalCmd = types.Endpoint{
-	Path:              "cluster",
-	AllowedBeforeInit: true,
+	Path: "cluster",
 
 	Post: types.EndpointAction{Handler: clusterPost, AllowUntrusted: true},
 }

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -129,7 +129,8 @@ func controlPost(state types.State, r *http.Request) types.Response {
 			<-r.Context().Done()
 
 			// Use `force=1` to ensure the node is fully removed, in case its listener hasn't been set up.
-			err = internalClient.DeleteClusterMember(r.Context(), client, req.Name, "", true)
+			// Use the background context as the original request context is already cancelled at this point.
+			err = internalClient.DeleteClusterMember(context.Background(), client, req.Name, "", true)
 			if err != nil {
 				logger.Error("Failed to clean up cluster state after join failure", slog.String("error", err.Error()))
 			}

--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -23,6 +23,7 @@ import (
 )
 
 var controlCmd = types.Endpoint{
+	// Required to allow bootstrapping or joining a not yet initialized node.
 	AllowedBeforeInit: true,
 
 	Post: types.EndpointAction{Handler: controlPost, AccessHandler: access.AllowAuthenticated},

--- a/internal/rest/resources/daemon.go
+++ b/internal/rest/resources/daemon.go
@@ -13,7 +13,7 @@ import (
 	"github.com/canonical/microcluster/v3/microcluster/types"
 )
 
-var daemonCmd = types.Endpoint{
+var daemonServersCmd = types.Endpoint{
 	Path: "daemon/servers",
 
 	Get: types.EndpointAction{Handler: daemonServersGet, AccessHandler: access.AllowAuthenticated},

--- a/internal/rest/resources/database.go
+++ b/internal/rest/resources/database.go
@@ -10,6 +10,7 @@ import (
 )
 
 var databaseCmd = types.Endpoint{
+	// Allow dialing into the database during initialization phase.
 	AllowedBeforeInit: true,
 	Path:              "database",
 

--- a/internal/rest/resources/member.go
+++ b/internal/rest/resources/member.go
@@ -7,13 +7,14 @@ import (
 	"github.com/canonical/microcluster/v3/microcluster/types"
 )
 
-var api10Cmd = types.Endpoint{
+var memberCmd = types.Endpoint{
+	// Allow getting some basic member status information even if not yet initialized.
 	AllowedBeforeInit: true,
 
-	Get: types.EndpointAction{Handler: api10Get, AllowUntrusted: true},
+	Get: types.EndpointAction{Handler: memberGet, AllowUntrusted: true},
 }
 
-func api10Get(s types.State, r *http.Request) types.Response {
+func memberGet(s types.State, r *http.Request) types.Response {
 	addrPort, err := types.ParseAddrPort(s.Address().Host)
 	if err != nil {
 		return types.SmartError(err)

--- a/internal/rest/resources/ready.go
+++ b/internal/rest/resources/ready.go
@@ -10,6 +10,7 @@ import (
 )
 
 var readyCmd = types.Endpoint{
+	// Allow waiting for the daemon to become ready even if not yet initialized.
 	AllowedBeforeInit: true,
 	Path:              "ready",
 

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -22,14 +22,15 @@ var UnixEndpoints = types.Resources{
 }
 
 // PublicEndpoints are the /core/1.0 API endpoints available at the listen address.
+// Client functions can be used to call these endpoints or they can be called directly.
 var PublicEndpoints = types.Resources{
 	PathPrefix: types.PublicEndpoint,
 	Endpoints: []types.Endpoint{
-		api10Cmd,
-		clusterCertificatesCmd,
 		clusterCmd,
 		clusterMemberCmd,
+		clusterCertificatesCmd,
 		daemonServersCmd,
+		memberCmd,
 		readyCmd,
 	},
 }

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -16,6 +16,7 @@ var UnixEndpoints = types.Resources{
 	Endpoints: []types.Endpoint{
 		controlCmd,
 		shutdownCmd,
+		sqlCmd,
 		tokenCmd,
 		tokensCmd,
 	},
@@ -45,7 +46,6 @@ var InternalEndpoints = types.Resources{
 		databaseCmd,
 		heartbeatCmd,
 		hooksCmd,
-		sqlCmd,
 		trustCmd,
 		trustEntryCmd,
 	},

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -10,11 +10,13 @@ import (
 )
 
 // UnixEndpoints are the endpoints available over the unix socket.
+// These endpoints are only ever required locally.
 var UnixEndpoints = types.Resources{
 	PathPrefix: types.ControlEndpoint,
 	Endpoints: []types.Endpoint{
 		controlCmd,
 		shutdownCmd,
+		tokenCmd,
 		tokensCmd,
 	},
 }
@@ -27,7 +29,6 @@ var PublicEndpoints = types.Resources{
 		clusterCertificatesCmd,
 		clusterCmd,
 		clusterMemberCmd,
-		tokenCmd,
 		daemonServersCmd,
 		readyCmd,
 	},

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -34,17 +34,18 @@ var PublicEndpoints = types.Resources{
 }
 
 // InternalEndpoints are the /core/internal API endpoints available at the listen address.
+// Those can be changed anytime and should not be called directly.
 var InternalEndpoints = types.Resources{
 	PathPrefix: types.InternalEndpoint,
 	Endpoints: []types.Endpoint{
 		clusterInternalCmd,
 		clusterMemberInternalCmd,
 		databaseCmd,
-		sqlCmd,
 		heartbeatCmd,
+		hooksCmd,
+		sqlCmd,
 		trustCmd,
 		trustEntryCmd,
-		hooksCmd,
 	},
 }
 

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -27,8 +27,8 @@ var PublicEndpoints = types.Resources{
 		clusterCertificatesCmd,
 		clusterCmd,
 		clusterMemberCmd,
-		daemonCmd,
 		tokenCmd,
+		daemonServersCmd,
 		readyCmd,
 	},
 }

--- a/internal/rest/resources/shutdown.go
+++ b/internal/rest/resources/shutdown.go
@@ -10,6 +10,7 @@ import (
 )
 
 var shutdownCmd = types.Endpoint{
+	// Allow shutting down the node even if not yet initialized.
 	AllowedBeforeInit: true,
 	Path:              "shutdown",
 

--- a/internal/rest/resources/truststore.go
+++ b/internal/rest/resources/truststore.go
@@ -19,8 +19,9 @@ import (
 )
 
 var trustCmd = types.Endpoint{
-	Path:              "truststore",
+	// Required to enable trust store updates when adding members.
 	AllowedBeforeInit: true,
+	Path:              "truststore",
 
 	Post: types.EndpointAction{Handler: trustPost, AccessHandler: access.AllowAuthenticated},
 }

--- a/internal/rest/resources/truststore.go
+++ b/internal/rest/resources/truststore.go
@@ -27,8 +27,7 @@ var trustCmd = types.Endpoint{
 }
 
 var trustEntryCmd = types.Endpoint{
-	Path:              "truststore/{name}",
-	AllowedBeforeInit: true,
+	Path: "truststore/{name}",
 
 	Delete: types.EndpointAction{Handler: trustDelete, AccessHandler: access.AllowAuthenticated},
 }

--- a/microcluster/types/endpoint.go
+++ b/microcluster/types/endpoint.go
@@ -5,10 +5,10 @@ import (
 )
 
 const (
-	// PublicEndpoint - Internally managed APIs.
+	// PublicEndpoint - All external endpoints.
 	PublicEndpoint EndpointPrefix = "core/1.0"
 
-	// InternalEndpoint - All internal endpoints restricted to trusted servers.
+	// InternalEndpoint - All internal endpoints.
 	InternalEndpoint EndpointPrefix = "core/internal"
 
 	// ControlEndpoint - All internal endpoints available on the local unix socket.


### PR DESCRIPTION
Closes https://github.com/canonical/microcluster/pull/534.

This is the **eleventh and last** PR taken from a single commit in https://github.com/canonical/microcluster/pull/534 (even though in this case the actual changes are very different from the original commit).

This PR mainly adds context around the various endpoints about there presence during and before init and moves some of the endpoints to the Unix socket for security reasons (e.g. SQL endpoints).

Furthermore I found a regression which was introduced by picking the wrong context. Fixed in the last commit.

