### PR TITLE
make: Pin recommended dqlite version (v3)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 GOMIN=1.25.7
 GOPATH ?= $(shell go env GOPATH)
 DQLITE_PATH=$(GOPATH)/deps/dqlite
-DQLITE_BRANCH=main
+DQLITE_BRANCH=v1.18.x
 
 .PHONY: default
 default: update-schema


### PR DESCRIPTION
Integrating Microcluster requires the dqlite deps to be built.

Pin the recommended version of dqlite for the 'make deps' call for clarity. Also this ensures the tests on v3 are always executed using deps built from v1.18.x