### PR TITLE
Backport failure domains (v3)

### DIFF
--- a/doc/api.md
+++ b/doc/api.md
@@ -76,3 +76,81 @@ dargs := microcluster.DaemonArgs{
     },
 }
 ```
+
+### Daemon configuration API
+
+The local daemon configuration is exposed via:
+
+* `GET /core/1.0/daemon/config`
+* `PUT /core/1.0/daemon/config`
+* `PATCH /core/1.0/daemon/config`
+
+`GET` returns `types.DaemonConfig`:
+
+```json
+{
+  "name": "m1",
+  "address": "127.0.0.1:9001",
+  "servers": {
+    "metrics.example.com": {
+      "address": "127.0.0.1:9443"
+    }
+  },
+  "failure-domain": 1
+}
+```
+
+`PUT` performs a full replacement of all mutable fields:
+
+* `servers` — replaces the servers map entirely. Omitting or setting `null` clears all servers.
+* `failure-domain` — sets a new value. Omitting or setting `null` clears the failure domain.
+
+`name` and `address` are immutable. If provided they must match the current values; if omitted they are ignored.
+
+`PATCH` supports **partial updates** using the `DaemonConfigPatch` request body:
+
+* `servers` — omit the field to leave existing server configuration unchanged; include it to replace the servers map entirely (send `{}` to clear all servers).
+* `failure-domain` — omit the field to leave the existing value unchanged; include it to set a new value (send `0` to clear the failure domain).
+
+`name` and `address` are not part of the `PATCH` request body and are ignored if present in the payload.
+
+To update only `failure-domain` without touching servers (PATCH):
+
+```json
+{
+  "failure-domain": 2
+}
+```
+
+To update only `servers` without touching `failure-domain` (PATCH):
+
+```json
+{
+  "servers": {
+    "metrics.example.com": {
+      "address": "127.0.0.1:9443"
+    }
+  }
+}
+```
+
+To clear all servers explicitly, send an empty object for the field:
+
+```json
+{
+  "servers": {}
+}
+```
+
+To clear `failure-domain`, send `0`:
+
+```json
+{
+  "failure-domain": 0
+}
+```
+
+`servers` updates are applied immediately to listener configuration.
+`failure-domain` changes are persisted immediately but only applied to dqlite on the next daemon start.
+
+The legacy `PUT /core/1.0/daemon/servers` endpoint remains available.

--- a/doc/api.md
+++ b/doc/api.md
@@ -100,21 +100,26 @@ The local daemon configuration is exposed via:
 }
 ```
 
-`PUT` performs a full replacement of all mutable fields:
+`PUT` uses `DaemonConfig` as the request body and performs a full replacement of all mutable fields:
 
-* `servers` — replaces the servers map entirely. Omitting or setting `null` clears all servers.
-* `failure-domain` — sets a new value. Omitting or setting `null` clears the failure domain (default: `0`).
+* `servers` — replaces the servers map entirely. Omitting or sending `null` clears all servers.
+* `failure-domain` — sets a new value. Omitting resets it to the default (`0`).
 
 `name` and `address` are immutable. If provided they must match the current values; if omitted they are ignored.
 
-`PATCH` supports **partial updates** using the `DaemonConfigPatch` request body:
+`PATCH` uses `DaemonConfigPatch` as the request body and performs a partial update:
 
-* `servers` — omit the field to leave existing server configuration unchanged; include it to replace the servers map entirely (send `{}` to clear all servers).
-* `failure-domain` — omit the field to leave the existing value unchanged; include it to set a new value (send `0` to reset to the default).
+* `servers` — omit to leave existing server configuration unchanged; include it to replace the servers map entirely (send `{}` to clear).
+* `failure-domain` — omit to leave the existing value unchanged; include it to set a new value (send `0` to reset to the default).
 
 `name` and `address` are not part of the `PATCH` request body and are ignored if present in the payload.
 
-To update only `failure-domain` without touching servers (PATCH):
+Both `PUT` and `PATCH` accept an optional `restart` query parameter:
+
+* `?restart=true` — after persisting the config changes, the local dqlite node is restarted so that `failure-domain` and other dqlite-level settings take effect immediately without a full daemon restart. The request returns only after the local restart has completed. The restart is local only; each member must issue its own request if a cluster-wide restart is needed.
+* `?restart=false` (default) — config is persisted and listeners are updated, but dqlite is not restarted. `failure-domain` changes will take effect on the next daemon start.
+
+To update `failure-domain` and restart dqlite immediately, send the request to `PATCH /core/1.0/daemon/config?restart=true`:
 
 ```json
 {
@@ -122,7 +127,15 @@ To update only `failure-domain` without touching servers (PATCH):
 }
 ```
 
-To update only `servers` without touching `failure-domain` (PATCH):
+To update only `failure-domain` without touching servers (PATCH only):
+
+```json
+{
+  "failure-domain": 2
+}
+```
+
+To update only `servers` without touching `failure-domain` (PATCH only):
 
 ```json
 {
@@ -151,6 +164,8 @@ To clear `failure-domain`, send `0` (the default):
 ```
 
 `servers` updates are applied immediately to listener configuration.
-`failure-domain` changes are persisted immediately but only applied to dqlite on the next daemon start.
+`failure-domain` changes are persisted immediately but only applied to dqlite on the next daemon start unless `?restart=true` is set.
+
+To avoid the need for a restart entirely, set the `InitFailureDomain` field in `DaemonArgs` before starting the daemon. This initialises the failure domain from the start so no subsequent restart is required.
 
 The legacy `PUT /core/1.0/daemon/servers` endpoint remains available.

--- a/doc/api.md
+++ b/doc/api.md
@@ -103,14 +103,14 @@ The local daemon configuration is exposed via:
 `PUT` performs a full replacement of all mutable fields:
 
 * `servers` — replaces the servers map entirely. Omitting or setting `null` clears all servers.
-* `failure-domain` — sets a new value. Omitting or setting `null` clears the failure domain.
+* `failure-domain` — sets a new value. Omitting or setting `null` clears the failure domain (default: `0`).
 
 `name` and `address` are immutable. If provided they must match the current values; if omitted they are ignored.
 
 `PATCH` supports **partial updates** using the `DaemonConfigPatch` request body:
 
 * `servers` — omit the field to leave existing server configuration unchanged; include it to replace the servers map entirely (send `{}` to clear all servers).
-* `failure-domain` — omit the field to leave the existing value unchanged; include it to set a new value (send `0` to clear the failure domain).
+* `failure-domain` — omit the field to leave the existing value unchanged; include it to set a new value (send `0` to reset to the default).
 
 `name` and `address` are not part of the `PATCH` request body and are ignored if present in the payload.
 
@@ -142,7 +142,7 @@ To clear all servers explicitly, send an empty object for the field:
 }
 ```
 
-To clear `failure-domain`, send `0`:
+To clear `failure-domain`, send `0` (the default):
 
 ```json
 {

--- a/doc/state.md
+++ b/doc/state.md
@@ -7,7 +7,7 @@ All Microcluster information is stored and looked up in the state directory spec
 Name              | Description
 :---              | :----
 `control.socket`  | Internal Microcluster unix socket used for communication between the client and daemon
-`daemon.yaml`     | Daemon information (member name, address, additional servers)
+`daemon.yaml`     | Daemon information (member name, address, additional servers, failure domain)
 `cluster.crt/key` | Certificate keypair used for dqlite traffic and Core API
 `server.crt/key`  | Certificate keypair used for member identification and intra-cluster authentication
 `truststore`      | Directory containing local `yaml` record of cluster members

--- a/example/cmd/microctl/describe.go
+++ b/example/cmd/microctl/describe.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"net"
+	"os"
+	"path/filepath"
+	"time"
+
+	dqliteClient "github.com/canonical/go-dqlite/v3/client"
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	internalClient "github.com/canonical/microcluster/v3/internal/rest/client"
+)
+
+type cmdDescribe struct {
+	common *CmdControl
+
+	flagTimeout int
+}
+
+func (c *cmdDescribe) command() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "describe <address>",
+		Short: "Describe dqlite node metadata",
+		RunE:  c.run,
+	}
+
+	cmd.Flags().IntVarP(&c.flagTimeout, "timeout", "t", 5, "Number of seconds before timing out")
+	return cmd
+}
+
+func (c *cmdDescribe) run(cmd *cobra.Command, args []string) error {
+	if len(args) != 1 {
+		return cmd.Help()
+	}
+
+	ctx := cmd.Context()
+	var cancel context.CancelFunc = func() {}
+	if c.flagTimeout > 0 {
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(c.flagTimeout)*time.Second)
+	}
+
+	defer cancel()
+
+	meta, err := describeDqliteNodeMetadata(ctx, c.common.FlagStateDir, args[0])
+	if err != nil {
+		return err
+	}
+
+	out, err := yaml.Marshal(struct {
+		FailureDomain uint64 `yaml:"failure-domain"`
+		Weight        uint64 `yaml:"weight"`
+	}{
+		FailureDomain: meta.FailureDomain,
+		Weight:        meta.Weight,
+	})
+	if err != nil {
+		return fmt.Errorf("Failed marshalling dqlite node metadata: %w", err)
+	}
+
+	fmt.Print(string(out))
+	return nil
+}
+
+// describeDqliteNodeMetadata connects to the given dqlite address and returns node metadata.
+// This helper exists to support developer/test verification workflows and is not intended as a
+// stable API surface.
+func describeDqliteNodeMetadata(ctx context.Context, stateDir string, address string) (*dqliteClient.NodeMetadata, error) {
+	serverCert, err := tls.LoadX509KeyPair(filepath.Join(stateDir, "server.crt"), filepath.Join(stateDir, "server.key"))
+	if err != nil {
+		return nil, fmt.Errorf("Failed loading server keypair: %w", err)
+	}
+
+	clusterPEM, err := os.ReadFile(filepath.Join(stateDir, "cluster.crt"))
+	if err != nil {
+		return nil, fmt.Errorf("Failed reading cluster certificate: %w", err)
+	}
+
+	block, _ := pem.Decode(clusterPEM)
+	if block == nil {
+		return nil, fmt.Errorf("Failed decoding cluster certificate")
+	}
+
+	clusterX509, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("Failed parsing cluster certificate: %w", err)
+	}
+
+	pool := x509.NewCertPool()
+	ok := pool.AppendCertsFromPEM(clusterPEM)
+	if !ok {
+		return nil, fmt.Errorf("Failed appending cluster certificates to pool")
+	}
+
+	dial := func(ctx context.Context, address string) (net.Conn, error) {
+		config := &tls.Config{
+			Certificates: []tls.Certificate{serverCert},
+			RootCAs:      pool,
+			MinVersion:   tls.VersionTLS12,
+		}
+
+		if len(clusterX509.DNSNames) > 0 {
+			config.ServerName = clusterX509.DNSNames[0]
+		}
+
+		return internalClient.DialDqlite(ctx, address, config)
+	}
+
+	client, err := dqliteClient.New(ctx, address, dqliteClient.WithDialFunc(dial))
+	if err != nil {
+		return nil, fmt.Errorf("Failed connecting to dqlite: %w", err)
+	}
+
+	defer client.Close()
+
+	meta, err := client.Describe(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("Failed describing dqlite node metadata: %w", err)
+	}
+
+	return meta, nil
+}

