### PR TITLE
Daemon: Add `OnStop` hook

### DIFF
--- a/example/cmd/microd/main.go
+++ b/example/cmd/microd/main.go
@@ -132,6 +132,14 @@ func (c *cmdDaemon) run(cmd *cobra.Command, args []string) error {
 			return nil
 		},
 
+		OnStop: func(ctx context.Context, s types.State) error {
+			logger := m.LoggerFromContext(ctx)
+
+			logger.Info("This is a hook that runs after the daemon is stopped", slog.String("error", ctx.Err().Error()))
+
+			return nil
+		},
+
 		// PostJoin is run after the daemon is initialized and joins a cluster.
 		PostJoin: func(ctx context.Context, s types.State, initConfig map[string]string) error {
 			logger := m.LoggerFromContext(ctx)

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2,6 +2,7 @@ package daemon
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -139,23 +140,27 @@ func NewDaemon() *Daemon {
 			}
 		}
 
+		var endpointErr error
 		if d.endpoints != nil {
 			// Stop the listeners and shutdown the underlying servers.
-			err := d.endpoints.Down(true)
-			if err != nil {
-				return err
+			endpointErr = d.endpoints.Down(true)
+			if endpointErr != nil {
+				d.log().Error("Failed shutting down endpoints", slog.String("error", endpointErr.Error()))
 			}
 		}
 
+		var onStopErr error
 		if d.hooks.OnStop != nil {
 			// Wait for any shutdown routines
-			err := d.hooks.OnStop(d.shutdownCtx, d.State())
-			if err != nil {
-				return err
+			onStopErr = d.hooks.OnStop(d.shutdownCtx, d.State())
+			if onStopErr != nil {
+				d.log().Error("Failed running OnStop hook", slog.String("error", onStopErr.Error()))
 			}
 		}
 
-		return dqliteErr
+		// Filters out nil errors if there are some.
+		// Multiple errors are separated by a newline.
+		return errors.Join(dqliteErr, endpointErr, onStopErr)
 	})
 
 	return d

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -147,6 +147,14 @@ func NewDaemon() *Daemon {
 			}
 		}
 
+		if d.hooks.OnStop != nil {
+			// Wait for any shutdown routines
+			err := d.hooks.OnStop(d.shutdownCtx, d.State())
+			if err != nil {
+				return err
+			}
+		}
+
 		return dqliteErr
 	})
 

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -2,8 +2,13 @@ package daemon
 
 import (
 	"context"
+	"errors"
+	"io"
+	"log/slog"
 	"path/filepath"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/canonical/lxd/shared"
 	"github.com/canonical/lxd/shared/api"
@@ -259,5 +264,69 @@ func (t *daemonsSuite) Test_UpdateServers() {
 		// Close all endpoints.
 		err = daemon.endpoints.Down(true, endpoints.EndpointNetwork)
 		require.NoError(t.T(), err)
+	}
+}
+
+func (t *daemonsSuite) Test_OnStopHook() {
+	hookRanErr := errors.New("Hook ran")
+
+	tests := []struct {
+		name        string
+		hook        func(ctx context.Context, s types.State) error
+		expectedErr error
+	}{
+		{
+			name: "The OnStop hook runs after the daemon gets stopped",
+			hook: func(ctx context.Context, s types.State) error {
+				return hookRanErr
+			},
+			expectedErr: hookRanErr,
+		},
+		{
+			name: "The OnStop hook blocks the daemon from exiting until it returns",
+			hook: func(ctx context.Context, s types.State) error {
+				time.Sleep(time.Second)
+				return hookRanErr
+			},
+			expectedErr: hookRanErr,
+		},
+		{
+			name: "The OnStop hook returns silently if it returns nil",
+			hook: func(ctx context.Context, s types.State) error {
+				return nil
+			},
+			expectedErr: nil,
+		},
+	}
+
+	for i, test := range tests {
+		t.T().Logf("%s (case %d)", test.name, i)
+
+		// Suppress the log messages.
+		ctx := types.ContextWithLogger(context.Background(), slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{})))
+		ctx, cancel := context.WithCancel(ctx)
+
+		daemon := NewDaemon()
+
+		wg := sync.WaitGroup{}
+		wg.Go(func() {
+			// Blocks until the daemon's context gets cancelled.
+			err := daemon.Run(ctx, t.T().TempDir(), Args{
+				Version: "1.0.0",
+				Hooks: &types.Hooks{
+					OnStop: test.hook,
+				},
+			})
+			require.ErrorIs(t.T(), err, test.expectedErr)
+		})
+
+		// Wait for the daemon to be ready.
+		<-daemon.ReadyChan
+
+		// Shutdown the daemon.
+		cancel()
+
+		// Wait for the daemon to return.
+		wg.Wait()
 	}
 }

--- a/microcluster/types/hooks.go
+++ b/microcluster/types/hooks.go
@@ -63,6 +63,10 @@ type Hooks struct {
 	// OnStart is run after the daemon is started. Its context will not be cancelled until the daemon is shutting down.
 	OnStart func(ctx context.Context, s State) error
 
+	// OnStop is run after the daemon is stopped. Its context is already cancelled but allows access to the logger.
+	// The daemon will wait for this hook to complete before exiting.
+	OnStop func(ctx context.Context, s State) error
+
 	// PostJoin is run after the daemon is initialized, joined the cluster and existing members triggered
 	// their 'OnNewMember' hooks.
 	PostJoin func(ctx context.Context, s State, initConfig map[string]string) error


### PR DESCRIPTION
This allows Microcluster users to hook into the shutdown sequence and force the daemon to wait for potential cleanup tasks to happen.

We found in https://github.com/canonical/microcloud/pull/801 that it is necessary to be able to wait on user spawned routines (like the cluster manager pings and reverse tunnel) to gracefully shutdown before the daemon actually exits.