### PR TITLE
internal/db: Remove node from dqlite cluster on failed join

### DIFF
--- a/internal/db/dqlite.go
+++ b/internal/db/dqlite.go
@@ -155,7 +155,9 @@ func (db *DqliteDB) Bootstrap(extensions extensions.Extensions, addr api.URL, cl
 	}
 
 	// Only close the dqlite app if the entire Bootstrap process fails or exits.
-	// dqlite.Close() immediately tears down all Raft connections and removes this node from the dqlite cluster.
+	// NOTE: dqlite.Close() tears down Raft connections but does NOT remove
+	// the node from the dqlite cluster. For bootstrap this is fine since
+	// the node is the sole member.
 	reverter := revert.New()
 	defer reverter.Fail()
 	reverter.Add(func() {
@@ -207,18 +209,38 @@ func (db *DqliteDB) Join(extensions extensions.Extensions, addr api.URL, joinAdd
 
 	// Only close the dqlite app if the entire Join process fails or exits.
 	// This ensures dqlite.Close() is not called on every Open() retry, but only if we fully give up joining.
-	// dqlite.Close() immediately tears down all Raft connections and removes this node from the dqlite cluster.
+	//
+	// NOTE: dqlite.Close() tears down Raft connections but does NOT remove
+	// the node from the dqlite cluster. We must explicitly ask the leader to
+	// remove us before closing; otherwise the node remains as a ghost member,
+	// which can break quorum calculations and membership consistency checks.
 	reverter := revert.New()
 	defer reverter.Fail()
 	reverter.Add(func() {
-		if db.dqlite != nil {
-			closeErr := db.dqlite.Close()
-			if closeErr != nil {
-				logger.Error("Failed to close database", logger.Ctx{"address": db.listenAddr.String(), "error": closeErr})
-			}
-
-			db.dqlite = nil
+		if db.dqlite == nil {
+			return
 		}
+
+		removeCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+
+		cli, err := db.dqlite.Leader(removeCtx, dqliteClient.WithConcurrentLeaderConns(1))
+		if err != nil {
+			logger.Warn("Failed to connect to dqlite leader to remove ourselves from the cluster", logger.Ctx{"address": db.listenAddr.String(), "error": err})
+		} else {
+			err = cli.Remove(removeCtx, db.dqlite.ID())
+			cli.Close()
+			if err != nil {
+				logger.Warn("Failed to remove ourselves from the dqlite cluster", logger.Ctx{"id": db.dqlite.ID(), "address": db.listenAddr.String(), "error": err})
+			}
+		}
+
+		closeErr := db.dqlite.Close()
+		if closeErr != nil {
+			logger.Error("Failed to close database", logger.Ctx{"address": db.listenAddr.String(), "error": closeErr})
+		}
+
+		db.dqlite = nil
 	})
 
 	for {


### PR DESCRIPTION
dqlite.Close() tears down Raft connections but does not remove the node from the dqlite cluster membership. When db.Join() fails after the node has already been added to the cluster (via cli.Add in app.run), the reverter only called Close(), leaving a ghost member in dqlite.

This ghost node causes CheckMembershipConsistency to fail (the node exists in dqlite but not in core_cluster_members), which blocks token generation and all future cluster joins.

Fix the Join reverter to explicitly ask the dqlite leader to remove us before closing. Also correct a misleading comment in the Bootstrap reverter.


(cherry picked from commit f9c6754bc762d84225ca5928c5b5c5908acf1057)