--- a/example/cmd/microctl/main.go
+++ b/example/cmd/microctl/main.go
@@ -80,6 +80,9 @@ func main() {
 	var cmdExtended = cmdExtended{common: &commonCmd}
 	app.AddCommand(cmdExtended.command())
 
+	var cmdDescribe = cmdDescribe{common: &commonCmd}
+	app.AddCommand(cmdDescribe.command())
+
 	app.InitDefaultHelpCmd()
 
 	err := app.Execute()

--- a/example/test/main.sh
+++ b/example/test/main.sh
@@ -11,7 +11,21 @@ fi
 
 test_dir="$(realpath -e "$(dirname -- "${BASH_SOURCE[0]}")")/system"
 
-trap shutdown_systems EXIT HUP INT TERM
+# Must be set before cleanup().
+TEST_CURRENT="setup"
+TEST_RESULT="failure"
+
+declare -A test_results
+
+cleanup() {
+  shutdown_systems
+
+  echo ""
+  echo ""
+  echo "==> Test result: ${TEST_RESULT}"
+}
+
+trap cleanup EXIT HUP INT TERM
 
 new_systems() {
   if [ -d "${test_dir}" ]; then
@@ -73,6 +87,25 @@ shutdown_systems() {
       kill -9 "${job_pid}" 2>/dev/null || true
     fi
   done
+}
+
+run_test() {
+  local test_name="${1}"
+
+  TEST_CURRENT="${test_name}"
+  echo "==> TEST BEGIN: ${TEST_CURRENT}"
+
+  if "test_${test_name}"; then
+    test_results["${test_name}"]="PASS"
+  else
+    test_results["${test_name}"]="FAIL"
+  fi
+  echo "==> TEST DONE: ${TEST_CURRENT}"
+
+  if [ "${test_results[${test_name}]}" != "PASS" ]; then
+    TEST_RESULT="failure"
+    return 1
+  fi
 }
 
 test_misc() {
@@ -952,40 +985,43 @@ test_self_deletion() {
 }
 
 # allow for running a specific set of tests
+TEST_RESULT="success"
 if [ "${1:-"all"}" = "all" ] || [ "${1}" = "" ]; then
-  test_misc
-  test_tokens
-  test_recover
-  test_join_token_after_cluster_formed
-  test_join_token_before_cluster_formed
-  test_daemon_config_api
-  test_extended_endpoints
-  test_membership_consistency
-  test_truststore_force_removal
-  test_parallel_joins
-  test_self_deletion
+  run_test misc
+  run_test tokens
+  run_test recover
+  run_test join_token_after_cluster_formed
+  run_test join_token_before_cluster_formed
+  run_test daemon_config_api
+  run_test extended_endpoints
+  run_test membership_consistency
+  run_test truststore_force_removal
+  run_test parallel_joins
+  run_test self_deletion
 elif [ "${1}" = "recover" ]; then
-  test_recover
+  run_test recover
 elif [ "${1}" = "tokens" ]; then
-  test_tokens
+  run_test tokens
 elif [ "${1}" = "misc" ]; then
-  test_misc
+  run_test misc
 elif [ "${1}" = "join-after" ]; then
-  test_join_token_after_cluster_formed
+  run_test join_token_after_cluster_formed
 elif [ "${1}" = "join-before" ]; then
-  test_join_token_before_cluster_formed
+  run_test join_token_before_cluster_formed
 elif [ "${1}" = "extended" ]; then
-  test_extended_endpoints
+  run_test extended_endpoints
 elif [ "${1}" = "membership" ]; then
-  test_membership_consistency
+  run_test membership_consistency
 elif [ "${1}" = "force-removal" ]; then
-  test_truststore_force_removal
+  run_test truststore_force_removal
 elif [ "${1}" = "parallel-join" ]; then
-  test_parallel_joins
+  run_test parallel_joins
 elif [ "${1}" = "self-deletion" ]; then
-  test_self_deletion
+  run_test self_deletion
 elif [ "${1}" = "daemon-config" ]; then
-  test_daemon_config_api
+  run_test daemon_config_api
 else
   echo "Unknown test ${1}"
+  TEST_RESULT="failure"
+  exit 1
 fi

--- a/example/test/main.sh
+++ b/example/test/main.sh
@@ -641,6 +641,247 @@ test_parallel_joins() {
   shutdown_systems
 }
 
+test_daemon_config_api() {
+  echo "Testing daemon/config API"
+
+  new_systems 2 --heartbeat 2s
+  bootstrap_systems
+
+  socket_path="${test_dir}/c1/control.socket"
+
+  daemon_config_get() {
+    curl -sS --unix-socket "${socket_path}" \
+      http://unix/core/1.0/daemon/config
+  }
+
+  daemon_config_put() {
+    local payload="${1}"
+
+    curl -sS --unix-socket "${socket_path}" \
+      -X PUT \
+      -H "Content-Type: application/json" \
+      -d "${payload}" \
+      http://unix/core/1.0/daemon/config
+  }
+
+  daemon_config_patch() {
+    local payload="${1}"
+
+    curl -sS --unix-socket "${socket_path}" \
+      -X PATCH \
+      -H "Content-Type: application/json" \
+      -d "${payload}" \
+      http://unix/core/1.0/daemon/config
+  }
+
+  json_get() {
+    local payload="${1}"
+    local expr="${2}"
+
+    echo "${payload}" | yq -r "${expr}"
+  }
+
+  response_code() {
+    local payload="${1}"
+
+    local status_code
+    status_code="$(json_get "${payload}" '.status_code')"
+    if [ "${status_code}" != "0" ]; then
+      echo "${status_code}"
+      return
+    fi
+
+    json_get "${payload}" '.error_code'
+  }
+
+  # Ensure initial daemon config can be retrieved.
+  config_resp="$(daemon_config_get)"
+  [[ "$(response_code "${config_resp}")" == "200" ]] || {
+    echo "ERROR: Failed to GET daemon config"
+    echo "${config_resp}"
+    return 1
+  }
+  [[ "$(json_get "${config_resp}" '.metadata.name')" == "c1" ]] || {
+    echo "ERROR: Expected daemon name c1"
+    echo "${config_resp}"
+    return 1
+  }
+  [[ "$(json_get "${config_resp}" '.metadata.address')" == "127.0.0.1:9001" ]] || {
+    echo "ERROR: Expected daemon address 127.0.0.1:9001"
+    echo "${config_resp}"
+    return 1
+  }
+  [[ "$(json_get "${config_resp}" '.metadata."failure-domain"')" == "0" ]] || {
+    echo "ERROR: Expected initial failure-domain to be 0"
+    echo "${config_resp}"
+    return 1
+  }
+
+  # PUT sets failure-domain and clears servers (full replacement).
+  update_payload='{"name":"c1","address":"127.0.0.1:9001","failure-domain":9}'
+  update_resp="$(daemon_config_put "${update_payload}")"
+  [[ "$(response_code "${update_resp}")" == "200" ]] || {
+    echo "ERROR: Failed to update daemon config"
+    echo "${update_resp}"
+    return 1
+  }
+
+  config_resp="$(daemon_config_get)"
+  [[ "$(json_get "${config_resp}" '.metadata."failure-domain"')" == "9" ]] || {
+    echo "ERROR: Expected failure-domain to be updated to 9"
+    echo "${config_resp}"
+    return 1
+  }
+  [[ "$(json_get "${config_resp}" '.metadata.servers | length')" == "0" ]] || {
+    echo "ERROR: Expected servers map to be empty after PUT"
+    echo "${config_resp}"
+    return 1
+  }
+  grep -q "^failure-domain: 9$" "${test_dir}/c1/daemon.yaml" || {
+    echo "ERROR: daemon.yaml missing failure-domain persistence"
+    cat "${test_dir}/c1/daemon.yaml"
+    return 1
+  }
+
+  # PUT without failure-domain clears it (full replacement semantics).
+  update_payload='{"name":"c1","address":"127.0.0.1:9001"}'
+  update_resp="$(daemon_config_put "${update_payload}")"
+  [[ "$(response_code "${update_resp}")" == "200" ]] || {
+    echo "ERROR: Failed to PUT daemon config without failure-domain"
+    echo "${update_resp}"
+    return 1
+  }
+
+  config_resp="$(daemon_config_get)"
+  [[ "$(json_get "${config_resp}" '.metadata."failure-domain"')" == "0" ]] || {
+    echo "ERROR: Expected failure-domain to be cleared by PUT (full replacement)"
+    echo "${config_resp}"
+    return 1
+  }
+
+  # PATCH tests.
+
+  # Set failure-domain to a known value first via PUT.
+  update_payload='{"name":"c1","address":"127.0.0.1:9001","failure-domain":5}'
+  update_resp="$(daemon_config_put "${update_payload}")"
+  [[ "$(response_code "${update_resp}")" == "200" ]] || {
+    echo "ERROR: Failed to PUT failure-domain=5"
+    echo "${update_resp}"
+    return 1
+  }
+
+  # PATCH omitting failure-domain preserves the existing value.
+  patch_payload='{"name":"c1","address":"127.0.0.1:9001"}'
+  patch_resp="$(daemon_config_patch "${patch_payload}")"
+  [[ "$(response_code "${patch_resp}")" == "200" ]] || {
+    echo "ERROR: PATCH daemon config failed"
+    echo "${patch_resp}"
+    return 1
+  }
+
+  config_resp="$(daemon_config_get)"
+  [[ "$(json_get "${config_resp}" '.metadata."failure-domain"')" == "5" ]] || {
+    echo "ERROR: PATCH should preserve failure-domain when omitted (expected 5)"
+    echo "${config_resp}"
+    return 1
+  }
+
+  # PATCH updates failure-domain without clearing it.
+  patch_payload='{"name":"c1","address":"127.0.0.1:9001","failure-domain":7}'
+  patch_resp="$(daemon_config_patch "${patch_payload}")"
+  [[ "$(response_code "${patch_resp}")" == "200" ]] || {
+    echo "ERROR: PATCH with failure-domain failed"
+    echo "${patch_resp}"
+    return 1
+  }
+
+  config_resp="$(daemon_config_get)"
+  [[ "$(json_get "${config_resp}" '.metadata."failure-domain"')" == "7" ]] || {
+    echo "ERROR: Expected failure-domain to be updated to 7 via PATCH"
+    echo "${config_resp}"
+    return 1
+  }
+  grep -q "^failure-domain: 7$" "${test_dir}/c1/daemon.yaml" || {
+    echo "ERROR: daemon.yaml missing PATCH failure-domain persistence"
+    cat "${test_dir}/c1/daemon.yaml"
+    return 1
+  }
+
+  # PATCH ignores name and address fields — they are not part of DaemonConfigPatch.
+  # A payload containing a different name or address succeeds; the values are not applied.
+  ignore_payload='{"name":"renamed","address":"127.0.0.1:9999","failure-domain":7}'
+  ignore_resp="$(daemon_config_patch "${ignore_payload}")"
+  [[ "$(response_code "${ignore_resp}")" == "200" ]] || {
+    echo "ERROR: PATCH with unknown fields should succeed (name/address are ignored)"
+    echo "${ignore_resp}"
+    return 1
+  }
+
+  config_resp="$(daemon_config_get)"
+  [[ "$(json_get "${config_resp}" '.metadata.name')" == "c1" ]] || {
+    echo "ERROR: PATCH should not have changed the name"
+    echo "${config_resp}"
+    return 1
+  }
+  [[ "$(json_get "${config_resp}" '.metadata.address')" == "127.0.0.1:9001" ]] || {
+    echo "ERROR: PATCH should not have changed the address"
+    echo "${config_resp}"
+    return 1
+  }
+
+  # PUT Name is immutable.
+  bad_payload='{"name":"renamed","address":"127.0.0.1:9001","servers":{},"failure-domain":9}'
+  bad_resp="$(daemon_config_put "${bad_payload}")"
+  [[ "$(response_code "${bad_resp}")" == "400" ]] || {
+    echo "ERROR: PUT name change should be rejected"
+    echo "${bad_resp}"
+    return 1
+  }
+  echo "${bad_resp}" | grep -q "Name is immutable" || {
+    echo "ERROR: Expected immutable name error from PUT"
+    echo "${bad_resp}"
+    return 1
+  }
+
+  # PUT Address is immutable.
+  bad_payload='{"name":"c1","address":"127.0.0.1:9999","servers":{},"failure-domain":9}'
+  bad_resp="$(daemon_config_put "${bad_payload}")"
+  [[ "$(response_code "${bad_resp}")" == "400" ]] || {
+    echo "ERROR: PUT address change should be rejected"
+    echo "${bad_resp}"
+    return 1
+  }
+  echo "${bad_resp}" | grep -q "Address is immutable" || {
+    echo "ERROR: Expected immutable address error from PUT"
+    echo "${bad_resp}"
+    return 1
+  }
+
+  # PUT Unknown extension server should be rejected.
+  bad_payload='{"name":"c1","address":"127.0.0.1:9001","servers":{"unknown.example.com":{"address":"127.0.0.1:9443"}},"failure-domain":9}'
+  bad_resp="$(daemon_config_put "${bad_payload}")"
+  [[ "$(response_code "${bad_resp}")" == "400" ]] || {
+    echo "ERROR: Unknown server should be rejected"
+    echo "${bad_resp}"
+    return 1
+  }
+  echo "${bad_resp}" | grep -q "No matching additional listener found" || {
+    echo "ERROR: Expected unknown server validation error"
+    echo "${bad_resp}"
+    return 1
+  }
+
+  # Legacy endpoint should still be accessible.
+  legacy_resp="$(curl -sS --unix-socket "${socket_path}" http://unix/core/1.0/daemon/servers)"
+  [[ "$(response_code "${legacy_resp}")" == "200" ]] || {
+    echo "ERROR: Legacy daemon/servers endpoint should remain available"
+    echo "${legacy_resp}"
+    return 1
+  }
+
+  shutdown_systems
+}
+
 test_extended_endpoints() {
   new_systems 4 --heartbeat 2s
 
@@ -717,6 +958,7 @@ if [ "${1:-"all"}" = "all" ] || [ "${1}" = "" ]; then
   test_recover
   test_join_token_after_cluster_formed
   test_join_token_before_cluster_formed
+  test_daemon_config_api
   test_extended_endpoints
   test_membership_consistency
   test_truststore_force_removal
@@ -742,6 +984,8 @@ elif [ "${1}" = "parallel-join" ]; then
   test_parallel_joins
 elif [ "${1}" = "self-deletion" ]; then
   test_self_deletion
+elif [ "${1}" = "daemon-config" ]; then
+  test_daemon_config_api
 else
   echo "Unknown test ${1}"
 fi

--- a/example/test/main.sh
+++ b/example/test/main.sh
@@ -689,22 +689,30 @@ test_daemon_config_api() {
 
   daemon_config_put() {
     local payload="${1}"
+    local query_suffix=""
+    if [ -n "${2:-}" ]; then
+      query_suffix="?restart=${2}"
+    fi
 
     curl -sS --unix-socket "${socket_path}" \
       -X PUT \
       -H "Content-Type: application/json" \
       -d "${payload}" \
-      http://unix/core/1.0/daemon/config
+      "http://unix/core/1.0/daemon/config${query_suffix}"
   }
 
   daemon_config_patch() {
     local payload="${1}"
+    local query_suffix=""
+    if [ -n "${2:-}" ]; then
+      query_suffix="?restart=${2}"
+    fi
 
     curl -sS --unix-socket "${socket_path}" \
       -X PATCH \
       -H "Content-Type: application/json" \
       -d "${payload}" \
-      http://unix/core/1.0/daemon/config
+      "http://unix/core/1.0/daemon/config${query_suffix}"
   }
 
   json_get() {
@@ -727,7 +735,8 @@ test_daemon_config_api() {
     json_get "${payload}" '.error_code'
   }
 
-  # Ensure initial daemon config can be retrieved.
+  # Initial state: GET should return the bootstrap member identity and the default failure-domain.
+  echo "==> initial state and PUT semantics"
   config_resp="$(daemon_config_get)"
   [[ "$(response_code "${config_resp}")" == "200" ]] || {
     echo "ERROR: Failed to GET daemon config"
@@ -749,8 +758,7 @@ test_daemon_config_api() {
     echo "${config_resp}"
     return 1
   }
-
-  # PUT sets failure-domain and clears servers (full replacement).
+  # Full replacement: PUT sets failure-domain and clears servers when servers are omitted.
   update_payload='{"name":"c1","address":"127.0.0.1:9001","failure-domain":9}'
   update_resp="$(daemon_config_put "${update_payload}")"
   [[ "$(response_code "${update_resp}")" == "200" ]] || {
@@ -775,8 +783,7 @@ test_daemon_config_api() {
     cat "${test_dir}/c1/daemon.yaml"
     return 1
   }
-
-  # PUT without failure-domain clears it (full replacement semantics).
+  # Full replacement: PUT without failure-domain resets it to the default value.
   update_payload='{"name":"c1","address":"127.0.0.1:9001"}'
   update_resp="$(daemon_config_put "${update_payload}")"
   [[ "$(response_code "${update_resp}")" == "200" ]] || {
@@ -791,10 +798,9 @@ test_daemon_config_api() {
     echo "${config_resp}"
     return 1
   }
+  echo "==> PATCH semantics"
 
-  # PATCH tests.
-
-  # Set failure-domain to a known value first via PUT.
+  # Prime a known failure-domain value so PATCH preservation semantics are observable.
   update_payload='{"name":"c1","address":"127.0.0.1:9001","failure-domain":5}'
   update_resp="$(daemon_config_put "${update_payload}")"
   [[ "$(response_code "${update_resp}")" == "200" ]] || {
@@ -803,7 +809,7 @@ test_daemon_config_api() {
     return 1
   }
 
-  # PATCH omitting failure-domain preserves the existing value.
+  # Partial update: omitting failure-domain preserves the existing value.
   patch_payload='{"name":"c1","address":"127.0.0.1:9001"}'
   patch_resp="$(daemon_config_patch "${patch_payload}")"
   [[ "$(response_code "${patch_resp}")" == "200" ]] || {
@@ -818,8 +824,7 @@ test_daemon_config_api() {
     echo "${config_resp}"
     return 1
   }
-
-  # PATCH updates failure-domain without clearing it.
+  # Partial update: PATCH can update failure-domain directly and should persist it to daemon.yaml.
   patch_payload='{"name":"c1","address":"127.0.0.1:9001","failure-domain":7}'
   patch_resp="$(daemon_config_patch "${patch_payload}")"
   [[ "$(response_code "${patch_resp}")" == "200" ]] || {
@@ -839,9 +844,8 @@ test_daemon_config_api() {
     cat "${test_dir}/c1/daemon.yaml"
     return 1
   }
-
-  # PATCH ignores name and address fields — they are not part of DaemonConfigPatch.
-  # A payload containing a different name or address succeeds; the values are not applied.
+  # PATCH ignores name and address fields because they are not part of DaemonConfigPatch.
+  # A payload containing different values should succeed without applying them.
   ignore_payload='{"name":"renamed","address":"127.0.0.1:9999","failure-domain":7}'
   ignore_resp="$(daemon_config_patch "${ignore_payload}")"
   [[ "$(response_code "${ignore_resp}")" == "200" ]] || {
@@ -861,8 +865,9 @@ test_daemon_config_api() {
     echo "${config_resp}"
     return 1
   }
+  echo "==> validation failures"
 
-  # PUT Name is immutable.
+  # PUT rejects a changed name because name is immutable.
   bad_payload='{"name":"renamed","address":"127.0.0.1:9001","servers":{},"failure-domain":9}'
   bad_resp="$(daemon_config_put "${bad_payload}")"
   [[ "$(response_code "${bad_resp}")" == "400" ]] || {
@@ -875,8 +880,7 @@ test_daemon_config_api() {
     echo "${bad_resp}"
     return 1
   }
-
-  # PUT Address is immutable.
+  # PUT rejects a changed address because address is immutable.
   bad_payload='{"name":"c1","address":"127.0.0.1:9999","servers":{},"failure-domain":9}'
   bad_resp="$(daemon_config_put "${bad_payload}")"
   [[ "$(response_code "${bad_resp}")" == "400" ]] || {
@@ -889,8 +893,7 @@ test_daemon_config_api() {
     echo "${bad_resp}"
     return 1
   }
-
-  # PUT Unknown extension server should be rejected.
+  # PUT rejects unknown extension listeners instead of silently accepting them.
   bad_payload='{"name":"c1","address":"127.0.0.1:9001","servers":{"unknown.example.com":{"address":"127.0.0.1:9443"}},"failure-domain":9}'
   bad_resp="$(daemon_config_put "${bad_payload}")"
   [[ "$(response_code "${bad_resp}")" == "400" ]] || {
@@ -903,8 +906,7 @@ test_daemon_config_api() {
     echo "${bad_resp}"
     return 1
   }
-
-  # Legacy endpoint should still be accessible.
+  # Compatibility: the legacy daemon/servers endpoint should still be accessible.
   legacy_resp="$(curl -sS --unix-socket "${socket_path}" http://unix/core/1.0/daemon/servers)"
   [[ "$(response_code "${legacy_resp}")" == "200" ]] || {
     echo "ERROR: Legacy daemon/servers endpoint should remain available"
@@ -912,6 +914,67 @@ test_daemon_config_api() {
     return 1
   }
 
+  echo "==> restart semantics"
+
+  # Before requesting a restart, the live dqlite metadata should still report the default value.
+  fd_before="$(microctl --state-dir "${test_dir}/c1" describe 127.0.0.1:9001 | yq -r '."failure-domain"')"
+  [[ "${fd_before}" == "0" ]] || {
+    echo "ERROR: Expected initial dqlite failure-domain to be 0, got ${fd_before}"
+    return 1
+  }
+
+  # PATCH with restart=true should apply the failure-domain to the live dqlite node before returning.
+  patch_resp="$(daemon_config_patch '{"failure-domain":42}' true)"
+  [[ "$(response_code "${patch_resp}")" == "200" ]] || {
+    echo "ERROR: PATCH with restart failed"
+    echo "${patch_resp}"
+    return 1
+  }
+  # The request should return only after the local database is back online.
+  fd_after="$(microctl --state-dir "${test_dir}/c1" describe 127.0.0.1:9001 | yq -r '."failure-domain"')"
+  [[ "${fd_after}" == "42" ]] || {
+    echo "ERROR: Expected dqlite failure-domain to be 42 after PATCH restart, got ${fd_after}"
+    return 1
+  }
+
+  config_resp="$(daemon_config_get)"
+  [[ "$(json_get "${config_resp}" '.metadata."failure-domain"')" == "42" ]] || {
+    echo "ERROR: GET should reflect failure-domain=42 after PATCH restart"
+    echo "${config_resp}"
+    return 1
+  }
+  # PUT with restart=true should preserve full replacement semantics and still wait for the restart.
+  put_resp="$(daemon_config_put '{"name":"c1","address":"127.0.0.1:9001","failure-domain":99}' true)"
+  [[ "$(response_code "${put_resp}")" == "200" ]] || {
+    echo "ERROR: PUT with restart failed"
+    echo "${put_resp}"
+    return 1
+  }
+  fd_after="$(microctl --state-dir "${test_dir}/c1" describe 127.0.0.1:9001 | yq -r '."failure-domain"')"
+  [[ "${fd_after}" == "99" ]] || {
+    echo "ERROR: Expected dqlite failure-domain to be 99 after PUT restart, got ${fd_after}"
+    return 1
+  }
+  # Without restart=true, PATCH persists the new value but live dqlite metadata remains unchanged.
+  patch_resp="$(daemon_config_patch '{"failure-domain":7}')"
+  [[ "$(response_code "${patch_resp}")" == "200" ]] || {
+    echo "ERROR: PATCH without restart failed"
+    echo "${patch_resp}"
+    return 1
+  }
+
+  fd_live="$(microctl --state-dir "${test_dir}/c1" describe 127.0.0.1:9001 | yq -r '."failure-domain"')"
+  [[ "${fd_live}" == "99" ]] || {
+    echo "ERROR: Without restart, live dqlite failure-domain should still be 99, got ${fd_live}"
+    return 1
+  }
+
+  config_resp="$(daemon_config_get)"
+  [[ "$(json_get "${config_resp}" '.metadata."failure-domain"')" == "7" ]] || {
+    echo "ERROR: GET should reflect the persisted failure-domain=7 even without restart"
+    echo "${config_resp}"
+    return 1
+  }
   shutdown_systems
 }
 

--- a/internal/config/daemon.go
+++ b/internal/config/daemon.go
@@ -112,9 +112,7 @@ func (d *DaemonConfig) GetServers() map[string]types.ServerConfig {
 
 	// Create a deep copy to not return the reference to the original map.
 	serverConfigCopy := make(map[string]types.ServerConfig, len(d.config.Servers))
-	for k, v := range d.config.Servers {
-		serverConfigCopy[k] = v
-	}
+	maps.Copy(serverConfigCopy, d.config.Servers)
 
 	return serverConfigCopy
 }

--- a/internal/config/daemon.go
+++ b/internal/config/daemon.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"sync"
 
@@ -57,7 +58,17 @@ func (d *DaemonConfig) Load() error {
 
 // Dump dumps the entire daemon's config.
 func (d *DaemonConfig) Dump() *types.DaemonConfig {
-	return d.config
+	d.lock.RLock()
+	defer d.lock.RUnlock()
+
+	dump := *d.config
+
+	serversCopy := make(map[string]types.ServerConfig, len(d.config.Servers))
+	maps.Copy(serversCopy, d.config.Servers)
+
+	dump.Servers = serversCopy
+
+	return &dump
 }
 
 // Write writes the daemon's config to its path.

--- a/internal/config/daemon.go
+++ b/internal/config/daemon.go
@@ -131,3 +131,19 @@ func (d *DaemonConfig) SetServers(servers map[string]types.ServerConfig) {
 
 	d.config.Servers = servers
 }
+
+// GetFailureDomain returns the daemon's failure domain.
+func (d *DaemonConfig) GetFailureDomain() uint64 {
+	d.lock.RLock()
+	defer d.lock.RUnlock()
+
+	return d.config.FailureDomain
+}
+
+// SetFailureDomain sets the daemon's failure domain.
+func (d *DaemonConfig) SetFailureDomain(failureDomain uint64) {
+	d.lock.Lock()
+	defer d.lock.Unlock()
+
+	d.config.FailureDomain = failureDomain
+}

--- a/internal/config/daemon_test.go
+++ b/internal/config/daemon_test.go
@@ -1,0 +1,60 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/canonical/microcluster/v3/microcluster/types"
+)
+
+func TestDaemonConfigFailureDomainDefaultsToZeroWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "daemon.yaml")
+
+	content := `name: m1
+address: 127.0.0.1:9001
+servers: {}
+`
+
+	err := os.WriteFile(path, []byte(content), 0600)
+	require.NoError(t, err)
+
+	cfg := NewDaemonConfig(path)
+
+	err = cfg.Load()
+	require.NoError(t, err)
+
+	require.Equal(t, uint64(0), cfg.GetFailureDomain())
+}
+
+func TestDaemonConfigFailureDomainRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "daemon.yaml")
+
+	cfg := NewDaemonConfig(path)
+	addr, err := types.ParseAddrPort("127.0.0.1:9001")
+	require.NoError(t, err)
+
+	cfg.SetName("m1")
+	cfg.SetAddress(addr)
+	cfg.SetServers(map[string]types.ServerConfig{})
+	cfg.SetFailureDomain(42)
+
+	err = cfg.Write()
+	require.NoError(t, err)
+
+	content, err := os.ReadFile(path)
+	require.NoError(t, err)
+	require.True(t, strings.Contains(string(content), "failure-domain: 42"))
+
+	reloaded := NewDaemonConfig(path)
+	err = reloaded.Load()
+	require.NoError(t, err)
+	require.Equal(t, uint64(42), reloaded.GetFailureDomain())
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -73,6 +73,13 @@ type Args struct {
 	// If nil, default signals (SIGPWR, SIGTERM, SIGINT, SIGQUIT) will be used.
 	// If set to an empty slice, no signal handling will be performed.
 	ShutdownSignals []os.Signal
+
+	// InitFailureDomain is the initial dqlite failure-domain for this node. It is
+	// used by dqlite to place voting replicas across fault boundaries. If the node
+	// has already been bootstrapped and daemon.yaml contains a failure-domain value,
+	// that value takes precedence over this field. Set this to avoid a dqlite
+	// restart when the failure domain is known at daemon startup time.
+	InitFailureDomain uint64
 }
 
 // Daemon holds information for the microcluster daemon.
@@ -187,6 +194,13 @@ func (d *Daemon) Run(ctx context.Context, stateDir string, args Args) error {
 
 	// Setup the deamon's internal config.
 	d.config = internalConfig.NewDaemonConfig(filepath.Join(d.os.StateDir(), "daemon.yaml"))
+
+	// Apply the failure domain from args as an initial value. If daemon.yaml already
+	// exists (restart/rejoin), config.Load() called inside reload() will overwrite this
+	// with the persisted value, which takes precedence.
+	if args.InitFailureDomain != 0 {
+		d.config.SetFailureDomain(args.InitFailureDomain)
+	}
 
 	// Clean up the daemon state on an error during init.
 	reverter := revert.New()

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -288,7 +288,7 @@ func (d *Daemon) init(listenAddress string, socketGroup string, heartbeatInterva
 		return fmt.Errorf("Failed to initialize trust store: %w", err)
 	}
 
-	d.db, err = db.NewDB(d.shutdownCtx, d.ServerCert, d.ClusterCert, d.Name, d.os, heartbeatInterval)
+	d.db, err = db.NewDB(d.shutdownCtx, d.ServerCert, d.ClusterCert, d.Name, d.config.GetFailureDomain, d.os, heartbeatInterval)
 	if err != nil {
 		return fmt.Errorf("Failed to initialize database: %w", err)
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1148,6 +1148,9 @@ func (d *Daemon) State() types.State {
 
 			return exit, stopErr
 		},
+		RestartDB: func() error {
+			return d.db.Restart(d.Extensions, d.trustStore.Remotes().RemoteAddresses())
+		},
 		StopListeners: func() error {
 			err := d.fsWatcher.Close()
 			if err != nil {

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -34,10 +34,11 @@ import (
 
 // DqliteDB holds all information internal to the dqlite database.
 type DqliteDB struct {
-	memberName  func() string           // Local cluster member name
-	clusterCert func() *shared.CertInfo // Cluster certificate for dqlite authentication.
-	serverCert  func() *shared.CertInfo // Server certificate for dqlite authentication.
-	listenAddr  *url.URL                // Listen address for this dqlite node.
+	memberName    func() string           // Local cluster member name
+	clusterCert   func() *shared.CertInfo // Cluster certificate for dqlite authentication.
+	serverCert    func() *shared.CertInfo // Server certificate for dqlite authentication.
+	failureDomain func() uint64           // Local daemon failure-domain value applied when starting dqlite.
+	listenAddr    *url.URL                // Listen address for this dqlite node.
 
 	dbName string // This is db.bin.
 	os     types.OS
@@ -71,7 +72,7 @@ func (db *DqliteDB) Accept(conn net.Conn) {
 }
 
 // NewDB creates an empty db struct with no dqlite connection.
-func NewDB(ctx context.Context, serverCert func() *shared.CertInfo, clusterCert func() *shared.CertInfo, memberName func() string, os types.OS, heartbeatInterval time.Duration) (*DqliteDB, error) {
+func NewDB(ctx context.Context, serverCert func() *shared.CertInfo, clusterCert func() *shared.CertInfo, memberName func() string, failureDomain func() uint64, os types.OS, heartbeatInterval time.Duration) (*DqliteDB, error) {
 	shutdownCtx, shutdownCancel := context.WithCancel(ctx)
 
 	if heartbeatInterval == 0 {
@@ -82,6 +83,7 @@ func NewDB(ctx context.Context, serverCert func() *shared.CertInfo, clusterCert 
 		memberName:        memberName,
 		serverCert:        serverCert,
 		clusterCert:       clusterCert,
+		failureDomain:     failureDomain,
 		dbName:            filepath.Base(os.DatabasePath()),
 		os:                os,
 		acceptCh:          make(chan net.Conn),
@@ -149,6 +151,7 @@ func (db *DqliteDB) Bootstrap(extensions types.Extensions, addr *url.URL, cluste
 	db.listenAddr = addr
 	db.dqlite, err = dqlite.New(db.os.DatabaseDir(),
 		dqlite.WithAddress(db.listenAddr.Host),
+		dqlite.WithFailureDomain(db.failureDomain()),
 		dqlite.WithRolesAdjustmentFrequency(db.heartbeatInterval),
 		dqlite.WithRolesAdjustmentHook(db.heartbeat),
 		dqlite.WithConcurrentLeaderConns(&db.maxConns),
@@ -202,6 +205,7 @@ func (db *DqliteDB) Join(extensions types.Extensions, addr *url.URL, joinAddress
 		dqlite.WithRolesAdjustmentFrequency(db.heartbeatInterval),
 		dqlite.WithRolesAdjustmentHook(db.heartbeat),
 		dqlite.WithAddress(db.listenAddr.Host),
+		dqlite.WithFailureDomain(db.failureDomain()),
 		dqlite.WithConcurrentLeaderConns(&db.maxConns),
 		dqlite.WithExternalConn(db.dialFunc(), db.acceptCh),
 		dqlite.WithUnixSocket(os.Getenv(sys.DqliteSocket)))

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
@@ -46,6 +47,7 @@ type DqliteDB struct {
 	db        *sql.DB
 	dqlite    *dqlite.App
 	acceptCh  chan net.Conn
+	acceptMu  sync.RWMutex
 	upgradeCh chan struct{}
 
 	ctx    context.Context
@@ -66,9 +68,22 @@ const (
 	DefaultHeartbeatInterval time.Duration = time.Second * 10
 )
 
-// Accept sends the outbound connection through the acceptCh channel to be received by dqlite.
+// Accept passes conn to dqlite. During normal operation the send completes
+// immediately. During a Restart the channel has no consumer yet, so the call
+// blocks for up to 10s, keeping clients "on hold" until the new dqlite
+// instance is ready, making the restart invisible to them.
+// acceptMu is held so that Restart can atomically rotate the channel.
 func (db *DqliteDB) Accept(conn net.Conn) {
-	db.acceptCh <- conn
+	db.acceptMu.RLock()
+	defer db.acceptMu.RUnlock()
+
+	select {
+	case db.acceptCh <- conn:
+	case <-time.After(10 * time.Second):
+		conn.Close()
+	case <-db.ctx.Done():
+		conn.Close()
+	}
 }
 
 // NewDB creates an empty db struct with no dqlite connection.
@@ -549,6 +564,118 @@ func (db *DqliteDB) Stop() error {
 		if err != nil {
 			return err
 		}
+	}
+
+	return nil
+}
+
+// Restart closes the dqlite app and SQL connection without cancelling the daemon context,
+// then reconnects to the cluster. This allows changes like failure-domain to take effect
+// without a full daemon restart.
+func (db *DqliteDB) Restart(extensions types.Extensions, clusterMembers map[string]types.AddrPort) error {
+	if db.listenAddr != nil && db.dqlite != nil {
+		ctx, cancel := context.WithTimeout(db.ctx, 30*time.Second)
+		defer cancel()
+
+		// Query the current cluster leader before stopping the local dqlite app.
+		leader, err := db.Leader(ctx)
+		if err != nil {
+			return fmt.Errorf("Failed to determine current dqlite leader before restart: %w", err)
+		}
+
+		defer leader.Close()
+
+		leaderInfo, err := leader.Leader(ctx)
+		if err != nil {
+			return fmt.Errorf("Failed to fetch dqlite leader information before restart: %w", err)
+		}
+
+		// Only transfer leadership when restarting the current leader. Followers can
+		// restart immediately without disrupting cluster leadership.
+		if leaderInfo.Address == db.listenAddr.Host {
+			err = db.transferLeadership(ctx, leader, leaderInfo)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	db.statusLock.Lock()
+	db.status = types.DatabaseOffline
+	db.statusLock.Unlock()
+
+	// Swap in a fresh accept channel for the next dqlite instance and close the
+	// old one so any stale go-dqlite reader ranging over it can exit.
+	// Accept() holds acceptMu for every send, so once the write lock is held there
+	// can be no remaining senders on the old channel.
+	db.acceptMu.Lock()
+	oldAcceptCh := db.acceptCh
+	db.acceptCh = make(chan net.Conn)
+	db.acceptMu.Unlock()
+
+	if oldAcceptCh != nil {
+		close(oldAcceptCh)
+	}
+
+	if db.db != nil {
+		_ = db.db.Close()
+		db.db = nil
+	}
+
+	if db.dqlite != nil {
+		_ = db.dqlite.Close()
+		db.dqlite = nil
+	}
+
+	return db.StartWithCluster(extensions, db.listenAddr, clusterMembers)
+}
+
+// transferLeadership hands leadership to another voter before the local leader
+// restarts. This avoids forcing the cluster to detect leader loss mid-restart.
+func (db *DqliteDB) transferLeadership(ctx context.Context, leader *dqliteClient.Client, leaderInfo *dqliteClient.NodeInfo) error {
+	info, err := leader.Cluster(ctx)
+	if err != nil {
+		return fmt.Errorf("Failed to fetch dqlite cluster information before restart: %w", err)
+	}
+
+	if len(info) < 2 {
+		return nil
+	}
+
+	// In a 2-node cluster, ensure the remaining node is promotable before transferring leadership.
+	if len(info) == 2 {
+		for _, node := range info {
+			if node.Address != leaderInfo.Address && node.Role != dqliteClient.Voter {
+				err = leader.Assign(ctx, node.ID, dqliteClient.Voter)
+				if err != nil {
+					return fmt.Errorf("Failed to promote peer to voter before leadership transfer: %w", err)
+				}
+			}
+		}
+
+		info, err = leader.Cluster(ctx)
+		if err != nil {
+			return fmt.Errorf("Failed to refresh dqlite cluster information before restart: %w", err)
+		}
+	}
+
+	// Prefer transferring directly to another voter, since only voters are eligible
+	// to become raft leader.
+	var otherVoters []uint64
+	for _, node := range info {
+		if node.Address != leaderInfo.Address && node.Role == dqliteClient.Voter {
+			otherVoters = append(otherVoters, node.ID)
+		}
+	}
+
+	if len(otherVoters) == 0 {
+		return fmt.Errorf("Found no voters to transfer dqlite leadership to before restart")
+	}
+
+	target := otherVoters[rand.Intn(len(otherVoters))]
+	err = leader.Transfer(ctx, target)
+	if err != nil {
+		return fmt.Errorf("Failed to transfer dqlite leadership before restart: %w", err)
 	}
 
 	return nil

--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -1,13 +1,10 @@
 package db
 
 import (
-	"bufio"
 	"context"
-	"crypto/tls"
 	"database/sql"
 	"errors"
 	"fmt"
-	"io"
 	"log/slog"
 	"math/rand"
 	"net"
@@ -435,11 +432,6 @@ func (db *DqliteDB) heartbeat(leaderInfo dqliteClient.NodeInfo, servers []dqlite
 
 // dqliteNetworkDial creates a connection to the internal database endpoint.
 func dqliteNetworkDial(ctx context.Context, addr string, db *DqliteDB) (net.Conn, error) {
-	addrPort, err := types.ParseAddrPort(addr)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to parse the address: %w", err)
-	}
-
 	peerCert, err := db.clusterCert().PublicKeyX509()
 	if err != nil {
 		return nil, err
@@ -450,41 +442,11 @@ func dqliteNetworkDial(ctx context.Context, addr string, db *DqliteDB) (net.Conn
 		return nil, fmt.Errorf("Failed to parse TLS config: %w", err)
 	}
 
-	// Establish the connection
-	request := &http.Request{
-		Method:     "POST",
-		Proto:      "HTTP/1.1",
-		ProtoMajor: 1,
-		ProtoMinor: 1,
-		Header:     make(http.Header),
-		Host:       addrPort.String(),
-	}
-
-	request.URL = &url.URL{
-		Scheme: "https",
-		Host:   addrPort.String(),
-		Path:   fmt.Sprintf("/%s/%s", types.InternalEndpoint, "database"),
-	}
-
-	request.Header.Set("Upgrade", "dqlite")
-	request.Header.Set("X-Dqlite-Version", fmt.Sprintf("%d", 1))
-	request = request.WithContext(ctx)
-
-	revert := revert.New()
-	defer revert.Fail()
-
-	tlsDialer := tls.Dialer{Config: config}
-	conn, err := tlsDialer.DialContext(ctx, "tcp", addr)
+	conn, err := internalClient.DialDqlite(ctx, addr, config)
 	if err != nil {
-		return nil, fmt.Errorf("Failed connecting to HTTP endpoint %q: %w", addr, err)
+		return nil, err
 	}
 
-	revert.Add(func() {
-		err := conn.Close()
-		if err != nil {
-			db.log().Error("Failed to close connection to dqlite", slog.String("error", err.Error()))
-		}
-	})
 	slogGroup := slog.Group("peers", slog.String("local", conn.LocalAddr().String()), slog.String("remote", conn.RemoteAddr().String()))
 	db.log().Debug("Successfully established outbound dqlite connection", slogGroup)
 
@@ -499,50 +461,6 @@ func dqliteNetworkDial(ctx context.Context, addr string, db *DqliteDB) (net.Conn
 		}
 	}
 
-	err = request.Write(conn)
-	if err != nil {
-		return nil, fmt.Errorf("Failed sending HTTP requrest to %q: %w", request.URL, err)
-	}
-
-	response, err := http.ReadResponse(bufio.NewReader(conn), request)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to read response: %w", err)
-	}
-
-	revert.Add(func() {
-		err := response.Body.Close()
-		if err != nil {
-			db.log().Error("Failed to close dqlite response body", slog.String("error", err.Error()))
-		}
-	})
-
-	_, err = io.Copy(io.Discard, response.Body)
-	if err != nil {
-		db.log().Error("Failed to read dqlite response body", slog.String("error", err.Error()))
-	}
-
-	// We are done reading the response body. Close it.
-	err = response.Body.Close()
-	if err != nil {
-		return nil, fmt.Errorf("Failed to close dqlite response body: %w", err)
-	}
-
-	// If the remote server has detected that we are out of date, let's
-	// trigger an upgrade.
-	if response.StatusCode == http.StatusUpgradeRequired {
-		// TODO: trigger update.
-		return nil, fmt.Errorf("Upgrade needed")
-	}
-
-	if response.StatusCode != http.StatusSwitchingProtocols {
-		return nil, fmt.Errorf("Dialing failed: expected status code 101 got %d", response.StatusCode)
-	}
-
-	if response.Header.Get("Upgrade") != "dqlite" {
-		return nil, fmt.Errorf("Missing or unexpected Upgrade header in response")
-	}
-
-	revert.Success()
 	return conn, nil
 }
 

--- a/internal/rest/client/daemon.go
+++ b/internal/rest/client/daemon.go
@@ -9,6 +9,39 @@ import (
 	"github.com/canonical/microcluster/v3/microcluster/types"
 )
 
+// GetDaemonConfig retrieves local daemon configuration.
+func GetDaemonConfig(ctx context.Context, c types.Client) (*types.DaemonConfig, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	endpoint := api.NewURL().Path("daemon", "config")
+	config := types.DaemonConfig{}
+	err := c.Query(queryCtx, "GET", types.PublicEndpoint, &endpoint.URL, nil, &config)
+	if err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+// UpdateDaemonConfig updates local daemon configuration.
+func UpdateDaemonConfig(ctx context.Context, c types.Client, config types.DaemonConfig) error {
+	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	endpoint := api.NewURL().Path("daemon", "config")
+	return c.Query(queryCtx, "PUT", types.PublicEndpoint, &endpoint.URL, config, nil)
+}
+
+// PatchDaemonConfig partially updates local daemon configuration.
+func PatchDaemonConfig(ctx context.Context, c types.Client, config types.DaemonConfigPatch) error {
+	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	endpoint := api.NewURL().Path("daemon", "config")
+	return c.Query(queryCtx, "PATCH", types.PublicEndpoint, &endpoint.URL, config, nil)
+}
+
 // UpdateServers updates the additional servers config.
 func UpdateServers(ctx context.Context, c types.Client, config map[string]types.ServerConfig) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)

--- a/internal/rest/client/daemon.go
+++ b/internal/rest/client/daemon.go
@@ -2,6 +2,7 @@ package client
 
 import (
 	"context"
+	"net/url"
 	"time"
 
 	"github.com/canonical/lxd/shared/api"
@@ -25,21 +26,21 @@ func GetDaemonConfig(ctx context.Context, c types.Client) (*types.DaemonConfig, 
 }
 
 // UpdateDaemonConfig updates local daemon configuration.
-func UpdateDaemonConfig(ctx context.Context, c types.Client, config types.DaemonConfig) error {
+func UpdateDaemonConfig(ctx context.Context, c types.Client, config types.DaemonConfig, restart bool) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	endpoint := api.NewURL().Path("daemon", "config")
-	return c.Query(queryCtx, "PUT", types.PublicEndpoint, &endpoint.URL, config, nil)
+	endpoint := daemonConfigURL(restart)
+	return c.Query(queryCtx, "PUT", types.PublicEndpoint, endpoint, config, nil)
 }
 
 // PatchDaemonConfig partially updates local daemon configuration.
-func PatchDaemonConfig(ctx context.Context, c types.Client, config types.DaemonConfigPatch) error {
+func PatchDaemonConfig(ctx context.Context, c types.Client, config types.DaemonConfigPatch, restart bool) error {
 	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
 
-	endpoint := api.NewURL().Path("daemon", "config")
-	return c.Query(queryCtx, "PATCH", types.PublicEndpoint, &endpoint.URL, config, nil)
+	endpoint := daemonConfigURL(restart)
+	return c.Query(queryCtx, "PATCH", types.PublicEndpoint, endpoint, config, nil)
 }
 
 // UpdateServers updates the additional servers config.
@@ -49,4 +50,13 @@ func UpdateServers(ctx context.Context, c types.Client, config map[string]types.
 
 	endpoint := api.NewURL().Path("daemon", "servers")
 	return c.Query(queryCtx, "PUT", types.PublicEndpoint, &endpoint.URL, config, nil)
+}
+
+func daemonConfigURL(restart bool) *url.URL {
+	endpoint := api.NewURL().Path("daemon", "config")
+	if restart {
+		endpoint = endpoint.WithQuery("restart", "true")
+	}
+
+	return &endpoint.URL
 }

--- a/internal/rest/client/dqlite.go
+++ b/internal/rest/client/dqlite.go
@@ -1,0 +1,100 @@
+package client
+
+import (
+	"bufio"
+	"context"
+	"crypto/tls"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+
+	"github.com/canonical/lxd/shared/revert"
+
+	"github.com/canonical/microcluster/v3/microcluster/types"
+)
+
+// DialDqlite dials a remote member's internal database endpoint and upgrades the
+// connection to the dqlite protocol.
+func DialDqlite(ctx context.Context, addr string, config *tls.Config) (net.Conn, error) {
+	if config == nil {
+		return nil, fmt.Errorf("Invalid TLS config")
+	}
+
+	addrPort, err := types.ParseAddrPort(addr)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to parse the address: %w", err)
+	}
+
+	request := &http.Request{
+		Method:     "POST",
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     make(http.Header),
+		Host:       addrPort.String(),
+	}
+
+	request.URL = &url.URL{
+		Scheme: "https",
+		Host:   addrPort.String(),
+		Path:   fmt.Sprintf("/%s/%s", types.InternalEndpoint, "database"),
+	}
+
+	request.Header.Set("Upgrade", "dqlite")
+	request.Header.Set("X-Dqlite-Version", "1")
+	request = request.WithContext(ctx)
+
+	reverter := revert.New()
+	defer reverter.Fail()
+
+	tlsDialer := tls.Dialer{Config: config}
+	conn, err := tlsDialer.DialContext(ctx, "tcp", addrPort.String())
+	if err != nil {
+		return nil, fmt.Errorf("Failed connecting to HTTP endpoint %q: %w", addrPort.String(), err)
+	}
+
+	reverter.Add(func() {
+		_ = conn.Close()
+	})
+
+	err = request.Write(conn)
+	if err != nil {
+		return nil, fmt.Errorf("Failed sending HTTP request to %q: %w", request.URL, err)
+	}
+
+	response, err := http.ReadResponse(bufio.NewReader(conn), request)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read response: %w", err)
+	}
+
+	reverter.Add(func() {
+		_ = response.Body.Close()
+	})
+
+	_, err = io.Copy(io.Discard, response.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read dqlite response body: %w", err)
+	}
+
+	err = response.Body.Close()
+	if err != nil {
+		return nil, fmt.Errorf("Failed to close dqlite response body: %w", err)
+	}
+
+	if response.StatusCode == http.StatusUpgradeRequired {
+		return nil, fmt.Errorf("Upgrade needed")
+	}
+
+	if response.StatusCode != http.StatusSwitchingProtocols {
+		return nil, fmt.Errorf("Dialing failed: expected status code 101 got %d", response.StatusCode)
+	}
+
+	if response.Header.Get("Upgrade") != "dqlite" {
+		return nil, fmt.Errorf("Missing or unexpected Upgrade header in response")
+	}
+
+	reverter.Success()
+	return conn, nil
+}

--- a/internal/rest/resources/daemon.go
+++ b/internal/rest/resources/daemon.go
@@ -20,6 +20,21 @@ var daemonServersCmd = types.Endpoint{
 	Put: types.EndpointAction{Handler: daemonServersPut, AccessHandler: access.AllowAuthenticated},
 }
 
+var daemonConfigCmd = types.Endpoint{
+	Path: "daemon/config",
+
+	Get: types.EndpointAction{Handler: daemonConfigGet, AccessHandler: access.AllowAuthenticated},
+}
+
+func daemonConfigGet(s types.State, r *http.Request) types.Response {
+	intState, err := internalState.ToInternal(s)
+	if err != nil {
+		return types.SmartError(err)
+	}
+
+	return types.SyncResponse(true, intState.LocalConfig().Dump())
+}
+
 func daemonServersGet(s types.State, r *http.Request) types.Response {
 	intState, err := internalState.ToInternal(s)
 	if err != nil {

--- a/internal/rest/resources/daemon.go
+++ b/internal/rest/resources/daemon.go
@@ -23,7 +23,9 @@ var daemonServersCmd = types.Endpoint{
 var daemonConfigCmd = types.Endpoint{
 	Path: "daemon/config",
 
-	Get: types.EndpointAction{Handler: daemonConfigGet, AccessHandler: access.AllowAuthenticated},
+	Get:   types.EndpointAction{Handler: daemonConfigGet, AccessHandler: access.AllowAuthenticated},
+	Put:   types.EndpointAction{Handler: daemonConfigPut, AccessHandler: access.AllowAuthenticated},
+	Patch: types.EndpointAction{Handler: daemonConfigPatch, AccessHandler: access.AllowAuthenticated},
 }
 
 func daemonConfigGet(s types.State, r *http.Request) types.Response {
@@ -74,6 +76,72 @@ func daemonServersPut(s types.State, r *http.Request) types.Response {
 	return types.EmptySyncResponse
 }
 
+func daemonConfigPut(s types.State, r *http.Request) types.Response {
+	req := types.DaemonConfig{}
+
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		return types.BadRequest(err)
+	}
+
+	intState, err := internalState.ToInternal(s)
+	if err != nil {
+		return types.SmartError(err)
+	}
+
+	err = validateDaemonConfigUpdate(intState, req)
+	if err != nil {
+		return types.BadRequest(err)
+	}
+
+	daemonConfig := intState.LocalConfig()
+	daemonConfig.SetServers(req.Servers)
+	daemonConfig.SetFailureDomain(req.FailureDomain)
+
+	err = applyAndNotifyDaemonConfig(r.Context(), intState)
+	if err != nil {
+		return types.SmartError(err)
+	}
+
+	return types.EmptySyncResponse
+}
+
+func daemonConfigPatch(s types.State, r *http.Request) types.Response {
+	req := types.DaemonConfigPatch{}
+	err := json.NewDecoder(r.Body).Decode(&req)
+	if err != nil {
+		return types.BadRequest(err)
+	}
+
+	intState, err := internalState.ToInternal(s)
+	if err != nil {
+		return types.SmartError(err)
+	}
+
+	if req.Servers != nil {
+		err = validateServerConfigs(intState, *req.Servers)
+		if err != nil {
+			return types.BadRequest(err)
+		}
+	}
+
+	daemonConfig := intState.LocalConfig()
+	if req.Servers != nil {
+		daemonConfig.SetServers(*req.Servers)
+	}
+
+	if req.FailureDomain != nil {
+		daemonConfig.SetFailureDomain(*req.FailureDomain)
+	}
+
+	err = applyAndNotifyDaemonConfig(r.Context(), intState)
+	if err != nil {
+		return types.SmartError(err)
+	}
+
+	return types.EmptySyncResponse
+}
+
 // applyAndNotifyDaemonConfig persists the current daemon configuration to file,
 // updates additional listeners, and notifies all cluster members by running
 // the OnDaemonConfigUpdate hook.
@@ -113,6 +181,26 @@ func applyAndNotifyDaemonConfig(ctx context.Context, intState *internalState.Int
 
 		return internalClient.RunOnDaemonConfigUpdateHook(ctx, c.UseTarget(remote.Name), daemonConfig.Dump())
 	})
+}
+
+// validateDaemonConfigUpdate checks that any provided immutable fields (Name, Address)
+// have not changed and delegates server config validation to validateServerConfigs.
+func validateDaemonConfigUpdate(s *internalState.InternalState, req types.DaemonConfig) error {
+	daemonConfig := s.LocalConfig().Dump()
+	if req.Name != "" && req.Name != daemonConfig.Name {
+		return fmt.Errorf("Name is immutable")
+	}
+
+	var zeroAddr types.AddrPort
+	if req.Address != zeroAddr && req.Address != daemonConfig.Address {
+		return fmt.Errorf("Address is immutable")
+	}
+
+	if req.Servers != nil {
+		return validateServerConfigs(s, req.Servers)
+	}
+
+	return nil
 }
 
 // validateServerConfigs checks that each server name has a matching additional

--- a/internal/rest/resources/daemon.go
+++ b/internal/rest/resources/daemon.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"net/http"
 	"slices"
+	"strconv"
 
 	"github.com/canonical/microcluster/v3/internal/rest/access"
 	internalClient "github.com/canonical/microcluster/v3/internal/rest/client"
@@ -89,6 +90,11 @@ func daemonConfigPut(s types.State, r *http.Request) types.Response {
 		return types.SmartError(err)
 	}
 
+	restart, err := daemonConfigRestartRequested(r)
+	if err != nil {
+		return types.BadRequest(err)
+	}
+
 	err = validateDaemonConfigUpdate(intState, req)
 	if err != nil {
 		return types.BadRequest(err)
@@ -101,6 +107,10 @@ func daemonConfigPut(s types.State, r *http.Request) types.Response {
 	err = applyAndNotifyDaemonConfig(r.Context(), intState)
 	if err != nil {
 		return types.SmartError(err)
+	}
+
+	if restart {
+		return daemonRestart(intState)
 	}
 
 	return types.EmptySyncResponse
@@ -116,6 +126,11 @@ func daemonConfigPatch(s types.State, r *http.Request) types.Response {
 	intState, err := internalState.ToInternal(s)
 	if err != nil {
 		return types.SmartError(err)
+	}
+
+	restart, err := daemonConfigRestartRequested(r)
+	if err != nil {
+		return types.BadRequest(err)
 	}
 
 	if req.Servers != nil {
@@ -135,6 +150,36 @@ func daemonConfigPatch(s types.State, r *http.Request) types.Response {
 	}
 
 	err = applyAndNotifyDaemonConfig(r.Context(), intState)
+	if err != nil {
+		return types.SmartError(err)
+	}
+
+	if restart {
+		return daemonRestart(intState)
+	}
+
+	return types.EmptySyncResponse
+}
+
+func daemonConfigRestartRequested(r *http.Request) (bool, error) {
+	value := r.URL.Query().Get("restart")
+	if value == "" {
+		return false, nil
+	}
+
+	restart, err := strconv.ParseBool(value)
+	if err != nil {
+		return false, fmt.Errorf("Invalid restart query parameter %q", value)
+	}
+
+	return restart, nil
+}
+
+// daemonRestart restarts the dqlite database on the local member so that pending
+// configuration changes such as failure-domain take effect immediately. The call
+// is synchronous and only returns once the local database has come back online.
+func daemonRestart(intState *internalState.InternalState) types.Response {
+	err := intState.RestartDB()
 	if err != nil {
 		return types.SmartError(err)
 	}

--- a/internal/rest/resources/daemon_test.go
+++ b/internal/rest/resources/daemon_test.go
@@ -1,0 +1,732 @@
+package resources
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/canonical/lxd/shared"
+	"github.com/canonical/lxd/shared/api"
+	"github.com/stretchr/testify/require"
+
+	internalConfig "github.com/canonical/microcluster/v3/internal/config"
+	internalState "github.com/canonical/microcluster/v3/internal/state"
+	"github.com/canonical/microcluster/v3/internal/trust"
+	"github.com/canonical/microcluster/v3/microcluster/types"
+)
+
+func TestDaemonConfigGet(t *testing.T) {
+	t.Parallel()
+
+	addr, err := types.ParseAddrPort("127.0.0.1:9001")
+	require.NoError(t, err)
+
+	serverAddr, err := types.ParseAddrPort("127.0.0.1:9443")
+	require.NoError(t, err)
+
+	cfg := internalConfig.NewDaemonConfig(filepath.Join(t.TempDir(), "daemon.yaml"))
+	cfg.SetName("m1")
+	cfg.SetAddress(addr)
+	cfg.SetServers(map[string]types.ServerConfig{
+		"metrics.example.com": {Address: serverAddr},
+	})
+	cfg.SetFailureDomain(7)
+
+	s := &internalState.InternalState{
+		LocalConfig: func() *internalConfig.DaemonConfig { return cfg },
+	}
+
+	req := &http.Request{
+		Method: http.MethodGet,
+		URL:    &url.URL{},
+	}
+
+	resp := daemonConfigGet(s, req)
+	recorder := httptest.NewRecorder()
+	err = resp.Render(recorder, req)
+	require.NoError(t, err)
+
+	var body api.Response
+	err = json.NewDecoder(recorder.Result().Body).Decode(&body)
+	require.NoError(t, err)
+	require.Equal(t, api.SyncResponse, body.Type)
+	require.Equal(t, http.StatusOK, body.StatusCode)
+
+	metadata, err := json.Marshal(body.Metadata)
+	require.NoError(t, err)
+
+	var got types.DaemonConfig
+	err = json.Unmarshal(metadata, &got)
+	require.NoError(t, err)
+
+	require.Equal(t, "m1", got.Name)
+	require.Equal(t, "127.0.0.1:9001", got.Address.String())
+	require.Equal(t, uint64(7), got.FailureDomain)
+	require.NotNil(t, got.Servers)
+	require.Contains(t, got.Servers, "metrics.example.com")
+	require.Equal(t, "127.0.0.1:9443", got.Servers["metrics.example.com"].Address.String())
+}
+
+func TestDaemonServersGetCompatibility(t *testing.T) {
+	t.Parallel()
+
+	serverAddr, err := types.ParseAddrPort("127.0.0.1:9443")
+	require.NoError(t, err)
+
+	cfg := internalConfig.NewDaemonConfig(filepath.Join(t.TempDir(), "daemon.yaml"))
+	cfg.SetServers(map[string]types.ServerConfig{
+		"metrics.example.com": {Address: serverAddr},
+	})
+
+	s := &internalState.InternalState{
+		LocalConfig: func() *internalConfig.DaemonConfig { return cfg },
+	}
+
+	req := &http.Request{
+		Method: http.MethodGet,
+		URL:    &url.URL{},
+	}
+
+	resp := daemonServersGet(s, req)
+	recorder := httptest.NewRecorder()
+	err = resp.Render(recorder, req)
+	require.NoError(t, err)
+
+	var body api.Response
+	err = json.NewDecoder(recorder.Result().Body).Decode(&body)
+	require.NoError(t, err)
+	require.Equal(t, api.SyncResponse, body.Type)
+	require.Equal(t, http.StatusOK, body.StatusCode)
+
+	metadata, err := json.Marshal(body.Metadata)
+	require.NoError(t, err)
+
+	var got map[string]types.ServerConfig
+	err = json.Unmarshal(metadata, &got)
+	require.NoError(t, err)
+	require.Len(t, got, 1)
+	require.Contains(t, got, "metrics.example.com")
+	require.Equal(t, "127.0.0.1:9443", got["metrics.example.com"].Address.String())
+}
+
+func TestValidateDaemonConfigUpdateRejects(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		mutate  func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfig
+		wantErr string
+	}{
+		{
+			name: "name change",
+			mutate: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfig {
+				servers := cfg.GetServers()
+				fd := cfg.GetFailureDomain()
+				return types.DaemonConfig{
+					Name:          "m2",
+					Address:       cfg.GetAddress(),
+					Servers:       servers,
+					FailureDomain: fd,
+				}
+			},
+			wantErr: "Name is immutable",
+		},
+		{
+			name: "address change",
+			mutate: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfig {
+				otherAddr, err := types.ParseAddrPort("127.0.0.1:9002")
+				require.NoError(t, err)
+
+				servers := cfg.GetServers()
+				fd := cfg.GetFailureDomain()
+				return types.DaemonConfig{
+					Name:          cfg.GetName(),
+					Address:       otherAddr,
+					Servers:       servers,
+					FailureDomain: fd,
+				}
+			},
+			wantErr: "Address is immutable",
+		},
+		{
+			name: "unknown server",
+			mutate: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfig {
+				serverAddr, err := types.ParseAddrPort("127.0.0.1:9444")
+				require.NoError(t, err)
+
+				fd := cfg.GetFailureDomain()
+				servers := map[string]types.ServerConfig{
+					"unknown.example.com": {Address: serverAddr},
+				}
+
+				return types.DaemonConfig{
+					Name:          cfg.GetName(),
+					Address:       cfg.GetAddress(),
+					Servers:       servers,
+					FailureDomain: fd,
+				}
+			},
+			wantErr: "No matching additional listener found",
+		},
+		{
+			name: "address conflict",
+			mutate: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfig {
+				conflicting, err := types.ParseAddrPort("127.0.0.1:9001")
+				require.NoError(t, err)
+
+				fd := cfg.GetFailureDomain()
+				servers := map[string]types.ServerConfig{
+					"metrics.example.com": {Address: conflicting},
+				}
+
+				return types.DaemonConfig{
+					Name:          cfg.GetName(),
+					Address:       cfg.GetAddress(),
+					Servers:       servers,
+					FailureDomain: fd,
+				}
+			},
+			wantErr: "already in use",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			addr, err := types.ParseAddrPort("127.0.0.1:9001")
+			require.NoError(t, err)
+			serverAddr, err := types.ParseAddrPort("127.0.0.1:9443")
+			require.NoError(t, err)
+
+			cfg := internalConfig.NewDaemonConfig(filepath.Join(t.TempDir(), "daemon.yaml"))
+			cfg.SetName("m1")
+			cfg.SetAddress(addr)
+			cfg.SetServers(map[string]types.ServerConfig{
+				"metrics.example.com": {Address: serverAddr},
+			})
+			cfg.SetFailureDomain(3)
+
+			updateCalls := 0
+			s := &internalState.InternalState{
+				LocalConfig: func() *internalConfig.DaemonConfig {
+					return cfg
+				},
+				UpdateServers: func() error {
+					updateCalls++
+					return nil
+				},
+				InternalAddress: func() *url.URL {
+					return &url.URL{Host: addr.String()}
+				},
+				InternalExtensionServers: func() []string {
+					return []string{"metrics.example.com"}
+				},
+			}
+
+			req := tt.mutate(t, cfg)
+
+			err = validateDaemonConfigUpdate(s, req)
+			require.Error(t, err)
+			require.ErrorContains(t, err, tt.wantErr)
+			require.Equal(t, 0, updateCalls)
+		})
+	}
+}
+
+func TestDaemonConfigPut(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		request         func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfig
+		wantType        api.ResponseType
+		wantStatusCode  int
+		wantBodyContain string
+		wantUpdateCalls int
+		verifyState     func(t *testing.T, cfg *internalConfig.DaemonConfig, cfgPath string)
+	}{
+		{
+			name: "applies and persists",
+			request: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfig {
+				newServerAddr, err := types.ParseAddrPort("127.0.0.1:9555")
+				require.NoError(t, err)
+
+				fd := uint64(9)
+				servers := map[string]types.ServerConfig{
+					"metrics.example.com": {Address: newServerAddr},
+				}
+
+				return types.DaemonConfig{
+					Name:          cfg.GetName(),
+					Address:       cfg.GetAddress(),
+					Servers:       servers,
+					FailureDomain: fd,
+				}
+			},
+			wantType:        api.SyncResponse,
+			wantStatusCode:  http.StatusOK,
+			wantUpdateCalls: 1,
+			verifyState: func(t *testing.T, cfg *internalConfig.DaemonConfig, cfgPath string) {
+				t.Helper()
+
+				require.Equal(t, uint64(9), cfg.GetFailureDomain())
+				require.Equal(t, "127.0.0.1:9555", cfg.GetServers()["metrics.example.com"].Address.String())
+
+				reloaded := internalConfig.NewDaemonConfig(cfgPath)
+				err := reloaded.Load()
+				require.NoError(t, err)
+				require.Equal(t, uint64(9), reloaded.GetFailureDomain())
+				require.Equal(t, "127.0.0.1:9555", reloaded.GetServers()["metrics.example.com"].Address.String())
+			},
+		},
+		{
+			name: "rejects name change",
+			request: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfig {
+				servers := cfg.GetServers()
+				fd := cfg.GetFailureDomain()
+				return types.DaemonConfig{
+					Name:          "m2",
+					Address:       cfg.GetAddress(),
+					Servers:       servers,
+					FailureDomain: fd,
+				}
+			},
+			wantType:        api.ErrorResponse,
+			wantStatusCode:  http.StatusBadRequest,
+			wantBodyContain: "Name is immutable",
+			wantUpdateCalls: 0,
+		},
+		{
+			name: "omitting servers clears existing servers",
+			request: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfig {
+				fd := uint64(5)
+				return types.DaemonConfig{
+					Name:          cfg.GetName(),
+					Address:       cfg.GetAddress(),
+					FailureDomain: fd,
+				}
+			},
+			wantType:        api.SyncResponse,
+			wantStatusCode:  http.StatusOK,
+			wantUpdateCalls: 1,
+			verifyState: func(t *testing.T, cfg *internalConfig.DaemonConfig, cfgPath string) {
+				t.Helper()
+
+				// FailureDomain updated.
+				require.Equal(t, uint64(5), cfg.GetFailureDomain())
+				// Servers cleared (nil map → empty).
+				require.Empty(t, cfg.GetServers())
+			},
+		},
+		{
+			name: "omitting failure-domain clears existing value",
+			request: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfig {
+				newServerAddr, err := types.ParseAddrPort("127.0.0.1:9555")
+				require.NoError(t, err)
+
+				servers := map[string]types.ServerConfig{
+					"metrics.example.com": {Address: newServerAddr},
+				}
+
+				return types.DaemonConfig{
+					Name:    cfg.GetName(),
+					Address: cfg.GetAddress(),
+					Servers: servers,
+				}
+			},
+			wantType:        api.SyncResponse,
+			wantStatusCode:  http.StatusOK,
+			wantUpdateCalls: 1,
+			verifyState: func(t *testing.T, cfg *internalConfig.DaemonConfig, cfgPath string) {
+				t.Helper()
+
+				// Servers updated.
+				require.Equal(t, "127.0.0.1:9555", cfg.GetServers()["metrics.example.com"].Address.String())
+				// FailureDomain cleared (was 3, now 0).
+				require.Equal(t, uint64(0), cfg.GetFailureDomain())
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfgPath := filepath.Join(t.TempDir(), "daemon.yaml")
+			addr, err := types.ParseAddrPort("127.0.0.1:9001")
+			require.NoError(t, err)
+			serverAddr, err := types.ParseAddrPort("127.0.0.1:9443")
+			require.NoError(t, err)
+
+			cfg := internalConfig.NewDaemonConfig(cfgPath)
+			cfg.SetName("m1")
+			cfg.SetAddress(addr)
+			cfg.SetServers(map[string]types.ServerConfig{
+				"metrics.example.com": {Address: serverAddr},
+			})
+			cfg.SetFailureDomain(3)
+			err = cfg.Write()
+			require.NoError(t, err)
+
+			updateCalls := 0
+			s := &internalState.InternalState{
+				LocalConfig: func() *internalConfig.DaemonConfig {
+					return cfg
+				},
+				UpdateServers: func() error {
+					updateCalls++
+					return nil
+				},
+				InternalAddress: func() *url.URL {
+					return &url.URL{Host: addr.String()}
+				},
+				InternalExtensionServers: func() []string {
+					return []string{"metrics.example.com"}
+				},
+			}
+
+			trustStorePath := filepath.Join(t.TempDir(), "truststore")
+			certPath := filepath.Join(t.TempDir(), "certs")
+			err = os.MkdirAll(certPath, 0755)
+			require.NoError(t, err)
+			serverCert, err := shared.KeyPairAndCA(certPath, string(types.ServerCertificateName), shared.CertServer, shared.CertOptions{})
+			require.NoError(t, err)
+			clusterCert, err := shared.KeyPairAndCA(certPath, string(types.ClusterCertificateName), shared.CertServer, shared.CertOptions{})
+			require.NoError(t, err)
+			clusterX509, err := clusterCert.PublicKeyX509()
+			require.NoError(t, err)
+
+			remotes := &trust.Remotes{}
+			err = os.MkdirAll(trustStorePath, 0755)
+			require.NoError(t, err)
+			err = remotes.Load(trustStorePath)
+			require.NoError(t, err)
+			err = remotes.Add(trustStorePath, types.Remote{
+				Location: types.Location{Name: "m1", Address: addr},
+				Certificate: types.X509Certificate{
+					Certificate: clusterX509,
+				},
+			})
+			require.NoError(t, err)
+
+			s.InternalServerCert = func() *shared.CertInfo {
+				return serverCert
+			}
+
+			s.InternalClusterCert = func() *shared.CertInfo {
+				return clusterCert
+			}
+
+			s.InternalRemotes = func() *trust.Remotes {
+				return remotes
+			}
+
+			reqBody := tt.request(t, cfg)
+			body, err := json.Marshal(reqBody)
+			require.NoError(t, err)
+
+			req := &http.Request{
+				Method: http.MethodPut,
+				URL:    &url.URL{},
+				Body:   io.NopCloser(bytes.NewReader(body)),
+			}
+
+			resp := daemonConfigPut(s, req)
+			recorder := httptest.NewRecorder()
+			err = resp.Render(recorder, req)
+			require.NoError(t, err)
+
+			var apiResp api.Response
+			err = json.NewDecoder(recorder.Result().Body).Decode(&apiResp)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantType, apiResp.Type)
+			require.Equal(t, tt.wantStatusCode, recorder.Result().StatusCode)
+			require.Equal(t, tt.wantUpdateCalls, updateCalls)
+
+			if tt.wantBodyContain != "" {
+				require.Contains(t, recorder.Body.String(), tt.wantBodyContain)
+			}
+
+			if tt.verifyState != nil {
+				tt.verifyState(t, cfg, cfgPath)
+			}
+		})
+	}
+}
+
+func TestDaemonConfigPatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		request         func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfigPatch
+		wantType        api.ResponseType
+		wantStatusCode  int
+		wantBodyContain string
+		wantUpdateCalls int
+		verifyState     func(t *testing.T, cfg *internalConfig.DaemonConfig, cfgPath string)
+	}{
+		{
+			name: "applies and persists",
+			request: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfigPatch {
+				newServerAddr, err := types.ParseAddrPort("127.0.0.1:9555")
+				require.NoError(t, err)
+
+				fd := uint64(7)
+				servers := map[string]types.ServerConfig{
+					"metrics.example.com": {Address: newServerAddr},
+				}
+
+				return types.DaemonConfigPatch{
+					Servers:       &servers,
+					FailureDomain: &fd,
+				}
+			},
+			wantType:        api.SyncResponse,
+			wantStatusCode:  http.StatusOK,
+			wantUpdateCalls: 1,
+			verifyState: func(t *testing.T, cfg *internalConfig.DaemonConfig, cfgPath string) {
+				t.Helper()
+
+				require.Equal(t, uint64(7), cfg.GetFailureDomain())
+				require.Equal(t, "127.0.0.1:9555", cfg.GetServers()["metrics.example.com"].Address.String())
+
+				reloaded := internalConfig.NewDaemonConfig(cfgPath)
+				err := reloaded.Load()
+				require.NoError(t, err)
+				require.Equal(t, uint64(7), reloaded.GetFailureDomain())
+				require.Equal(t, "127.0.0.1:9555", reloaded.GetServers()["metrics.example.com"].Address.String())
+			},
+		},
+		{
+			name: "omitting servers preserves existing servers",
+			request: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfigPatch {
+				fd := uint64(5)
+				return types.DaemonConfigPatch{
+					FailureDomain: &fd,
+				}
+			},
+			wantType:        api.SyncResponse,
+			wantStatusCode:  http.StatusOK,
+			wantUpdateCalls: 1,
+			verifyState: func(t *testing.T, cfg *internalConfig.DaemonConfig, cfgPath string) {
+				t.Helper()
+
+				// FailureDomain updated.
+				require.Equal(t, uint64(5), cfg.GetFailureDomain())
+				// Existing servers untouched.
+				require.Contains(t, cfg.GetServers(), "metrics.example.com")
+			},
+		},
+		{
+			name: "omitting failure-domain preserves existing value",
+			request: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfigPatch {
+				newServerAddr, err := types.ParseAddrPort("127.0.0.1:9555")
+				require.NoError(t, err)
+
+				servers := map[string]types.ServerConfig{
+					"metrics.example.com": {Address: newServerAddr},
+				}
+
+				return types.DaemonConfigPatch{
+					Servers: &servers,
+				}
+			},
+			wantType:        api.SyncResponse,
+			wantStatusCode:  http.StatusOK,
+			wantUpdateCalls: 1,
+			verifyState: func(t *testing.T, cfg *internalConfig.DaemonConfig, cfgPath string) {
+				t.Helper()
+
+				// Servers updated.
+				require.Equal(t, "127.0.0.1:9555", cfg.GetServers()["metrics.example.com"].Address.String())
+				// FailureDomain untouched (was 3).
+				require.Equal(t, uint64(3), cfg.GetFailureDomain())
+			},
+		},
+		{
+			name: "setting failure-domain zero clears existing value",
+			request: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfigPatch {
+				fd := uint64(0)
+				return types.DaemonConfigPatch{
+					FailureDomain: &fd,
+				}
+			},
+			wantType:        api.SyncResponse,
+			wantStatusCode:  http.StatusOK,
+			wantUpdateCalls: 1,
+			verifyState: func(t *testing.T, cfg *internalConfig.DaemonConfig, cfgPath string) {
+				t.Helper()
+
+				require.Equal(t, uint64(0), cfg.GetFailureDomain())
+			},
+		},
+		{
+			name: "setting servers empty clears existing servers",
+			request: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfigPatch {
+				servers := map[string]types.ServerConfig{}
+				return types.DaemonConfigPatch{
+					Servers: &servers,
+				}
+			},
+			wantType:        api.SyncResponse,
+			wantStatusCode:  http.StatusOK,
+			wantUpdateCalls: 1,
+			verifyState: func(t *testing.T, cfg *internalConfig.DaemonConfig, cfgPath string) {
+				t.Helper()
+
+				require.Empty(t, cfg.GetServers())
+			},
+		},
+		{
+			name: "rejects unknown server name",
+			request: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfigPatch {
+				serverAddr, err := types.ParseAddrPort("127.0.0.1:9555")
+				require.NoError(t, err)
+
+				servers := map[string]types.ServerConfig{
+					"unknown.example.com": {Address: serverAddr},
+				}
+
+				return types.DaemonConfigPatch{
+					Servers: &servers,
+				}
+			},
+			wantType:        api.ErrorResponse,
+			wantStatusCode:  http.StatusBadRequest,
+			wantBodyContain: "No matching additional listener found",
+			wantUpdateCalls: 0,
+		},
+		{
+			name: "rejects server address conflict",
+			request: func(t *testing.T, cfg *internalConfig.DaemonConfig) types.DaemonConfigPatch {
+				conflicting, err := types.ParseAddrPort("127.0.0.1:9001")
+				require.NoError(t, err)
+
+				servers := map[string]types.ServerConfig{
+					"metrics.example.com": {Address: conflicting},
+				}
+
+				return types.DaemonConfigPatch{
+					Servers: &servers,
+				}
+			},
+			wantType:        api.ErrorResponse,
+			wantStatusCode:  http.StatusBadRequest,
+			wantBodyContain: "already in use",
+			wantUpdateCalls: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfgPath := filepath.Join(t.TempDir(), "daemon.yaml")
+			addr, err := types.ParseAddrPort("127.0.0.1:9001")
+			require.NoError(t, err)
+			serverAddr, err := types.ParseAddrPort("127.0.0.1:9443")
+			require.NoError(t, err)
+
+			cfg := internalConfig.NewDaemonConfig(cfgPath)
+			cfg.SetName("m1")
+			cfg.SetAddress(addr)
+			cfg.SetServers(map[string]types.ServerConfig{
+				"metrics.example.com": {Address: serverAddr},
+			})
+			cfg.SetFailureDomain(3)
+			err = cfg.Write()
+			require.NoError(t, err)
+
+			updateCalls := 0
+			s := &internalState.InternalState{
+				LocalConfig: func() *internalConfig.DaemonConfig {
+					return cfg
+				},
+				UpdateServers: func() error {
+					updateCalls++
+					return nil
+				},
+				InternalAddress: func() *url.URL {
+					return &url.URL{Host: addr.String()}
+				},
+				InternalExtensionServers: func() []string {
+					return []string{"metrics.example.com"}
+				},
+			}
+
+			trustStorePath := filepath.Join(t.TempDir(), "truststore")
+			certPath := filepath.Join(t.TempDir(), "certs")
+			err = os.MkdirAll(certPath, 0755)
+			require.NoError(t, err)
+			serverCert, err := shared.KeyPairAndCA(certPath, string(types.ServerCertificateName), shared.CertServer, shared.CertOptions{})
+			require.NoError(t, err)
+			clusterCert, err := shared.KeyPairAndCA(certPath, string(types.ClusterCertificateName), shared.CertServer, shared.CertOptions{})
+			require.NoError(t, err)
+			clusterX509, err := clusterCert.PublicKeyX509()
+			require.NoError(t, err)
+
+			remotes := &trust.Remotes{}
+			err = os.MkdirAll(trustStorePath, 0755)
+			require.NoError(t, err)
+			err = remotes.Load(trustStorePath)
+			require.NoError(t, err)
+			err = remotes.Add(trustStorePath, types.Remote{
+				Location: types.Location{Name: "m1", Address: addr},
+				Certificate: types.X509Certificate{
+					Certificate: clusterX509,
+				},
+			})
+			require.NoError(t, err)
+
+			s.InternalServerCert = func() *shared.CertInfo {
+				return serverCert
+			}
+
+			s.InternalClusterCert = func() *shared.CertInfo {
+				return clusterCert
+			}
+
+			s.InternalRemotes = func() *trust.Remotes {
+				return remotes
+			}
+
+			reqBody := tt.request(t, cfg)
+			body, err := json.Marshal(reqBody)
+			require.NoError(t, err)
+
+			req := &http.Request{
+				Method: http.MethodPatch,
+				URL:    &url.URL{},
+				Body:   io.NopCloser(bytes.NewReader(body)),
+			}
+
+			resp := daemonConfigPatch(s, req)
+			recorder := httptest.NewRecorder()
+			err = resp.Render(recorder, req)
+			require.NoError(t, err)
+
+			var apiResp api.Response
+			err = json.NewDecoder(recorder.Result().Body).Decode(&apiResp)
+			require.NoError(t, err)
+			require.Equal(t, tt.wantType, apiResp.Type)
+			require.Equal(t, tt.wantStatusCode, recorder.Result().StatusCode)
+			require.Equal(t, tt.wantUpdateCalls, updateCalls)
+
+			if tt.wantBodyContain != "" {
+				require.Contains(t, recorder.Body.String(), tt.wantBodyContain)
+			}
+
+			if tt.verifyState != nil {
+				tt.verifyState(t, cfg, cfgPath)
+			}
+		})
+	}
+}

--- a/internal/rest/resources/resources.go
+++ b/internal/rest/resources/resources.go
@@ -30,6 +30,7 @@ var PublicEndpoints = types.Resources{
 		clusterCmd,
 		clusterMemberCmd,
 		clusterCertificatesCmd,
+		daemonConfigCmd,
 		daemonServersCmd,
 		memberCmd,
 		readyCmd,

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -59,6 +59,10 @@ type InternalState struct {
 	// Stop fully stops the daemon, its database, all listeners, and all servers.
 	Stop func() (exit func(), stopErr error)
 
+	// RestartDB closes and restarts the dqlite database, applying any pending configuration
+	// changes such as an updated failure-domain without a full daemon restart.
+	RestartDB func() error
+
 	// Runtime extensions.
 	Extensions types.Extensions
 

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -481,13 +481,14 @@ func (m *MicroCluster) GetDaemonConfig(ctx context.Context) (*types.DaemonConfig
 
 // UpdateDaemonConfig partially updates local daemon configuration.
 // Only fields explicitly set (non-nil) in the patch are applied; omitted fields preserve their current values.
-func (m *MicroCluster) UpdateDaemonConfig(ctx context.Context, config types.DaemonConfigPatch) error {
+// When restart is true, the local dqlite node is restarted after persisting the config changes.
+func (m *MicroCluster) UpdateDaemonConfig(ctx context.Context, config types.DaemonConfigPatch, restart bool) error {
 	c, err := m.LocalClient()
 	if err != nil {
 		return err
 	}
 
-	return internalClient.PatchDaemonConfig(ctx, c, config)
+	return internalClient.PatchDaemonConfig(ctx, c, config, restart)
 }
 
 // UpdateServers updates the extension servers defined when starting the daemon.

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -491,6 +491,8 @@ func (m *MicroCluster) UpdateDaemonConfig(ctx context.Context, config types.Daem
 }
 
 // UpdateServers updates the extension servers defined when starting the daemon.
+//
+// Deprecated: Use UpdateDaemonConfig with a DaemonConfigPatch.Servers field instead.
 func (m *MicroCluster) UpdateServers(ctx context.Context, config map[string]types.ServerConfig) error {
 	c, err := m.LocalClient()
 	if err != nil {

--- a/microcluster/app.go
+++ b/microcluster/app.go
@@ -469,6 +469,27 @@ func (m *MicroCluster) LoggerFromContext(ctx context.Context) *slog.Logger {
 	return logger
 }
 
+// GetDaemonConfig returns the local daemon configuration.
+func (m *MicroCluster) GetDaemonConfig(ctx context.Context) (*types.DaemonConfig, error) {
+	c, err := m.LocalClient()
+	if err != nil {
+		return nil, err
+	}
+
+	return internalClient.GetDaemonConfig(ctx, c)
+}
+
+// UpdateDaemonConfig partially updates local daemon configuration.
+// Only fields explicitly set (non-nil) in the patch are applied; omitted fields preserve their current values.
+func (m *MicroCluster) UpdateDaemonConfig(ctx context.Context, config types.DaemonConfigPatch) error {
+	c, err := m.LocalClient()
+	if err != nil {
+		return err
+	}
+
+	return internalClient.PatchDaemonConfig(ctx, c, config)
+}
+
 // UpdateServers updates the extension servers defined when starting the daemon.
 func (m *MicroCluster) UpdateServers(ctx context.Context, config map[string]types.ServerConfig) error {
 	c, err := m.LocalClient()

--- a/microcluster/types/config.go
+++ b/microcluster/types/config.go
@@ -2,7 +2,8 @@ package types
 
 // DaemonConfig is the in memory version of the local daemon.yaml file.
 type DaemonConfig struct {
-	Name    string                  `json:"name" yaml:"name"`
-	Address AddrPort                `json:"address" yaml:"address"`
-	Servers map[string]ServerConfig `json:"servers" yaml:"servers"`
+	Name          string                  `json:"name" yaml:"name"`
+	Address       AddrPort                `json:"address" yaml:"address"`
+	Servers       map[string]ServerConfig `json:"servers" yaml:"servers"`
+	FailureDomain uint64                  `json:"failure-domain" yaml:"failure-domain"`
 }

--- a/microcluster/types/config.go
+++ b/microcluster/types/config.go
@@ -7,3 +7,10 @@ type DaemonConfig struct {
 	Servers       map[string]ServerConfig `json:"servers" yaml:"servers"`
 	FailureDomain uint64                  `json:"failure-domain" yaml:"failure-domain"`
 }
+
+// DaemonConfigPatch is the request body for PATCH /core/1.0/daemon/config.
+// Optional fields preserve existing values when omitted.
+type DaemonConfigPatch struct {
+	Servers       *map[string]ServerConfig `json:"servers,omitempty" yaml:"servers,omitempty"`
+	FailureDomain *uint64                  `json:"failure-domain,omitempty" yaml:"failure-domain,omitempty"`
+}


### PR DESCRIPTION
Backports https://github.com/canonical/microcluster/pull/629 and https://github.com/canonical/microcluster/pull/635 in `v3` LTS.