### PR TITLE
fix: add check to validate cp node name = token declared node-name

### DIFF
--- a/internal/rest/resources/cluster.go
+++ b/internal/rest/resources/cluster.go
@@ -151,6 +151,10 @@ func clusterPost(s types.State, r *http.Request) types.Response {
 			return fmt.Errorf("Joining server certificate SAN does not contain join token name")
 		}
 
+		if req.Name != record.Name {
+			return fmt.Errorf("Joining cluster member name %q does not match token name %q", req.Name, record.Name)
+		}
+
 		_, err = cluster.CreateCoreClusterMember(ctx, tx, dbClusterMember)
 		if err != nil {
 			return err


### PR DESCRIPTION
Currently, microcluster does not validate that the name of a joining node matches the name attached to the token in joins with. So for example, I can do get-join-token on node x, and use it to join with node y. The docs [doc/clustering.md] says that this behavior should not be the case.

This causes problems for us in k8s-snap, where we need to enforce node name deduplication to prevent data store drifts between microcluster and etcd (https://github.com/canonical/cluster-api-k8s/issues/229) and indeed we are doing this for worker nodes, but we cannot affect this behavior for CP nodes, as their lifecycle is owned by microcluster. This fix should prevent joins where a node uses a token that declares a different node name