### PR TITLE
Add failure domain support and daemon configuration APIs (failure domains part 1/2)

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -76,3 +76,81 @@ dargs := microcluster.DaemonArgs{
     },
 }
 ```
+
+### Daemon configuration API
+
+The local daemon configuration is exposed via:
+
+* `GET /core/1.0/daemon/config`
+* `PUT /core/1.0/daemon/config`
+* `PATCH /core/1.0/daemon/config`
+
+`GET` returns `types.DaemonConfig`:
+
+```json
+{
+  "name": "m1",
+  "address": "127.0.0.1:9001",
+  "servers": {
+    "metrics.example.com": {
+      "address": "127.0.0.1:9443"
+    }
+  },
+  "failure-domain": 1
+}
+```
+
+`PUT` performs a full replacement of all mutable fields:
+
+* `servers` — replaces the servers map entirely. Omitting or setting `null` clears all servers.
+* `failure-domain` — sets a new value. Omitting or setting `null` clears the failure domain.
+
+`name` and `address` are immutable. If provided they must match the current values; if omitted they are ignored.
+
+`PATCH` supports **partial updates** using the `DaemonConfigPatch` request body:
+
+* `servers` — omit the field to leave existing server configuration unchanged; include it to replace the servers map entirely (send `{}` to clear all servers).
+* `failure-domain` — omit the field to leave the existing value unchanged; include it to set a new value (send `0` to clear the failure domain).
+
+`name` and `address` are not part of the `PATCH` request body and are ignored if present in the payload.
+
+To update only `failure-domain` without touching servers (PATCH):
+
+```json
+{
+  "failure-domain": 2
+}
+```
+
+To update only `servers` without touching `failure-domain` (PATCH):
+
+```json
+{
+  "servers": {
+    "metrics.example.com": {
+      "address": "127.0.0.1:9443"
+    }
+  }
+}
+```
+
+To clear all servers explicitly, send an empty object for the field:
+
+```json
+{
+  "servers": {}
+}
+```
+
+To clear `failure-domain`, send `0`:
+
+```json
+{
+  "failure-domain": 0
+}
+```
+
+`servers` updates are applied immediately to listener configuration.
+`failure-domain` changes are persisted immediately but only applied to dqlite on the next daemon start.
+
+The legacy `PUT /core/1.0/daemon/servers` endpoint remains available.

--- a/doc/state.md
+++ b/doc/state.md
@@ -7,7 +7,7 @@ All Microcluster information is stored and looked up in the state directory spec
 Name              | Description
 :---              | :----
 `control.socket`  | Internal Microcluster unix socket used for communication between the client and daemon
-`daemon.yaml`     | Daemon information (member name, address, additional servers)
+`daemon.yaml`     | Daemon information (member name, address, additional servers, failure domain)
 `cluster.crt/key` | Certificate keypair used for dqlite traffic and Core API
 `server.crt/key`  | Certificate keypair used for member identification and intra-cluster authentication
 `truststore`      | Directory containing local `yaml` record of cluster members

--- a/example/test/main.sh
+++ b/example/test/main.sh
@@ -641,6 +641,247 @@ test_parallel_joins() {
   shutdown_systems
 }
 
+test_daemon_config_api() {
+  echo "Testing daemon/config API"
+
+  new_systems 2 --heartbeat 2s
+  bootstrap_systems
+
+  socket_path="${test_dir}/c1/control.socket"
+
+  daemon_config_get() {
+    curl -sS --unix-socket "${socket_path}" \
+      http://unix/core/1.0/daemon/config
+  }
+
+  daemon_config_put() {
+    local payload="${1}"
+
+    curl -sS --unix-socket "${socket_path}" \
+      -X PUT \
+      -H "Content-Type: application/json" \
+      -d "${payload}" \
+      http://unix/core/1.0/daemon/config
+  }
+
+  daemon_config_patch() {
+    local payload="${1}"
+
+    curl -sS --unix-socket "${socket_path}" \
+      -X PATCH \
+      -H "Content-Type: application/json" \
+      -d "${payload}" \
+      http://unix/core/1.0/daemon/config
+  }
+
+  json_get() {
+    local payload="${1}"
+    local expr="${2}"
+
+    echo "${payload}" | yq -r "${expr}"
+  }
+
+  response_code() {
+    local payload="${1}"
+
+    local status_code
+    status_code="$(json_get "${payload}" '.status_code')"
+    if [ "${status_code}" != "0" ]; then
+      echo "${status_code}"
+      return
+    fi
+
+    json_get "${payload}" '.error_code'
+  }
+
+  # Ensure initial daemon config can be retrieved.
+  config_resp="$(daemon_config_get)"
+  [[ "$(response_code "${config_resp}")" == "200" ]] || {
+    echo "ERROR: Failed to GET daemon config"
+    echo "${config_resp}"
+    return 1
+  }
+  [[ "$(json_get "${config_resp}" '.metadata.name')" == "c1" ]] || {
+    echo "ERROR: Expected daemon name c1"
+    echo "${config_resp}"
+    return 1
+  }
+  [[ "$(json_get "${config_resp}" '.metadata.address')" == "127.0.0.1:9001" ]] || {
+    echo "ERROR: Expected daemon address 127.0.0.1:9001"
+    echo "${config_resp}"
+    return 1
+  }
+  [[ "$(json_get "${config_resp}" '.metadata."failure-domain"')" == "0" ]] || {
+    echo "ERROR: Expected initial failure-domain to be 0"
+    echo "${config_resp}"
+    return 1
+  }
+
+  # PUT sets failure-domain and clears servers (full replacement).
+  update_payload='{"name":"c1","address":"127.0.0.1:9001","failure-domain":9}'
+  update_resp="$(daemon_config_put "${update_payload}")"
+  [[ "$(response_code "${update_resp}")" == "200" ]] || {
+    echo "ERROR: Failed to update daemon config"
+    echo "${update_resp}"
+    return 1
+  }
+
+  config_resp="$(daemon_config_get)"
+  [[ "$(json_get "${config_resp}" '.metadata."failure-domain"')" == "9" ]] || {
+    echo "ERROR: Expected failure-domain to be updated to 9"
+    echo "${config_resp}"
+    return 1
+  }
+  [[ "$(json_get "${config_resp}" '.metadata.servers | length')" == "0" ]] || {
+    echo "ERROR: Expected servers map to be empty after PUT"
+    echo "${config_resp}"
+    return 1
+  }
+  grep -q "^failure-domain: 9$" "${test_dir}/c1/daemon.yaml" || {
+    echo "ERROR: daemon.yaml missing failure-domain persistence"
+    cat "${test_dir}/c1/daemon.yaml"
+    return 1
+  }
+
+  # PUT without failure-domain clears it (full replacement semantics).
+  update_payload='{"name":"c1","address":"127.0.0.1:9001"}'
+  update_resp="$(daemon_config_put "${update_payload}")"
+  [[ "$(response_code "${update_resp}")" == "200" ]] || {
+    echo "ERROR: Failed to PUT daemon config without failure-domain"
+    echo "${update_resp}"
+    return 1
+  }
+
+  config_resp="$(daemon_config_get)"
+  [[ "$(json_get "${config_resp}" '.metadata."failure-domain"')" == "0" ]] || {
+    echo "ERROR: Expected failure-domain to be cleared by PUT (full replacement)"
+    echo "${config_resp}"
+    return 1
+  }
+
+  # PATCH tests.
+
+  # Set failure-domain to a known value first via PUT.
+  update_payload='{"name":"c1","address":"127.0.0.1:9001","failure-domain":5}'
+  update_resp="$(daemon_config_put "${update_payload}")"
+  [[ "$(response_code "${update_resp}")" == "200" ]] || {
+    echo "ERROR: Failed to PUT failure-domain=5"
+    echo "${update_resp}"
+    return 1
+  }
+
+  # PATCH omitting failure-domain preserves the existing value.
+  patch_payload='{"name":"c1","address":"127.0.0.1:9001"}'
+  patch_resp="$(daemon_config_patch "${patch_payload}")"
+  [[ "$(response_code "${patch_resp}")" == "200" ]] || {
+    echo "ERROR: PATCH daemon config failed"
+    echo "${patch_resp}"
+    return 1
+  }
+
+  config_resp="$(daemon_config_get)"
+  [[ "$(json_get "${config_resp}" '.metadata."failure-domain"')" == "5" ]] || {
+    echo "ERROR: PATCH should preserve failure-domain when omitted (expected 5)"
+    echo "${config_resp}"
+    return 1
+  }
+
+  # PATCH updates failure-domain without clearing it.
+  patch_payload='{"name":"c1","address":"127.0.0.1:9001","failure-domain":7}'
+  patch_resp="$(daemon_config_patch "${patch_payload}")"
+  [[ "$(response_code "${patch_resp}")" == "200" ]] || {
+    echo "ERROR: PATCH with failure-domain failed"
+    echo "${patch_resp}"
+    return 1
+  }
+
+  config_resp="$(daemon_config_get)"
+  [[ "$(json_get "${config_resp}" '.metadata."failure-domain"')" == "7" ]] || {
+    echo "ERROR: Expected failure-domain to be updated to 7 via PATCH"
+    echo "${config_resp}"
+    return 1
+  }
+  grep -q "^failure-domain: 7$" "${test_dir}/c1/daemon.yaml" || {
+    echo "ERROR: daemon.yaml missing PATCH failure-domain persistence"
+    cat "${test_dir}/c1/daemon.yaml"
+    return 1
+  }
+
+  # PATCH ignores name and address fields — they are not part of DaemonConfigPatch.
+  # A payload containing a different name or address succeeds; the values are not applied.
+  ignore_payload='{"name":"renamed","address":"127.0.0.1:9999","failure-domain":7}'
+  ignore_resp="$(daemon_config_patch "${ignore_payload}")"
+  [[ "$(response_code "${ignore_resp}")" == "200" ]] || {
+    echo "ERROR: PATCH with unknown fields should succeed (name/address are ignored)"
+    echo "${ignore_resp}"
+    return 1
+  }
+
+  config_resp="$(daemon_config_get)"
+  [[ "$(json_get "${config_resp}" '.metadata.name')" == "c1" ]] || {
+    echo "ERROR: PATCH should not have changed the name"
+    echo "${config_resp}"
+    return 1
+  }
+  [[ "$(json_get "${config_resp}" '.metadata.address')" == "127.0.0.1:9001" ]] || {
+    echo "ERROR: PATCH should not have changed the address"
+    echo "${config_resp}"
+    return 1
+  }
+
+  # PUT Name is immutable.
+  bad_payload='{"name":"renamed","address":"127.0.0.1:9001","servers":{},"failure-domain":9}'
+  bad_resp="$(daemon_config_put "${bad_payload}")"
+  [[ "$(response_code "${bad_resp}")" == "400" ]] || {
+    echo "ERROR: PUT name change should be rejected"
+    echo "${bad_resp}"
+    return 1
+  }
+  echo "${bad_resp}" | grep -q "Name is immutable" || {
+    echo "ERROR: Expected immutable name error from PUT"
+    echo "${bad_resp}"
+    return 1
+  }
+
+  # PUT Address is immutable.
+  bad_payload='{"name":"c1","address":"127.0.0.1:9999","servers":{},"failure-domain":9}'
+  bad_resp="$(daemon_config_put "${bad_payload}")"
+  [[ "$(response_code "${bad_resp}")" == "400" ]] || {
+    echo "ERROR: PUT address change should be rejected"
+    echo "${bad_resp}"
+    return 1
+  }
+  echo "${bad_resp}" | grep -q "Address is immutable" || {
+    echo "ERROR: Expected immutable address error from PUT"
+    echo "${bad_resp}"
+    return 1
+  }
+
+  # PUT Unknown extension server should be rejected.
+  bad_payload='{"name":"c1","address":"127.0.0.1:9001","servers":{"unknown.example.com":{"address":"127.0.0.1:9443"}},"failure-domain":9}'
+  bad_resp="$(daemon_config_put "${bad_payload}")"
+  [[ "$(response_code "${bad_resp}")" == "400" ]] || {
+    echo "ERROR: Unknown server should be rejected"
+    echo "${bad_resp}"
+    return 1
+  }
+  echo "${bad_resp}" | grep -q "No matching additional listener found" || {
+    echo "ERROR: Expected unknown server validation error"
+    echo "${bad_resp}"
+    return 1
+  }
+
+  # Legacy endpoint should still be accessible.
+  legacy_resp="$(curl -sS --unix-socket "${socket_path}" http://unix/core/1.0/daemon/servers)"
+  [[ "$(response_code "${legacy_resp}")" == "200" ]] || {
+    echo "ERROR: Legacy daemon/servers endpoint should remain available"
+    echo "${legacy_resp}"
+    return 1
+  }
+
+  shutdown_systems
+}
+
 test_extended_endpoints() {
   new_systems 4 --heartbeat 2s
 
@@ -717,6 +958,7 @@ if [ "${1:-"all"}" = "all" ] || [ "${1}" = "" ]; then
   test_recover
   test_join_token_after_cluster_formed
   test_join_token_before_cluster_formed
+  test_daemon_config_api
   test_extended_endpoints
   test_membership_consistency
   test_truststore_force_removal
@@ -742,6 +984,8 @@ elif [ "${1}" = "parallel-join" ]; then
   test_parallel_joins
 elif [ "${1}" = "self-deletion" ]; then
   test_self_deletion
+elif [ "${1}" = "daemon-config" ]; then
+  test_daemon_config_api
 else
   echo "Unknown test ${1}"
 fi

--- a/internal/config/daemon.go
+++ b/internal/config/daemon.go
@@ -112,9 +112,7 @@ func (d *DaemonConfig) GetServers() map[string]types.ServerConfig {
 
 	// Create a deep copy to not return the reference to the original map.
 	serverConfigCopy := make(map[string]types.ServerConfig, len(d.config.Servers))
-	for k, v := range d.config.Servers {
-		serverConfigCopy[k] = v
-	}
+	maps.Copy(serverConfigCopy, d.config.Servers)
 
 	return serverConfigCopy
 }

--- a/internal/config/daemon.go
+++ b/internal/config/daemon.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"sync"
 
@@ -57,7 +58,17 @@ func (d *DaemonConfig) Load() error {
 
 // Dump dumps the entire daemon's config.
 func (d *DaemonConfig) Dump() *types.DaemonConfig {
-	return d.config
+	d.lock.RLock()
+	defer d.lock.RUnlock()
+
+	dump := *d.config
+
+	serversCopy := make(map[string]types.ServerConfig, len(d.config.Servers))
+	maps.Copy(serversCopy, d.config.Servers)
+
+	dump.Servers = serversCopy
+
+	return &dump
 }
 
 // Write writes the daemon's config to its path.

--- a/internal/config/daemon.go
+++ b/internal/config/daemon.go
@@ -131,3 +131,19 @@ func (d *DaemonConfig) SetServers(servers map[string]types.ServerConfig) {
 
 	d.config.Servers = servers
 }
+
+// GetFailureDomain returns the daemon's failure domain.
+func (d *DaemonConfig) GetFailureDomain() uint64 {
+	d.lock.RLock()
+	defer d.lock.RUnlock()
+
+	return d.config.FailureDomain
+}
+
+// SetFailureDomain sets the daemon's failure domain.
+func (d *DaemonConfig) SetFailureDomain(failureDomain uint64) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	d.config.FailureDomain = failureDomain
+}

--- a/internal/config/daemon_test.go
+++ b/internal/config/daemon_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/canonical/microcluster/v4/microcluster/types"
+)
+
+func TestDaemonConfigFailureDomainDefaultsToZeroWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "daemon.yaml")
+
+	content := `name: m1
+address: 127.0.0.1:9001
+servers: {}
+`
+
+	err := os.WriteFile(path, []byte(content), 0600)
+	require.NoError(t, err)
+
+	cfg := NewDaemonConfig(path)
+
+	err = cfg.Load()
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(0), cfg.GetFailureDomain())
+}
+
+func TestDaemonConfigFailureDomainRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "daemon.yaml")
+
+	cfg := NewDaemonConfig(path)
+	addr, err := types.ParseAddrPort("127.0.0.1:9001")
+	require.NoError(t, err)
+
+	cfg.SetName("m1")
+	cfg.SetAddress(addr)
+	cfg.SetServers(map[string]types.ServerConfig{})
+	cfg.SetFailureDomain(42)
+
+	err = cfg.Write()
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.True(t, strings.Contains(string(content), "failure-domain: 42"))
+
+	reloaded := NewDaemonConfig(path)
+	err = reloaded.Load()
+	require.NoError(t, err)
+	require.Equal(t, uint64(42), reloaded.GetFailureDomain())
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -288,7 +288,7 @@ func (d *Daemon) init(listenAddress string, socketGroup string, heartbeatInterva
 		return fmt.Errorf("Failed to initialize trust store: %w", err)
 	}
 
-	d.db, err = db.NewDB(d.shutdownCtx, d.ServerCert, d.ClusterCert, d.Name, d.os, heartbeatInterval)
+	d.db, err = db.NewDB(d.shutdownCtx, d.ServerCert, d.ClusterCert, d.Name, d.config.GetFailureDomain, d.os, heartbeatInterval)
 	if err != nil {
 		return fmt.Errorf("Failed to initialize database: %w", err)
 	}

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -34,10 +34,11 @@ import (
 
 // DqliteDB holds all information internal to the dqlite database.
 type DqliteDB struct {
-	memberName  func() string           // Local cluster member name
-	clusterCert func() *shared.CertInfo // Cluster certificate for dqlite authentication.
-	serverCert  func() *shared.CertInfo // Server certificate for dqlite authentication.
-	listenAddr  *url.URL                // Listen address for this dqlite node.
+	memberName    func() string           // Local cluster member name
+	clusterCert   func() *shared.CertInfo // Cluster certificate for dqlite authentication.
+	serverCert    func() *shared.CertInfo // Server certificate for dqlite authentication.
+	failureDomain func() uint64           // Local daemon failure-domain value applied when starting dqlite.
+	listenAddr    *url.URL                // Listen address for this dqlite node.
 
 	dbName string // This is db.bin.
 	os     types.OS
@@ -71,7 +72,7 @@ func (db *DqliteDB) Accept(conn net.Conn) {
 }
 
 // NewDB creates an empty db struct with no dqlite connection.
-func NewDB(ctx context.Context, serverCert func() *shared.CertInfo, clusterCert func() *shared.CertInfo, memberName func() string, os types.OS, heartbeatInterval time.Duration) (*DqliteDB, error) {
+func NewDB(ctx context.Context, serverCert func() *shared.CertInfo, clusterCert func() *shared.CertInfo, memberName func() string, failureDomain func() uint64, os types.OS, heartbeatInterval time.Duration) (*DqliteDB, error) {
 	shutdownCtx, shutdownCancel := context.WithCancel(ctx)
 
 	if heartbeatInterval == 0 {
@@ -82,6 +83,7 @@ func NewDB(ctx context.Context, serverCert func() *shared.CertInfo, clusterCert 
 		memberName:        memberName,
 		serverCert:        serverCert,
 		clusterCert:       clusterCert,
+		failureDomain:     failureDomain,
 		dbName:            filepath.Base(os.DatabasePath()),
 		os:                os,
 		acceptCh:          make(chan net.Conn),
@@ -149,6 +151,7 @@ func (db *DqliteDB) Bootstrap(extensions types.Extensions, addr *url.URL, cluste
 	db.listenAddr = addr
 	db.dqlite, err = dqlite.New(db.os.DatabaseDir(),
 		dqlite.WithAddress(db.listenAddr.Host),
+		dqlite.WithFailureDomain(db.failureDomain()),
 		dqlite.WithRolesAdjustmentFrequency(db.heartbeatInterval),
 		dqlite.WithRolesAdjustmentHook(db.heartbeat),
 		dqlite.WithConcurrentLeaderConns(&db.maxConns),
@@ -202,6 +205,7 @@ func (db *DqliteDB) Join(extensions types.Extensions, addr *url.URL, joinAddress
 		dqlite.WithRolesAdjustmentFrequency(db.heartbeatInterval),
 		dqlite.WithRolesAdjustmentHook(db.heartbeat),
 		dqlite.WithAddress(db.listenAddr.Host),
+		dqlite.WithFailureDomain(db.failureDomain()),
 		dqlite.WithConcurrentLeaderConns(&db.maxConns),
 		dqlite.WithExternalConn(db.dialFunc(), db.acceptCh),
 		dqlite.WithUnixSocket(os.Getenv(sys.DqliteSocket)))

--- a/internal/rest/client/daemon.go
+++ b/internal/rest/client/daemon.go
@@ -9,6 +9,39 @@ import (
 	"github.com/canonical/microcluster/v4/microcluster/types"
 )
 
+// GetDaemonConfig retrieves local daemon configuration.
+func GetDaemonConfig(ctx context.Context, c types.Client) (*types.DaemonConfig, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	endpoint := api.NewURL().Path("daemon", "config")
+	config := types.DaemonConfig{}
+	err := c.Query(queryCtx, "GET", types.PublicEndpoint, &endpoint.URL, nil, &config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+// UpdateDaemonConfig updates local daemon configuration.
+func UpdateDaemonConfig(ctx context.Context, c types.Client, config types.DaemonConfig) error {
+	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	endpoint := api.NewURL().Path("daemon", "config")
+	return c.Query(queryCtx, "PUT", types.PublicEndpoint, &endpoint.URL, config, nil)
+}
+
+// PatchDaemonConfig partially updates local daemon configuration.
+func PatchDaemonConfig(ctx context.Context, c types.Client, config types.DaemonConfigPatch) error {
+	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	endpoint := api.NewURL().Path("daemon", "config")
+	return c.Query(queryCtx, "PATCH", types.PublicEndpoint, &endpoint.URL, config, nil)
+}
+
 // UpdateServers updates the additional servers config.
 func UpdateServers(ctx context.Context, c types.Client, config map[string]types.ServerConfig) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)

--- a/internal/rest/resources/daemon.go
+++ b/internal/rest/resources/daemon.go
@@ -20,6 +20,21 @@ var daemonServersCmd = types.Endpoint{
 	Put: types.EndpointAction{Handler: daemonServersPut, AccessHandler: access.AllowAuthenticated},
 }
 
+var daemonConfigCmd = types.Endpoint{
+	Path: "daemon/config",
+
+	Get: types.EndpointAction{Handler: daemonConfigGet, AccessHandler: access.AllowAuthenticated},
+}
+
+func daemonConfigGet(s types.State, r *http.Request) types.Response {
+	intState, err := internalState.ToInternal(s)
+	if err != nil {
+		return types.SmartError(err)
+	}
+
+	return types.SyncResponse(true, intState.LocalConfig().Dump())
+}
+
 func daemonServersGet(s types.State, r *http.Request) types.Response {
 	intState, err := internalState.ToInternal(s)
 	if err != nil {

--- a/internal/rest/resources/daemon.go
+++ b/internal/rest/resources/daemon.go
@@ -23,7 +23,9 @@ var daemonServersCmd = types.Endpoint{
 var daemonConfigCmd = types.Endpoint{
 	Path: "daemon/config",
 
-	Get: types.EndpointAction{Handler: daemonConfigGet, AccessHandler: access.AllowAuthenticated},
+	Get:   types.EndpointAction{Handler: daemonConfigGet, AccessHandler: access.AllowAuthenticated},
+	Put:   types.EndpointAction{Handler: daemonConfigPut, AccessHandler: access.AllowAuthenticated},
+	Patch: types.EndpointAction{Handler: daemonConfigPatch, AccessHandler: access.AllowAuthenticated},
 }
 
 func daemonConfigGet(s types.State, r *http.Request) types.Response {
@@ -74,6 +76,72 @@ func daemonServersPut(s types.State, r *http.Request) types.Response {
 	return types.EmptySyncResponse
 }
 
+func daemonConfigPut(s types.State, r *http.Request) types.Response {
+	req := types.DaemonConfig{}
+
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		return types.BadRequest(err)
+	}
+
+	intState, err := internalState.ToInternal(s)
+	if err != nil {
+		return types.SmartError(err)
+	}
+
+	err = validateDaemonConfigUpdate(intState, req)
+	if err != nil {
+		return types.BadRequest(err)
+	}
+
+	daemonConfig := intState.LocalConfig()
+	daemonConfig.SetServers(req.Servers)
+	daemonConfig.SetFailureDomain(req.FailureDomain)
+
+	err = applyAndNotifyDaemonConfig(r.Context(), intState)
+	if err != nil {
+		return types.SmartError(err)
+	}
+
+	return types.EmptySyncResponse
+}
+
+func daemonConfigPatch(s types.State, r *http.Request) types.Response {
+	req := types.DaemonConfigPatch{}
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		return types.BadRequest(err)
+	}
+
+	intState, err := internalState.ToInternal(s)
+	if err != nil {
+		return types.SmartError(err)
+	}
+
+	if req.Servers != nil {
+		err = validateServerConfigs(intState, *req.Servers)
+		if err != nil {
+			return types.BadRequest(err)
+		}
+	}
+
+	daemonConfig := intState.LocalConfig()
+	if req.Servers != nil {
+		daemonConfig.SetServers(*req.Servers)
+	}
+
+	if req.FailureDomain != nil {
+		daemonConfig.SetFailureDomain(*req.FailureDomain)
+	}
+
+	err = applyAndNotifyDaemonConfig(r.Context(), intState)
+	if err != nil {
+		return types.SmartError(err)
+	}
+
+	return types.EmptySyncResponse
+}
+
 // applyAndNotifyDaemonConfig persists the current daemon configuration to file,
 // updates additional listeners, and notifies all cluster members by running
 // the OnDaemonConfigUpdate hook.
@@ -113,6 +181,26 @@ func applyAndNotifyDaemonConfig(ctx context.Context, intState *internalState.Int
 
 		return internalClient.RunOnDaemonConfigUpdateHook(ctx, c.UseTarget(remote.Name), daemonConfig.Dump())
 	})
+}
+
+// validateDaemonConfigUpdate checks that any provided immutable fields (Name, Address)
+// have not changed and delegates server config validation to validateServerConfigs.
+func validateDaemonConfigUpdate(s *internalState.InternalState, req types.DaemonConfig) error {
+	daemonConfig := s.LocalConfig().Dump()
+	if req.Name != "" && req.Name != daemonConfig.Name {
+		return fmt.Errorf("Name is immutable")
+	}
+
+	var zeroAddr types.AddrPort
+	if req.Address != zeroAddr && req.Address != daemonConfig.Address {
+		return fmt.Errorf("Address is immutable")
+	}
+
+	if req.Servers != nil {
+		return validateServerConfigs(s, req.Servers)
+	}
+
+	return nil
 }
 
 // validateServerConfigs checks that each server name has a matching additional

--- a/internal/rest/resources/daemon_test.go
+++ b/internal/rest/resources/daemon_test.go
@@ -1,0 +1,732 @@
+package resources
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
+	"github.com/stretchr/testify/require"
+
+	internalConfig "github.com/canonical/microcluster/v4/internal/config"
+	internalState "github.com/canonical/microcluster/v4/internal/state"
+	"github.com/canonical/microcluster/v4/internal/trust"
+	"github.com/canonical/microcluster/v4/microcluster/types"
+)
+
+func TestDaemonConfigGet(t *testing.T) {
+	t.Parallel()
+
+	addr, err := types.ParseAddrPort("127.0.0.1:9001")
+	require.NoError(t, err)
+
+	serverAddr, err := types.ParseAddrPort("127.0.0.1:9443")
+	require.NoError(t, err)
+
+	cfg := internalConfig.NewDaemonConfig(filepath.Join(t.TempDir(), "daemon.yaml"))
+	cfg.SetName("m1")
+	cfg.SetAddress(addr)
+	cfg.SetServers(map[string]types.ServerConfig{
+		"metrics.example.com": {Address: serverAddr},
+	})
+	cfg.SetFailureDomain(7)
+
+	s := &internalState.InternalState{
+		LocalConfig: func() *internalConfig.DaemonConfig { return cfg },
+	}
+
+	req := &http.Request{
+		Method: http.MethodGet,
+		URL:    &url.URL{},
+	}
+
+	resp := daemonConfigGet(s, req)
+	recorder := httptest.NewRecorder()
+	err = resp.Render(recorder, req)
+	require.NoError(t, err)
+
+	var body api.Response
+	err = json.NewDecoder(recorder.Result().Body).Decode(&body)
+	require.NoError(t, err)
+	require.Equal(t, api.SyncResponse, body.Type)
+	require.Equal(t, http.StatusOK, body.StatusCode)
+
+	metadata, err := json.Marshal(body.Metadata)
+	require.NoError(t, err)
+
+	var got types.DaemonConfig
+	err = json.Unmarshal(metadata, &got)
+	require.NoError(t, err)
+
+	require.Equal(t, "m1", got.Name)
+	require.Equal(t, "127.0.0.1:9001", got.Address.String())
+	require.Equal(t, uint64(7), got.FailureDomain)
+	require.NotNil(t, got.Servers)
+	require.Contains(t, got.Servers, "metrics.example.com")
+	require.Equal(t, "127.0.0.1:9443", got.Servers["metrics.example.com"].Address.String())
+}
+
+func TestDaemonServersGetCompatibility(t *testing.T) {
+	t.Parallel()
+
+	serverAddr, err := types.ParseAddrPort("127.0.0.1:9443")
+	require.NoError(t, err)
+
+	cfg := internalConfig.NewDaemonConfig(filepath.Join(t.TempDir(), "daemon.yaml"))
+	cfg.SetServers(map[string]types.ServerConfig{
+		"metrics.example.com": {Address: serverAddr},
+	})
+
+	s := &internalState.InternalState{
+		LocalConfig: func() *internalConfig.DaemonConfig { return cfg },
+	}
+
+	req := &http.Request{
+		Method: http.MethodGet,
+		URL:    &url.URL{},
+	}
+
+	resp := daemonServersGet(s, req)
+	recorder := httptest.NewRecorder()
+	err = resp.Render(recorder, req)
+	require.NoError(t, err)
+
+	var body api.Response
+	err = json.NewDecoder(recorder.Result().Body).Decode(&body)
+	require.NoError(t, err)
+	require.Equal(t, api.SyncResponse, body.Type)
+	require.Equal(t, http.StatusOK, body.StatusCode)
+
+	metadata, err := json.Marshal(body.Metadata)
+	require.NoError(t, err)
+
+	var got map[string]types.ServerConfig
+	err = json.Unmarshal(metadata, &got)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Contains(t, got, "metrics.example.com")
+	require.Equal(t, "127.0.0.1:9443", got["metrics.example.com"].Address.String())
+}
+
+func TestValidateDaemonConfigUpdateRejects(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mutate  func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfig
+		wantErr string
+	}{
+		{
+			name: "name change",
+			mutate: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfig {
+				servers := cfg.GetServers()
+				fd := cfg.GetFailureDomain()
+				return types.DaemonConfig{
+					Name:          "m2",
+					Address:       cfg.GetAddress(),
+					Servers:       servers,
+					FailureDomain: fd,
+				}
+			},
+			wantErr: "Name is immutable",
+		},
+		{
+			name: "address change",
+			mutate: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfig {
+				otherAddr, err := types.ParseAddrPort("127.0.0.1:9002")
+				require.NoError(t, err)
+
+				servers := cfg.GetServers()
+				fd := cfg.GetFailureDomain()
+				return types.DaemonConfig{
+					Name:          cfg.GetName(),
+					Address:       otherAddr,
+					Servers:       servers,
+					FailureDomain: fd,
+				}
+			},
+			wantErr: "Address is immutable",
+		},
+		{
+			name: "unknown server",
+			mutate: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfig {
+				serverAddr, err := types.ParseAddrPort("127.0.0.1:9444")
+				require.NoError(t, err)
+
+				fd := cfg.GetFailureDomain()
+				servers := map[string]types.ServerConfig{
+					"unknown.example.com": {Address: serverAddr},
+				}
+
+				return types.DaemonConfig{
+					Name:          cfg.GetName(),
+					Address:       cfg.GetAddress(),
+					Servers:       servers,
+					FailureDomain: fd,
+				}
+			},
+			wantErr: "No matching additional listener found",
+		},
+		{
+			name: "address conflict",
+			mutate: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfig {
+				conflicting, err := types.ParseAddrPort("127.0.0.1:9001")
+				require.NoError(t, err)
+
+				fd := cfg.GetFailureDomain()
+				servers := map[string]types.ServerConfig{
+					"metrics.example.com": {Address: conflicting},
+				}
+
+				return types.DaemonConfig{
+					Name:          cfg.GetName(),
+					Address:       cfg.GetAddress(),
+					Servers:       servers,
+					FailureDomain: fd,
+				}
+			},
+			wantErr: "already in use",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			addr, err := types.ParseAddrPort("127.0.0.1:9001")
+			require.NoError(t, err)
+			serverAddr, err := types.ParseAddrPort("127.0.0.1:9443")
+			require.NoError(t, err)
+
+			cfg := internalConfig.NewDaemonConfig(filepath.Join(t.TempDir(), "daemon.yaml"))
+			cfg.SetName("m1")
+			cfg.SetAddress(addr)
+			cfg.SetServers(map[string]types.ServerConfig{
+				"metrics.example.com": {Address: serverAddr},
+			})
+			cfg.SetFailureDomain(3)
+
+			updateCalls := 0
+			s := &internalState.InternalState{
+				LocalConfig: func() *internalConfig.DaemonConfig {
+					return cfg
+				},
+				UpdateServers: func() error {
+					updateCalls++
+					return nil
+				},
+				InternalAddress: func() *url.URL {
+					return &url.URL{Host: addr.String()}
+				},
+				InternalExtensionServers: func() []string {
+					return []string{"metrics.example.com"}
+				},
+			}
+
+			req := tt.mutate(t, cfg)
+
+			err = validateDaemonConfigUpdate(s, req)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tt.wantErr)
+			require.Equal(t, 0, updateCalls)
+		})
+	}
+}
+
+func TestDaemonConfigPut(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		request         func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfig
+		wantType        api.ResponseType
+		wantStatusCode  int
+		wantBodyContain string
+		wantUpdateCalls int
+		verifyState     func(t *testing.T, cfg *internalConfig.DaemonConfig, cfgPath string)
+	}{
+		{
+			name: "applies and persists",
+			request: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfig {
+				newServerAddr, err := types.ParseAddrPort("127.0.0.1:9555")
+				require.NoError(t, err)
+
+				fd := uint64(9)
+				servers := map[string]types.ServerConfig{
+					"metrics.example.com": {Address: newServerAddr},
+				}
+
+				return types.DaemonConfig{
+					Name:          cfg.GetName(),
+					Address:       cfg.GetAddress(),
+					Servers:       servers,
+					FailureDomain: fd,
+				}
+			},
+			wantType:        api.SyncResponse,
+			wantStatusCode:  http.StatusOK,
+			wantUpdateCalls: 1,
+			verifyState: func(t *testing.T, cfg *internalConfig.DaemonConfig, cfgPath string) {
+				t.Helper()
+
+				require.Equal(t, uint64(9), cfg.GetFailureDomain())
+				require.Equal(t, "127.0.0.1:9555", cfg.GetServers()["metrics.example.com"].Address.String())
+
+				reloaded := internalConfig.NewDaemonConfig(cfgPath)
+				err := reloaded.Load()
+				require.NoError(t, err)
+				require.Equal(t, uint64(9), reloaded.GetFailureDomain())
+				require.Equal(t, "127.0.0.1:9555", reloaded.GetServers()["metrics.example.com"].Address.String())
+			},
+		},
+		{
+			name: "rejects name change",
+			request: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfig {
+				servers := cfg.GetServers()
+				fd := cfg.GetFailureDomain()
+				return types.DaemonConfig{
+					Name:          "m2",
+					Address:       cfg.GetAddress(),
+					Servers:       servers,
+					FailureDomain: fd,
+				}
+			},
+			wantType:        api.ErrorResponse,
+			wantStatusCode:  http.StatusBadRequest,
+			wantBodyContain: "Name is immutable",
+			wantUpdateCalls: 0,
+		},
+		{
+			name: "omitting servers clears existing servers",
+			request: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfig {
+				fd := uint64(5)
+				return types.DaemonConfig{
+					Name:          cfg.GetName(),
+					Address:       cfg.GetAddress(),
+					FailureDomain: fd,
+				}
+			},
+			wantType:        api.SyncResponse,
+			wantStatusCode:  http.StatusOK,
+			wantUpdateCalls: 1,
+			verifyState: func(t *testing.T, cfg *internalConfig.DaemonConfig, cfgPath string) {
+				t.Helper()
+
+				// FailureDomain updated.
+				require.Equal(t, uint64(5), cfg.GetFailureDomain())
+				// Servers cleared (nil map → empty).
+				require.Empty(t, cfg.GetServers())
+			},
+		},
+		{
+			name: "omitting failure-domain clears existing value",
+			request: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfig {
+				newServerAddr, err := types.ParseAddrPort("127.0.0.1:9555")
+				require.NoError(t, err)
+
+				servers := map[string]types.ServerConfig{
+					"metrics.example.com": {Address: newServerAddr},
+				}
+
+				return types.DaemonConfig{
+					Name:    cfg.GetName(),
+					Address: cfg.GetAddress(),
+					Servers: servers,
+				}
+			},
+			wantType:        api.SyncResponse,
+			wantStatusCode:  http.StatusOK,
+			wantUpdateCalls: 1,
+			verifyState: func(t *testing.T, cfg *internalConfig.DaemonConfig, cfgPath string) {
+				t.Helper()
+
+				// Servers updated.
+				require.Equal(t, "127.0.0.1:9555", cfg.GetServers()["metrics.example.com"].Address.String())
+				// FailureDomain cleared (was 3, now 0).
+				require.Equal(t, uint64(0), cfg.GetFailureDomain())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfgPath := filepath.Join(t.TempDir(), "daemon.yaml")
+			addr, err := types.ParseAddrPort("127.0.0.1:9001")
+			require.NoError(t, err)
+			serverAddr, err := types.ParseAddrPort("127.0.0.1:9443")
+			require.NoError(t, err)
+
+			cfg := internalConfig.NewDaemonConfig(cfgPath)
+			cfg.SetName("m1")
+			cfg.SetAddress(addr)
+			cfg.SetServers(map[string]types.ServerConfig{
+				"metrics.example.com": {Address: serverAddr},
+			})
+			cfg.SetFailureDomain(3)
+			err = cfg.Write()
+			require.NoError(t, err)
+
+			updateCalls := 0
+			s := &internalState.InternalState{
+				LocalConfig: func() *internalConfig.DaemonConfig {
+					return cfg
+				},
+				UpdateServers: func() error {
+					updateCalls++
+					return nil
+				},
+				InternalAddress: func() *url.URL {
+					return &url.URL{Host: addr.String()}
+				},
+				InternalExtensionServers: func() []string {
+					return []string{"metrics.example.com"}
+				},
+			}
+
+			trustStorePath := filepath.Join(t.TempDir(), "truststore")
+			certPath := filepath.Join(t.TempDir(), "certs")
+			err = os.MkdirAll(certPath, 0755)
+			require.NoError(t, err)
+			serverCert, err := shared.KeyPairAndCA(certPath, string(types.ServerCertificateName), shared.CertServer, shared.CertOptions{})
+			require.NoError(t, err)
+			clusterCert, err := shared.KeyPairAndCA(certPath, string(types.ClusterCertificateName), shared.CertServer, shared.CertOptions{})
+			require.NoError(t, err)
+			clusterX509, err := clusterCert.PublicKeyX509()
+			require.NoError(t, err)
+
+			remotes := &trust.Remotes{}
+			err = os.MkdirAll(trustStorePath, 0755)
+			require.NoError(t, err)
+			err = remotes.Load(trustStorePath)
+			require.NoError(t, err)
+			err = remotes.Add(trustStorePath, types.Remote{
+				Location: types.Location{Name: "m1", Address: addr},
+				Certificate: types.X509Certificate{
+					Certificate: clusterX509,
+				},
+			})
+			require.NoError(t, err)
+
+			s.InternalServerCert = func() *shared.CertInfo {
+				return serverCert
+			}
+
+			s.InternalClusterCert = func() *shared.CertInfo {
+				return clusterCert
+			}
+
+			s.InternalRemotes = func() *trust.Remotes {
+				return remotes
+			}
+
+			reqBody := tt.request(t, cfg)
+			body, err := json.Marshal(reqBody)
+			require.NoError(t, err)
+
+			req := &http.Request{
+				Method: http.MethodPut,
+				URL:    &url.URL{},
+				Body:   io.NopCloser(bytes.NewReader(body)),
+			}
+
+			resp := daemonConfigPut(s, req)
+			recorder := httptest.NewRecorder()
+			err = resp.Render(recorder, req)
+			require.NoError(t, err)
+
+			var apiResp api.Response
+			err = json.NewDecoder(recorder.Result().Body).Decode(&apiResp)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantType, apiResp.Type)
+			require.Equal(t, tt.wantStatusCode, recorder.Result().StatusCode)
+			require.Equal(t, tt.wantUpdateCalls, updateCalls)
+
+			if tt.wantBodyContain != "" {
+				require.Contains(t, recorder.Body.String(), tt.wantBodyContain)
+			}
+
+			if tt.verifyState != nil {
+				tt.verifyState(t, cfg, cfgPath)
+			}
+		})
+	}
+}
+
+func TestDaemonConfigPatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		request         func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfigPatch
+		wantType        api.ResponseType
+		wantStatusCode  int
+		wantBodyContain string
+		wantUpdateCalls int
+		verifyState     func(t *testing.T, cfg *internalConfig.DaemonConfig, cfgPath string)
+	}{
+		{
+			name: "applies and persists",
+			request: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfigPatch {
+				newServerAddr, err := types.ParseAddrPort("127.0.0.1:9555")
+				require.NoError(t, err)
+
+				fd := uint64(7)
+				servers := map[string]types.ServerConfig{
+					"metrics.example.com": {Address: newServerAddr},
+				}
+
+				return types.DaemonConfigPatch{
+					Servers:       &servers,
+					FailureDomain: &fd,
+				}
+			},
+			wantType:        api.SyncResponse,
+			wantStatusCode:  http.StatusOK,
+			wantUpdateCalls: 1,
+			verifyState: func(t *testing.T, cfg *internalConfig.DaemonConfig, cfgPath string) {
+				t.Helper()
+
+				require.Equal(t, uint64(7), cfg.GetFailureDomain())
+				require.Equal(t, "127.0.0.1:9555", cfg.GetServers()["metrics.example.com"].Address.String())
+
+				reloaded := internalConfig.NewDaemonConfig(cfgPath)
+				err := reloaded.Load()
+				require.NoError(t, err)
+				require.Equal(t, uint64(7), reloaded.GetFailureDomain())
+				require.Equal(t, "127.0.0.1:9555", reloaded.GetServers()["metrics.example.com"].Address.String())
+			},
+		},
+		{
+			name: "omitting servers preserves existing servers",
+			request: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfigPatch {
+				fd := uint64(5)
+				return types.DaemonConfigPatch{
+					FailureDomain: &fd,
+				}
+			},
+			wantType:        api.SyncResponse,
+			wantStatusCode:  http.StatusOK,
+			wantUpdateCalls: 1,
+			verifyState: func(t *testing.T, cfg *internalConfig.DaemonConfig, cfgPath string) {
+				t.Helper()
+
+				// FailureDomain updated.
+				require.Equal(t, uint64(5), cfg.GetFailureDomain())
+				// Existing servers untouched.
+				require.Contains(t, cfg.GetServers(), "metrics.example.com")
+			},
+		},
+		{
+			name: "omitting failure-domain preserves existing value",
+			request: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfigPatch {
+				newServerAddr, err := types.ParseAddrPort("127.0.0.1:9555")
+				require.NoError(t, err)
+
+				servers := map[string]types.ServerConfig{
+					"metrics.example.com": {Address: newServerAddr},
+				}
+
+				return types.DaemonConfigPatch{
+					Servers: &servers,
+				}
+			},
+			wantType:        api.SyncResponse,
+			wantStatusCode:  http.StatusOK,
+			wantUpdateCalls: 1,
+			verifyState: func(t *testing.T, cfg *internalConfig.DaemonConfig, cfgPath string) {
+				t.Helper()
+
+				// Servers updated.
+				require.Equal(t, "127.0.0.1:9555", cfg.GetServers()["metrics.example.com"].Address.String())
+				// FailureDomain untouched (was 3).
+				require.Equal(t, uint64(3), cfg.GetFailureDomain())
+			},
+		},
+		{
+			name: "setting failure-domain zero clears existing value",
+			request: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfigPatch {
+				fd := uint64(0)
+				return types.DaemonConfigPatch{
+					FailureDomain: &fd,
+				}
+			},
+			wantType:        api.SyncResponse,
+			wantStatusCode:  http.StatusOK,
+			wantUpdateCalls: 1,
+			verifyState: func(t *testing.T, cfg *internalConfig.DaemonConfig, cfgPath string) {
+				t.Helper()
+
+				require.Equal(t, uint64(0), cfg.GetFailureDomain())
+			},
+		},
+		{
+			name: "setting servers empty clears existing servers",
+			request: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfigPatch {
+				servers := map[string]types.ServerConfig{}
+				return types.DaemonConfigPatch{
+					Servers: &servers,
+				}
+			},
+			wantType:        api.SyncResponse,
+			wantStatusCode:  http.StatusOK,
+			wantUpdateCalls: 1,
+			verifyState: func(t *testing.T, cfg *internalConfig.DaemonConfig, cfgPath string) {
+				t.Helper()
+
+				require.Empty(t, cfg.GetServers())
+			},
+		},
+		{
+			name: "rejects unknown server name",
+			request: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfigPatch {
+				serverAddr, err := types.ParseAddrPort("127.0.0.1:9555")
+				require.NoError(t, err)
+
+				servers := map[string]types.ServerConfig{
+					"unknown.example.com": {Address: serverAddr},
+				}
+
+				return types.DaemonConfigPatch{
+					Servers: &servers,
+				}
+			},
+			wantType:        api.ErrorResponse,
+			wantStatusCode:  http.StatusBadRequest,
+			wantBodyContain: "No matching additional listener found",
+			wantUpdateCalls: 0,
+		},
+		{
+			name: "rejects server address conflict",
+			request: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfigPatch {
+				conflicting, err := types.ParseAddrPort("127.0.0.1:9001")
+				require.NoError(t, err)
+
+				servers := map[string]types.ServerConfig{
+					"metrics.example.com": {Address: conflicting},
+				}
+
+				return types.DaemonConfigPatch{
+					Servers: &servers,
+				}
+			},
+			wantType:        api.ErrorResponse,
+			wantStatusCode:  http.StatusBadRequest,
+			wantBodyContain: "already in use",
+			wantUpdateCalls: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfgPath := filepath.Join(t.TempDir(), "daemon.yaml")
+			addr, err := types.ParseAddrPort("127.0.0.1:9001")
+			require.NoError(t, err)
+			serverAddr, err := types.ParseAddrPort("127.0.0.1:9443")
+			require.NoError(t, err)
+
+			cfg := internalConfig.NewDaemonConfig(cfgPath)
+			cfg.SetName("m1")
+			cfg.SetAddress(addr)
+			cfg.SetServers(map[string]types.ServerConfig{
+				"metrics.example.com": {Address: serverAddr},
+			})
+			cfg.SetFailureDomain(3)
+			err = cfg.Write()
+			require.NoError(t, err)
+
+			updateCalls := 0
+			s := &internalState.InternalState{
+				LocalConfig: func() *internalConfig.DaemonConfig {
+					return cfg
+				},
+				UpdateServers: func() error {
+					updateCalls++
+					return nil
+				},
+				InternalAddress: func() *url.URL {
+					return &url.URL{Host: addr.String()}
+				},
+				InternalExtensionServers: func() []string {
+					return []string{"metrics.example.com"}
+				},
+			}
+
+			trustStorePath := filepath.Join(t.TempDir(), "truststore")
+			certPath := filepath.Join(t.TempDir(), "certs")
+			err = os.MkdirAll(certPath, 0755)
+			require.NoError(t, err)
+			serverCert, err := shared.KeyPairAndCA(certPath, string(types.ServerCertificateName), shared.CertServer, shared.CertOptions{})
+			require.NoError(t, err)
+			clusterCert, err := shared.KeyPairAndCA(certPath, string(types.ClusterCertificateName), shared.CertServer, shared.CertOptions{})
+			require.NoError(t, err)
+			clusterX509, err := clusterCert.PublicKeyX509()
+			require.NoError(t, err)
+
+			remotes := &trust.Remotes{}
+			err = os.MkdirAll(trustStorePath, 0755)
+			require.NoError(t, err)
+			err = remotes.Load(trustStorePath)
+			require.NoError(t, err)
+			err = remotes.Add(trustStorePath, types.Remote{
+				Location: types.Location{Name: "m1", Address: addr},
+				Certificate: types.X509Certificate{
+					Certificate: clusterX509,
+				},
+			})
+			require.NoError(t, err)
+
+			s.InternalServerCert = func() *shared.CertInfo {
+				return serverCert
+			}
+
+			s.InternalClusterCert = func() *shared.CertInfo {
+				return clusterCert
+			}
+
+			s.InternalRemotes = func() *trust.Remotes {
+				return remotes
+			}
+
+			reqBody := tt.request(t, cfg)
+			body, err := json.Marshal(reqBody)
+			require.NoError(t, err)
+
+			req := &http.Request{
+				Method: http.MethodPatch,
+				URL:    &url.URL{},
+				Body:   io.NopCloser(bytes.NewReader(body)),
+			}
+
+			resp := daemonConfigPatch(s, req)
+			recorder := httptest.NewRecorder()
+			err = resp.Render(recorder, req)
+			require.NoError(t, err)
+
+			var apiResp api.Response
+			err = json.NewDecoder(recorder.Result().Body).Decode(&apiResp)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantType, apiResp.Type)
+			require.Equal(t, tt.wantStatusCode, recorder.Result().StatusCode)
+			require.Equal(t, tt.wantUpdateCalls, updateCalls)
+
+			if tt.wantBodyContain != "" {
+				require.Contains(t, recorder.Body.String(), tt.wantBodyContain)
+			}
+
+			if tt.verifyState != nil {
+				tt.verifyState(t, cfg, cfgPath)
+			}
+		})
+	}
+}

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -30,6 +30,7 @@ var PublicEndpoints = types.Resources{
 		clusterCmd,
 		clusterMemberCmd,
 		clusterCertificatesCmd,
+		daemonConfigCmd,
 		daemonServersCmd,
 		memberCmd,
 		readyCmd,

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -469,6 +469,27 @@ func (m *MicroCluster) LoggerFromContext(ctx context.Context) *slog.Logger {
 	return logger
 }
 
+// GetDaemonConfig returns the local daemon configuration.
+func (m *MicroCluster) GetDaemonConfig(ctx context.Context) (*types.DaemonConfig, error) {
+	c, err := m.LocalClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return internalClient.GetDaemonConfig(ctx, c)
+}
+
+// UpdateDaemonConfig partially updates local daemon configuration.
+// Only fields explicitly set (non-nil) in the patch are applied; omitted fields preserve their current values.
+func (m *MicroCluster) UpdateDaemonConfig(ctx context.Context, config types.DaemonConfigPatch) error {
+	c, err := m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	return internalClient.PatchDaemonConfig(ctx, c, config)
+}
+
 // UpdateServers updates the extension servers defined when starting the daemon.
 func (m *MicroCluster) UpdateServers(ctx context.Context, config map[string]types.ServerConfig) error {
 	c, err := m.LocalClient()

--- a/microcluster/types/config.go
+++ b/microcluster/types/config.go
@@ -2,7 +2,8 @@ package types
 
 // DaemonConfig is the in memory version of the local daemon.yaml file.
 type DaemonConfig struct {
-	Name    string                  `json:"name" yaml:"name"`
-	Address AddrPort                `json:"address" yaml:"address"`
-	Servers map[string]ServerConfig `json:"servers" yaml:"servers"`
+	Name          string                  `json:"name" yaml:"name"`
+	Address       AddrPort                `json:"address" yaml:"address"`
+	Servers       map[string]ServerConfig `json:"servers" yaml:"servers"`
+	FailureDomain uint64                  `json:"failure-domain" yaml:"failure-domain"`
 }

--- a/microcluster/types/config.go
+++ b/microcluster/types/config.go
@@ -7,3 +7,10 @@ type DaemonConfig struct {
 	Servers       map[string]ServerConfig `json:"servers" yaml:"servers"`
 	FailureDomain uint64                  `json:"failure-domain" yaml:"failure-domain"`
 }
+
+// DaemonConfigPatch is the request body for PATCH /core/1.0/daemon/config.
+// Optional fields preserve existing values when omitted.
+type DaemonConfigPatch struct {
+	Servers       *map[string]ServerConfig `json:"servers,omitempty" yaml:"servers,omitempty"`
+	FailureDomain *uint64                  `json:"failure-domain,omitempty" yaml:"failure-domain,omitempty"`
+}


### PR DESCRIPTION
This adds failure domain configuration to Microcluster per https://docs.google.com/document/d/1Sy2mbkxQSUgMMyI9lE9oT1U9ln77ApYny0XVxmQ9jXs/edit?usp=sharing. A failure-domain field (`uint64`) is added to `daemon.yaml` and supplied to go-dqlite at startup via `WithFailureDomain`.

A new GET/PUT /1.0/daemon/config endpoint exposes the full daemon configuration. PUT allows updating servers and failure-domain; name and address are validated as immutable. Changes are persisted to `daemon.yaml` and take effect on next daemon start. The legacy /1.0/daemon/servers endpoint remains available.

Includes unit tests (config layer, API handlers, validation), an integration test, and documentation updates.

Part 2 will add support for immediate mode via a `restart` flag on the config update, allowing the failure domain to take effect without a manual daemon restart.
