### PR TITLE
Docs: Update links and used types

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@
 - [Lifecycle actions (hooks)](#lifecycle-actions-hooks)
 - [Query the Dqlite database directly](#query-the-dqlite-database-directly)
 - [Create your own API endpoints](#create-your-own-api-endpoints)
-- [Create your own schema extensions](#create-your-own-schema-extensions) 
-- [Additional developer documentation](#additional-developer-documentation) 
+- [Create your own schema extensions](#create-your-own-schema-extensions)
+- [Additional developer documentation](#additional-developer-documentation)
 
 ## Introduction
 
@@ -27,7 +27,7 @@ The [example package](example) in this repository, which includes a [tutorial](e
 To get the latest LTS release of Microcluster, run:
 
 ```
-go get github.com/canonical/microcluster/v2@latest
+go get github.com/canonical/microcluster/v3@latest
 ```
 
 ## Configure and start the Microcluster service
@@ -87,13 +87,13 @@ if err != nil {
 
 ### Lifecycle actions (hooks)
 
-The complete set of Microcluster hooks and their behaviors are defined [in this Go file](https://github.com/canonical/microcluster/blob/v3/internal/state/hooks.go).
+The complete set of Microcluster hooks and their behaviors are defined [in this Go file](https://github.com/canonical/microcluster/blob/v3/microcluster/types/hooks.go).
 
 Example using the `OnStart` hook:
 
 ```go
-dargs.Hooks = &state.Hooks{
-    OnStart: func(ctx context.Context, s state.State) error {
+dargs.Hooks = &types.Hooks{
+    OnStart: func(ctx context.Context, s types.State) error {
         // Code to execute on each startup.
     }
 }
@@ -158,28 +158,28 @@ When `ShutdownSignals` is not set (nil), MicroCluster uses default signals for g
 ### Create your own API endpoints
 
 ```go
-endpoint := rest.Endpoint{
+endpoint := types.Endpoint{
     Path: "mypath" // API is served over /mypath
 
-    Post: rest.EndpointAction{Handler: myHandler} // POST action for the endpoint.
+    Post: types.EndpointAction{Handler: myHandler} // POST action for the endpoint.
 }
 
-func myHandler(s state.State, r *http.Request) response.Response {
+func myHandler(s types.State, r *http.Request) types.Response {
     msg := fmt.Sprintf("This is a response from %q at %q", s.Name(), s.Address())
 
-    return response.SyncResponse(true, msg)
+    return types.SyncResponse(true, msg)
 }
 
 // Include your endpoints in DaemonArgs like so to serve over /1.0 over the default listener.
 dargs := microcluster.DaemonArgs{
-    Servers: map[string]rest.Server{
+    ExtensionServers: map[string]types.Server{
         "my-server": {
             CoreAPI: true,
             ServeUnix: true,
-            Resources: []rest.Resources{
+            Resources: []types.Resources{
                 {
                     PathPrefix: "1.0",
-                    Endpoints: []rest.Endpoint{endpoint},
+                    Endpoints: []types.Endpoint{endpoint},
                 },
             }
         }
@@ -212,4 +212,4 @@ Learn more about schema updates in [doc/upgrades.md](doc/upgrades.md).
 
 View the [doc](doc) directory for more information.
 
-You can also view the [Godoc-generated reference documentation](https://pkg.go.dev/github.com/canonical/microcluster/v2), which is generated from docstrings within the Microcluster code.
+You can also view the [Godoc-generated reference documentation](https://pkg.go.dev/github.com/canonical/microcluster/v3), which is generated from docstrings within the Microcluster code.

--- a/doc/clustering.md
+++ b/doc/clustering.md
@@ -56,7 +56,7 @@ if err != nil {
 
 Use an existing join token to add a new member to the cluster. This request can only be initiated over the local unix socket of the joiner.
 
-Before triggering the [PostJoin](https://github.com/canonical/microcluster/blob/4d80df396e335bf26f9895956e846e082bb8f624/internal/state/hooks.go#L23) lifecycle hook, all previously existing cluster members will concurrently run their [OnNewMember](https://github.com/canonical/microcluster/blob/4d80df396e335bf26f9895956e846e082bb8f624/internal/state/hooks.go#L39) lifecycle hooks.
+Before triggering the [PostJoin](https://github.com/canonical/microcluster/blob/v3/microcluster/types/hooks.go#L68) lifecycle hook, all previously existing cluster members will concurrently run their [OnNewMember](https://github.com/canonical/microcluster/blob/v3/microcluster/types/hooks.go#L84) lifecycle hooks.
 
 ```go
 m, err := microcluster.App(microcluster.Args{StateDir: "/path/to/state"})
@@ -88,8 +88,8 @@ In order to ensure database quorum is maintained, cluster members with a `PENDIN
 
 If `force=true`, errors encountered when attempting to reset the removed member back to an un-initialized state will be ignored. This should be used if the cluster member is no longer reachable by other members.
 
-* The [PreRemove](https://github.com/canonical/microcluster/blob/4d80df396e335bf26f9895956e846e082bb8f624/internal/state/hooks.go#L30) hook is executed on the to-be-removed member before it is removed from the database.
-* The [PostRemove](https://github.com/canonical/microcluster/blob/4d80df396e335bf26f9895956e846e082bb8f624/internal/state/hooks.go#L33) hook is executed on all remaining members after the to-be-removed member is removed from the database.
+* The [PreRemove](https://github.com/canonical/microcluster/blob/v3/microcluster/types/hooks.go#L75) hook is executed on the to-be-removed member before it is removed from the database.
+* The [PostRemove](https://github.com/canonical/microcluster/blob/v3/microcluster/types/hooks.go#L78) hook is executed on all remaining members after the to-be-removed member is removed from the database.
 
 ```go
 m, err := microcluster.App(microcluster.Args{StateDir: "/path/to/state"})
@@ -97,14 +97,22 @@ if err != nil {
     // ...
 }
 
-client, err := m.LocalClient()
+memberName := "member2"
+force := false
+err := m.RemoveClusterMember(ctx, memberName, "", force)
 if err != nil {
     // ...
 }
+```
 
+In the case of an inconsistency between the internal truststore, dqlite and the database, you can attempt a member removal by supplying the member's address, which allows Microcluster to determine the member if it can no longer be looked up by its name alone:
+
+```go
+force := true
 memberName := "member2"
-force := false
-err := client.DeleteClusterMember(ctx, name, force)
+memberAddress := "10.0.0.102:8000"
+
+err := m.RemoveClusterMember(ctx, memberName, memberAddress, force)
 if err != nil {
     // ...
 }

--- a/doc/status.md
+++ b/doc/status.md
@@ -1,6 +1,6 @@
 # Cluster member states
 
-Cluster member states are determinations about the status of a cluster member when making a request to `GET /core/1.0/cluster` or [client.GetClusterMembers](https://github.com/canonical/microcluster/blob/4d80df396e335bf26f9895956e846e082bb8f624/internal/rest/client/cluster.go#L40-L49). These states are not persisted.
+Cluster member states are determinations about the status of a cluster member when making a request to `GET /core/1.0/cluster` or [app.GetClusterMembers](https://github.com/canonical/microcluster/blob/v3/microcluster/app.go#L233). These states are not persisted.
 
 State         | Description
 :---          | :----

--- a/doc/upgrades.md
+++ b/doc/upgrades.md
@@ -4,7 +4,7 @@ When a new build of a project that uses Microcluster introduces logical changes 
 
 ## Schema updates
 
-The [app.Start function](https://github.com/canonical/microcluster/blob/v3/microcluster/app.go#L69-L92) accepts as an argument a list of functions that are run in sequence. These functions supply a database transaction that can be used to extend or modify the schema of the Dqlite database used by Microcluster. The order of the functions in this list must not change. New updates must be added to the end of the list, in the order to be executed.
+The [app.Start function](https://github.com/canonical/microcluster/blob/v3/microcluster/app.go#L82) accepts as an argument a list of functions that are run in sequence. These functions supply a database transaction that can be used to extend or modify the schema of the Dqlite database used by Microcluster. The order of the functions in this list must not change. New updates must be added to the end of the list, in the order to be executed.
 
 A schema version is maintained per cluster member, representing the sum-total of updates that the member is locally aware of.
 
@@ -23,7 +23,7 @@ You can see this code in use within [the example package](https://github.com/can
 
 ## API extensions
 
-The [app.Start function](https://github.com/canonical/microcluster/blob/v3/microcluster/app.go#L69-L92) accepts as argument a `[]string` that is interpreted as an ordered list of labels corresponding to changes to the API. Do not change the order of this list.
+The [app.Start function](https://github.com/canonical/microcluster/blob/v3/microcluster/app.go#L82) accepts as argument a `[]string` that is interpreted as an ordered list of labels corresponding to changes to the API. Do not change the order of this list.
 
 ### Example
 
@@ -52,9 +52,9 @@ Running cluster members that have not been upgraded will not be affected by a pe
 
 Cluster members that have not been upgraded cannot be restarted while an upgrade is in progress. The cluster member must either be upgraded, or all members waiting for the upgrade to be committed must revert to the previous version.
 
-* On members that have not been upgraded, [client.GetClusterMembers](https://github.com/canonical/microcluster/blob/4d80df396e335bf26f9895956e846e082bb8f624/internal/rest/client/cluster.go#L40-L49) will report [UNREACHABLE](https://github.com/canonical/microcluster/blob/4d80df396e335bf26f9895956e846e082bb8f624/rest/types/cluster.go#L47) for any members that have encountered an upgrade and are waiting.
+* On members that have not been upgraded, [app.GetClusterMembers](https://github.com/canonical/microcluster/blob/v3/microcluster/app.go#L233) will report [UNREACHABLE](https://github.com/canonical/microcluster/blob/v3/microcluster/types/cluster.go#L45) for any members that have encountered an upgrade and are waiting.
 
-* On upgraded members, before the upgrade is committed, [client.GetClusterMembers](https://github.com/canonical/microcluster/blob/4d80df396e335bf26f9895956e846e082bb8f624/internal/rest/client/cluster.go#L40-L49) will report [UPGRADING](https://github.com/canonical/microcluster/blob/4d80df396e335bf26f9895956e846e082bb8f624/rest/types/cluster.go#L56) for all waiting members, and [NEEDS UPGRADE](https://github.com/canonical/microcluster/blob/4d80df396e335bf26f9895956e846e082bb8f624/rest/types/cluster.go#L59) for all members that have not been upgraded.
+* On upgraded members, before the upgrade is committed, [app.GetClusterMembers](https://github.com/canonical/microcluster/blob/v3/microcluster/app.go#L233) will report [UPGRADING](https://github.com/canonical/microcluster/blob/v3/microcluster/types/cluster.go#L54) for all waiting members, and [NEEDS UPGRADE](https://github.com/canonical/microcluster/blob/v3/microcluster/types/cluster.go#L57) for all members that have not been upgraded.
 
 ## Example schema upgrade
 


### PR DESCRIPTION
To prepare for the v3 release, update all links and docs to accommodate the recent changes.