### PR TITLE
feat(db): make dqlite "ready" timeout configurable via DQLITE_READY_TIMEOUT

### DIFF
--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -27,8 +27,24 @@ import (
 // Returns true if we need to wait for other nodes to catch up to our version.
 func (db *DqliteDB) Open(ext types.Extensions, bootstrap bool) error {
 	// Allow dqlite up to 2 minutes to become ready when starting up.
-	// This is to allow for unready/dead nodes to time out.
-	ctx, cancel := context.WithTimeout(db.ctx, 120*time.Second)
+	// This is to allow for unready/dead nodes to time out. The timeout can be
+	// raised via the DQLITE_READY_TIMEOUT environment variable, which helps when
+	// a joining node must sync a large dqlite database over a slow link or disk
+	// and would otherwise exceed the default.
+	readyTimeout := 120 * time.Second
+	if v := os.Getenv(sys.DqliteReadyTimeout); v != "" {
+		parsed, err := time.ParseDuration(v)
+		switch {
+		case err != nil:
+			db.log().Warn("Ignoring invalid DQLITE_READY_TIMEOUT", slog.String("value", v), slog.String("error", err.Error()))
+		case parsed <= 0:
+			db.log().Warn("Ignoring non-positive DQLITE_READY_TIMEOUT", slog.String("value", v))
+		default:
+			readyTimeout = parsed
+		}
+	}
+
+	ctx, cancel := context.WithTimeout(db.ctx, readyTimeout)
 	defer cancel()
 
 	db.statusLock.Lock()

--- a/internal/sys/environment.go
+++ b/internal/sys/environment.go
@@ -4,6 +4,12 @@ const (
 	// DqliteSocket is the configurable location of the dqlite socket.
 	DqliteSocket = "DQLITE_SOCKET"
 
+	// DqliteReadyTimeout overrides how long to wait for dqlite to become ready
+	// when opening the database (a Go duration string, e.g. "30m"). Defaults to
+	// 2 minutes. Useful when a joining node must sync a large dqlite database
+	// over a slow link or disk and would otherwise exceed the default timeout.
+	DqliteReadyTimeout = "DQLITE_READY_TIMEOUT"
+
 	// StateDir is the location of the daemon state directory.
 	StateDir = "STATE_DIR"
 


### PR DESCRIPTION
### Problem

`DqliteDB.Open()` waits a hardcoded **120s** for dqlite to become ready ([`internal/db/db.go`](https://github.com/canonical/microcluster/blob/v4/internal/db/db.go#L28-L31)). On clusters whose dqlite database has grown large, a joining node cannot download + replay the state and reach `Ready` within that window, so `cluster join` fails:

```
Error: Failed to join cluster: Ready dqlite: context deadline exceeded
```

…while the leader logs `Received error sending heartbeat … error="Database is still starting"`.

Concretely, we hit this on a **MicroCeph (Squid)** cluster: the microcluster dqlite DB had grown to **~126 MB** (default raft snapshot `trailing=8192` x MicroCeph's large config/OSD raft entries), and a 4th node could never join — the sync simply exceeds the timeout. (MicroCeph's `dqlite.New(...)` doesn't set `WithSnapshotParams`, so the trailing window uses go-dqlite defaults, which Canonical's own [k8s-dqlite troubleshooting docs](https://documentation.ubuntu.com/canonical-kubernetes/release-1.32/snap/reference/troubleshooting/) describe as "too large for small clusters".)

### Change

Make the ready timeout overridable via a **`DQLITE_READY_TIMEOUT`** environment variable (a Go duration string, e.g. `30m`), matching the existing env-var convention in `internal/sys` (`DQLITE_SOCKET`, `STATE_DIR`, …).

- Default unchanged (**120s**).
- Invalid / non-positive values are ignored with a warning via the existing `db.log().Warn(...)` path.

A minimal, backward-compatible lever so operators with a legitimately large dqlite DB (or a slow disk/link) can let a join complete instead of failing outright.

### Notes

- Happy to make this a **typed config option** instead of an env var if you'd prefer — env var was chosen to match the existing `internal/sys` pattern and require no API change.
- A complementary fix would be to expose dqlite snapshot params (`threshold`/`trailing`) to bound DB growth, the way k8s-dqlite does via `tuning.yaml`. Glad to follow up.
- I could not run the full CGO build locally (no `libdqlite`/`dqlite.h` toolchain); `gofmt -l` is clean and `go build ./internal/sys/` is OK. `db.go` uses only symbols already imported in that file.

### Related

canonical/microceph#476, #444, #473 — node-join failures with the same `Ready dqlite: context deadline exceeded` symptom.
