### PR TITLE
internal/rest/resources/control: retry remaining join addresses on client connect err

### DIFF
--- a/internal/rest/resources/control.go
+++ b/internal/rest/resources/control.go
@@ -247,7 +247,9 @@ func joinWithToken(state types.State, r *http.Request, req *types.Control) (*typ
 
 		client, err := state.Connect().Member(&url.URL, false, cert)
 		if err != nil {
-			return nil, nil, err
+			logger.Warn("Failed to get client for cluster member", slog.String("address", url.String()), slog.String("error", err.Error()))
+			lastErr = err
+			continue
 		}
 
 		joinInfo, err = internalClient.AddClusterMember(context.Background(), client, newClusterMember)


### PR DESCRIPTION
When joining a cluster, `joinWithToken` iterates over all addresses in the token to find a reachable cluster member.

However, if `state.Connect().Member` fails for an address, the function returns immediately instead of trying the next address. This is inconsistent with how other failures in the same loop are handled (`GetRemoteCertificate` and `AddClusterMember` both continue to the next address on error).

The function now iterates over all the join addresses in this scenario.

(cherry picked from commit 39f47c058bed6f1cb65db3334a052ecc52139786)